### PR TITLE
create network interfaces with a dedicated tag

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -82,7 +82,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:4a0c4954a22fbdebaac8238bc54feeee2f4f09123a70e756b79d01afe68319c6"
+  digest = "1:5785e260519a1799821cfd17efb524b2c30513aec463fbbcc1f411b46791b68a"
   name = "github.com/denverdino/aliyungo"
   packages = [
     "common",
@@ -91,7 +91,7 @@
     "util",
   ]
   pruneopts = "UT"
-  revision = "7ab83b3440a1e57142a9ed059118d892014a42cc"
+  revision = "589d612576cf10cc400d4172d2067c4b89d1cd91"
 
 [[projects]]
   branch = "master"
@@ -688,6 +688,7 @@
     "google.golang.org/grpc",
     "gopkg.in/yaml.v2",
     "k8s.io/api/core/v1",
+    "k8s.io/apimachinery/pkg/api/errors",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/apimachinery/pkg/fields",
     "k8s.io/apimachinery/pkg/util/wait",

--- a/pkg/aliyun/ecs.go
+++ b/pkg/aliyun/ecs.go
@@ -15,6 +15,13 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
+const (
+	// NetworkInterfaceTagCreatorKey denotes the creator tag's key of network interface
+	NetworkInterfaceTagCreatorKey = "creator"
+	// NetworkInterfaceTagCreatorValue denotes the creator tag's value of network interface
+	NetworkInterfaceTagCreatorValue = "terway"
+)
+
 // ECS the interface of ecs operation set
 type ECS interface {
 	AllocateENI(vSwitch string, securityGroup string, instanceID string) (*types.ENI, error)
@@ -85,6 +92,9 @@ func (e *ecsImpl) AllocateENI(vSwitch string, securityGroup string, instanceID s
 		SecurityGroupId:      securityGroup,
 		NetworkInterfaceName: generateEniName(),
 		Description:          eniDescription,
+		Tag: map[string]string{
+			NetworkInterfaceTagCreatorKey: NetworkInterfaceTagCreatorValue,
+		},
 	}
 	createNetworkInterfaceResponse, err := e.clientSet.ecs.CreateNetworkInterface(createNetworkInterfaceArgs)
 	metric.OpenAPILatency.WithLabelValues("CreateNetworkInterface", fmt.Sprint(err != nil)).Observe(metric.MsSince(start))

--- a/vendor/github.com/denverdino/aliyungo/ecs/disks.go
+++ b/vendor/github.com/denverdino/aliyungo/ecs/disks.go
@@ -141,6 +141,7 @@ type CreateDiskArgs struct {
 	Size         int
 	SnapshotId   string
 	ClientToken  string
+	KMSKeyID     string
 }
 
 type CreateDisksResponse struct {

--- a/vendor/github.com/denverdino/aliyungo/ecs/eni.go
+++ b/vendor/github.com/denverdino/aliyungo/ecs/eni.go
@@ -2,10 +2,10 @@ package ecs
 
 import (
 	"fmt"
-	"github.com/denverdino/aliyungo/util"
 	"time"
 
 	"github.com/denverdino/aliyungo/common"
+	"github.com/denverdino/aliyungo/util"
 )
 
 type CreateNetworkInterfaceArgs struct {
@@ -13,9 +13,10 @@ type CreateNetworkInterfaceArgs struct {
 	VSwitchId            string
 	PrimaryIpAddress     string // optional
 	SecurityGroupId      string
-	NetworkInterfaceName string // optional
-	Description          string // optional
-	ClientToken          string // optional
+	NetworkInterfaceName string            // optional
+	Description          string            // optional
+	ClientToken          string            // optional
+	Tag                  map[string]string // optional
 }
 
 type CreateNetworkInterfaceResponse struct {
@@ -34,7 +35,9 @@ type DeleteNetworkInterfaceResponse struct {
 type DescribeNetworkInterfacesArgs struct {
 	RegionId             common.Region
 	VSwitchId            string
+	VpcID                string
 	PrimaryIpAddress     string
+	PrivateIpAddress     []string `query:"list"`
 	SecurityGroupId      string
 	NetworkInterfaceName string
 	Type                 string

--- a/vendor/github.com/denverdino/aliyungo/ecs/route_tables.go
+++ b/vendor/github.com/denverdino/aliyungo/ecs/route_tables.go
@@ -100,9 +100,13 @@ func (client *Client) DescribeRouteTablesWithRaw(args *DescribeRouteTablesArgs) 
 type NextHopType string
 
 const (
-	NextHopIntance               = NextHopType("Instance") //Default
-	NextHopTunnel                = NextHopType("Tunnel")
-	NextHopTunnelRouterInterface = NextHopType("RouterInterface")
+	NextHopInstance         = NextHopType("Instance") //Default
+	NextHopHaVip            = NextHopType("HaVip")
+	NextHopRouterInterface  = NextHopType("RouterInterface")
+	NextHopNetworkInterface = NextHopType("NetworkInterface")
+	NextHopVpnGateway       = NextHopType("VpnGateway")
+	NextHopIPv6Gateway      = NextHopType("IPv6Gateway")
+	NextHopTunnel           = NextHopType("Tunnel")
 )
 
 type CreateRouteEntryArgs struct {

--- a/vendor/github.com/denverdino/aliyungo/ecs/router_interface.go
+++ b/vendor/github.com/denverdino/aliyungo/ecs/router_interface.go
@@ -238,7 +238,7 @@ func (client *Client) WaitForRouterInterfaceAsyn(regionId common.Region, interfa
 	for {
 		interfaces, err := client.DescribeRouterInterfaces(&DescribeRouterInterfacesArgs{
 			RegionId: regionId,
-			Filter:   []Filter{Filter{Key: "RouterInterfaceId", Value: []string{interfaceId}}},
+			Filter:   []Filter{{Key: "RouterInterfaceId", Value: []string{interfaceId}}},
 		})
 		if err != nil {
 			return err

--- a/vendor/github.com/denverdino/aliyungo/ecs/snat_entry.go
+++ b/vendor/github.com/denverdino/aliyungo/ecs/snat_entry.go
@@ -1,12 +1,24 @@
 package ecs
 
-import "github.com/denverdino/aliyungo/common"
+import (
+	"time"
+
+	"github.com/denverdino/aliyungo/common"
+)
+
+type SnatEntryStatus string
+
+const (
+	SnatEntryStatusPending   = SnatEntryStatus("Pending")
+	SnatEntryStatusAvailable = SnatEntryStatus("Available")
+)
 
 type CreateSnatEntryArgs struct {
 	RegionId        common.Region
 	SnatTableId     string
 	SourceVSwitchId string
 	SnatIp          string
+	SourceCIDR      string
 }
 
 type CreateSnatEntryResponse struct {
@@ -21,12 +33,17 @@ type SnatEntrySetType struct {
 	SnatTableId     string
 	SourceCIDR      string
 	SourceVSwitchId string
-	Status          string
+	Status          SnatEntryStatus
 }
 
 type DescribeSnatTableEntriesArgs struct {
-	RegionId    common.Region
-	SnatTableId string
+	RegionId        common.Region
+	SnatTableId     string
+	SnatEntryId     string
+	SnatEntryName   string
+	SnatIp          string
+	SourceCIDR      string
+	SourceVSwitchId string
 	common.Pagination
 }
 
@@ -39,10 +56,11 @@ type DescribeSnatTableEntriesResponse struct {
 }
 
 type ModifySnatEntryArgs struct {
-	RegionId    common.Region
-	SnatTableId string
-	SnatEntryId string
-	SnatIp      string
+	RegionId      common.Region
+	SnatTableId   string
+	SnatEntryId   string
+	SnatIp        string
+	SnatEntryName string
 }
 
 type ModifySnatEntryResponse struct {
@@ -100,4 +118,38 @@ func (client *Client) DeleteSnatEntry(args *DeleteSnatEntryArgs) error {
 	response := DeleteSnatEntryResponse{}
 	err := client.Invoke("DeleteSnatEntry", args, &response)
 	return err
+}
+
+// WaitForSnatEntryAvailable waits for SnatEntry to available status
+func (client *Client) WaitForSnatEntryAvailable(regionId common.Region, snatTableId, snatEntryId string, timeout int) error {
+	if timeout <= 0 {
+		timeout = DefaultTimeout
+	}
+
+	args := &DescribeSnatTableEntriesArgs{
+		RegionId:    regionId,
+		SnatTableId: snatTableId,
+		SnatEntryId: snatEntryId,
+	}
+
+	for {
+		snatEntries, _, err := client.DescribeSnatTableEntries(args)
+		if err != nil {
+			return err
+		}
+
+		if len(snatEntries) == 0 {
+			return common.GetClientErrorFromString("Not found")
+		}
+		if snatEntries[0].Status == SnatEntryStatusAvailable {
+			break
+		}
+
+		timeout = timeout - DefaultWaitForInterval
+		if timeout <= 0 {
+			return common.GetClientErrorFromString("Timeout")
+		}
+		time.Sleep(DefaultWaitForInterval * time.Second)
+	}
+	return nil
 }

--- a/vendor/github.com/denverdino/aliyungo/ecs/vpcs.go
+++ b/vendor/github.com/denverdino/aliyungo/ecs/vpcs.go
@@ -76,12 +76,12 @@ type VpcSetType struct {
 	VSwitchIds struct {
 		VSwitchId []string
 	}
-	CidrBlock    string
-	VRouterId    string
-	Description  string
-	IsDefault    bool
-	CreationTime util.ISO6801Time
-	RouterTableIds struct{
+	CidrBlock      string
+	VRouterId      string
+	Description    string
+	IsDefault      bool
+	CreationTime   util.ISO6801Time
+	RouterTableIds struct {
 		RouterTableIds []string
 	}
 }

--- a/vendor/github.com/denverdino/aliyungo/metadata/client.go
+++ b/vendor/github.com/denverdino/aliyungo/metadata/client.go
@@ -58,9 +58,9 @@ type IMetaDataRequest interface {
 
 type MetaData struct {
 	// mock for unit test.
-	mock    requestMock
+	mock requestMock
 
-	client 	*http.Client
+	client *http.Client
 }
 
 func NewMetaData(client *http.Client) *MetaData {

--- a/vendor/github.com/denverdino/aliyungo/util/encoding.go
+++ b/vendor/github.com/denverdino/aliyungo/util/encoding.go
@@ -47,7 +47,7 @@ func setQueryValues(i interface{}, values *url.Values, prefix string) {
 	// add to support url.Values
 	mapValues, ok := i.(url.Values)
 	if ok {
-		for k, _ := range mapValues {
+		for k := range mapValues {
 			values.Set(k, mapValues.Get(k))
 		}
 		return
@@ -191,7 +191,7 @@ func setQueryValuesByFlattenMethod(i interface{}, values *url.Values, prefix str
 	// add to support url.Values
 	mapValues, ok := i.(url.Values)
 	if ok {
-		for k, _ := range mapValues {
+		for k := range mapValues {
 			values.Set(k, mapValues.Get(k))
 		}
 		return


### PR DESCRIPTION
create network interfaces with a dedicated tag, which can greatly facilitate our life and well itegrate with other systems.
such as: 
- Authorization system (e.g. RAM) can set up some policy based on tags. We trust our code, but we can not guarantee terway 100% bug-free, so we should set up a last defense by authorization policy to avoid terway to delete other people's ENI in some extreme case.  
- We can also manipulate ENIs created by terway via tags:  `aliyun ecs DescribeNetworkInterfaces --RegionId cn-hangzhou --Tag.1.Key creater --Tag.1.Value terway`. this may be helpful when there are lots of ENIs but most of them have no relationship with terway.

