### PR TITLE
Terway ENI's intelligent allocation feature for VSwitch/PodIP in multiple VSwitch scenario.

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -773,6 +773,12 @@ func setDefault(cfg *types.Configure) error {
 		cfg.HotPlug = conditionFalse
 	}
 
+	// Default policy for vswitch selection is random.
+	if cfg.VSwitchSelectionPolicy == "" ||
+		(cfg.VSwitchSelectionPolicy != types.VSwitchSelectionPolicyRandom &&
+			cfg.VSwitchSelectionPolicy != types.VSwitchSelectionPolicyOrdered) {
+		cfg.VSwitchSelectionPolicy = types.VSwitchSelectionPolicyRandom
+	}
 	return nil
 }
 
@@ -792,6 +798,7 @@ func getPoolConfig(cfg *types.Configure, ecs aliyun.ECS) (*types.PoolConfig, err
 		EniCapRatio:   cfg.EniCapRatio,
 		EniCapShift:   cfg.EniCapShift,
 		SecurityGroup: cfg.SecurityGroup,
+		VSwitchSelectionPolicy: cfg.VSwitchSelectionPolicy,
 	}
 
 	zone, err := aliyun.GetLocalZone()

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -786,16 +786,16 @@ func validateConfig(cfg *types.Configure) error {
 
 func getPoolConfig(cfg *types.Configure, ecs aliyun.ECS) (*types.PoolConfig, error) {
 	poolConfig := &types.PoolConfig{
-		MaxPoolSize:   cfg.MaxPoolSize,
-		MinPoolSize:   cfg.MinPoolSize,
-		MaxENI:        cfg.MaxENI,
-		MinENI:        cfg.MinENI,
-		AccessID:      cfg.AccessID,
-		AccessSecret:  cfg.AccessSecret,
-		HotPlug:       cfg.HotPlug == "true",
-		EniCapRatio:   cfg.EniCapRatio,
-		EniCapShift:   cfg.EniCapShift,
-		SecurityGroup: cfg.SecurityGroup,
+		MaxPoolSize:            cfg.MaxPoolSize,
+		MinPoolSize:            cfg.MinPoolSize,
+		MaxENI:                 cfg.MaxENI,
+		MinENI:                 cfg.MinENI,
+		AccessID:               cfg.AccessID,
+		AccessSecret:           cfg.AccessSecret,
+		HotPlug:                cfg.HotPlug == "true",
+		EniCapRatio:            cfg.EniCapRatio,
+		EniCapShift:            cfg.EniCapShift,
+		SecurityGroup:          cfg.SecurityGroup,
 		VSwitchSelectionPolicy: cfg.VSwitchSelectionPolicy,
 	}
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -774,9 +774,7 @@ func setDefault(cfg *types.Configure) error {
 	}
 
 	// Default policy for vswitch selection is random.
-	if cfg.VSwitchSelectionPolicy == "" ||
-		(cfg.VSwitchSelectionPolicy != types.VSwitchSelectionPolicyRandom &&
-			cfg.VSwitchSelectionPolicy != types.VSwitchSelectionPolicyOrdered) {
+	if cfg.VSwitchSelectionPolicy == "" {
 		cfg.VSwitchSelectionPolicy = types.VSwitchSelectionPolicyRandom
 	}
 	return nil

--- a/daemon/eni-multi-ip.go
+++ b/daemon/eni-multi-ip.go
@@ -22,9 +22,8 @@ const (
 // AssignPrivateIpAddresses const error message
 // Reference: https://help.aliyun.com/document_detail/85917.html
 const (
-
 	InvalidVSwitchId_IpNotEnough = "InvalidVSwitchId.IpNotEnough"
-	EniIpAllocInhibitTimeout = 10 * time.Minute
+	EniIpAllocInhibitTimeout     = 10 * time.Minute
 )
 
 const timeFormat = "2006-01-02 15:04:05"
@@ -143,7 +142,7 @@ func (f *eniIPFactory) submit() error {
 		logrus.Infof("check existing eni: %+v", eni)
 		eni.lock.Lock()
 		now := time.Now()
-		logrus.Infof("check if the current eni is in the time window for IP allocation inhibition: " +
+		logrus.Infof("check if the current eni is in the time window for IP allocation inhibition: "+
 			"eni = %+v, vsw= %s, now = %s, expireAt = %s", eni, eni.VSwitch, now.Format(timeFormat), eni.ipAllocInhibitExpireAt.Format(timeFormat))
 		// if the current eni has been inhibited for Pod IP allocation, then skip current eni.
 		if now.Before(eni.ipAllocInhibitExpireAt) {
@@ -153,7 +152,7 @@ func (f *eniIPFactory) submit() error {
 		}
 
 		ipCount := eni.pending + len(eni.ips)
-		logrus.Debugf("check if the current eni will reach eni IP quota with new pending IP added: " +
+		logrus.Debugf("check if the current eni will reach eni IP quota with new pending IP added: "+
 			"eni = %+v, eni.pending = %d, len(eni.ips) = %d, eni.MaxIPs = %d", eni, eni.pending, len(eni.ips), eni.MaxIPs)
 		if ipCount < eni.MaxIPs {
 			select {

--- a/daemon/eni-multi-ip.go
+++ b/daemon/eni-multi-ip.go
@@ -22,8 +22,8 @@ const (
 // AssignPrivateIpAddresses const error message
 // Reference: https://help.aliyun.com/document_detail/85917.html
 const (
-	InvalidVSwitchId_IpNotEnough = "InvalidVSwitchId.IpNotEnough"
-	EniIpAllocInhibitTimeout     = 10 * time.Minute
+	InvalidVSwitchIdIpNotEnough = "InvalidVSwitchId.IpNotEnough"
+	EniIPAllocInhibitTimeout    = 10 * time.Minute
 )
 
 const timeFormat = "2006-01-02 15:04:05"
@@ -120,16 +120,15 @@ func (f *eniIPFactory) getEnis() ([]*ENI, error) {
 	if err != nil {
 		logrus.Errorf("error to get vswitch slice: %v, instead use original eni slice in eniIPFactory: %v", err, f.enis)
 		return f.enis, err
-	} else {
-		for _, vswitch := range vSwitches {
-			for _, eni := range f.enis {
-				if vswitch == eni.VSwitch {
-					enis = append(enis, eni)
-				}
+	}
+	for _, vswitch := range vSwitches {
+		for _, eni := range f.enis {
+			if vswitch == eni.VSwitch {
+				enis = append(enis, eni)
 			}
 		}
-		return enis, nil
 	}
+	return enis, nil
 
 }
 
@@ -182,9 +181,9 @@ func (f *eniIPFactory) popResult() (ip *types.ENIIP, err error) {
 			for _, eni := range f.enis {
 				if eni.MAC == result.Eni.MAC {
 					eni.pending--
-					// if an error message with InvalidVSwitchId_IpNotEnough returned, then mark the ENI as IP allocation inhibited.
-					if strings.Contains(result.err.Error(), InvalidVSwitchId_IpNotEnough) {
-						eni.ipAllocInhibitExpireAt = time.Now().Add(EniIpAllocInhibitTimeout)
+					// if an error message with InvalidVSwitchIdIpNotEnough returned, then mark the ENI as IP allocation inhibited.
+					if strings.Contains(result.err.Error(), InvalidVSwitchIdIpNotEnough) {
+						eni.ipAllocInhibitExpireAt = time.Now().Add(EniIPAllocInhibitTimeout)
 						logrus.Infof("eni's associated vswitch %s has no available IP, set eni ipAllocInhibitExpireAt = %s",
 							eni.VSwitch, eni.ipAllocInhibitExpireAt.Format(timeFormat))
 					}

--- a/daemon/eni-multi-ip.go
+++ b/daemon/eni-multi-ip.go
@@ -22,7 +22,7 @@ const (
 // AssignPrivateIpAddresses const error message
 // Reference: https://help.aliyun.com/document_detail/85917.html
 const (
-	InvalidVSwitchIdIpNotEnough = "InvalidVSwitchId.IpNotEnough"
+	InvalidVSwitchIDIPNotEnough = "InvalidVSwitchId.IpNotEnough"
 	EniIPAllocInhibitTimeout    = 10 * time.Minute
 )
 
@@ -181,8 +181,8 @@ func (f *eniIPFactory) popResult() (ip *types.ENIIP, err error) {
 			for _, eni := range f.enis {
 				if eni.MAC == result.Eni.MAC {
 					eni.pending--
-					// if an error message with InvalidVSwitchIdIpNotEnough returned, then mark the ENI as IP allocation inhibited.
-					if strings.Contains(result.err.Error(), InvalidVSwitchIdIpNotEnough) {
+					// if an error message with InvalidVSwitchIDIPNotEnough returned, then mark the ENI as IP allocation inhibited.
+					if strings.Contains(result.err.Error(), InvalidVSwitchIDIPNotEnough) {
 						eni.ipAllocInhibitExpireAt = time.Now().Add(EniIPAllocInhibitTimeout)
 						logrus.Infof("eni's associated vswitch %s has no available IP, set eni ipAllocInhibitExpireAt = %s",
 							eni.VSwitch, eni.ipAllocInhibitExpireAt.Format(timeFormat))

--- a/daemon/eni.go
+++ b/daemon/eni.go
@@ -127,6 +127,7 @@ func newMapSorter(m map[string]int) MapSorter {
 }
 
 func (ms MapSorter) SortInDescendingOrder()  {
+	logrus.Debugf("before bubble sorting, slice = %+v", ms)
 	for i := 0; i < ms.Len(); i++ {
 		for j := 0; j < ms.Len()-i-1; j++ {
 			if ms[j].Val < ms[j+1].Val {
@@ -134,6 +135,8 @@ func (ms MapSorter) SortInDescendingOrder()  {
 			}
 		}
 	}
+	logrus.Debugf("after bubble sorting, slice = %+v", ms)
+
 }
 func (ms MapSorter) Len() int {
 	return len(ms)
@@ -235,7 +238,7 @@ func (f *eniFactory) GetVSwitches() ([]string, error) {
 
 func (f *eniFactory) Create() (types.NetworkResource, error) {
 	vSwitches, _ := f.GetVSwitches()
-	logrus.Debugf("adjusted vswitch slice: %+v", vSwitches)
+	logrus.Infof("adjusted vswitch slice: %+v", vSwitches)
 	return f.ecs.AllocateENI(vSwitches[0], f.securityGroup, f.instanceID)
 }
 

--- a/daemon/eni.go
+++ b/daemon/eni.go
@@ -1,13 +1,14 @@
 package daemon
 
 import (
+	"math/rand"
+	"sync"
+	"time"
+
 	"github.com/AliyunContainerService/terway/deviceplugin"
 	"github.com/AliyunContainerService/terway/pkg/pool"
 	"github.com/AliyunContainerService/terway/types"
 	"github.com/sirupsen/logrus"
-	"math/rand"
-	"sync"
-	"time"
 
 	"github.com/AliyunContainerService/terway/pkg/aliyun"
 	"github.com/pkg/errors"

--- a/daemon/eni.go
+++ b/daemon/eni.go
@@ -14,8 +14,8 @@ import (
 )
 
 const (
-	// The duration for the vswitchIPCntMap content's effectiveness
-	VSwitchIPCntTimeout = 10 * time.Minute
+	// vSwitchIPCntTimeout is the duration for the vswitchIPCntMap content's effectiveness
+	vSwitchIPCntTimeout = 10 * time.Minute
 )
 
 type eniResourceManager struct {
@@ -131,7 +131,7 @@ func newMapSorter(m map[string]int) MapSorter {
 	return ms
 }
 
-// Bubble sort per element's value
+// SortInDescendingOrder is a bubble sort per element's value
 func (ms MapSorter) SortInDescendingOrder() {
 	logrus.Debugf("before bubble sorting, slice = %+v", ms)
 	for i := 0; i < ms.Len(); i++ {
@@ -223,7 +223,7 @@ func (f *eniFactory) GetVSwitches() ([]string, error) {
 			}
 
 			f.Lock()
-			f.tsExpireAt = time.Now().Add(VSwitchIPCntTimeout)
+			f.tsExpireAt = time.Now().Add(vSwitchIPCntTimeout)
 			f.Unlock()
 		}
 

--- a/daemon/eni.go
+++ b/daemon/eni.go
@@ -118,6 +118,7 @@ type Item struct {
 	Key string
 	Val int
 }
+
 func newMapSorter(m map[string]int) MapSorter {
 	ms := make(MapSorter, 0, len(m))
 	for k, v := range m {
@@ -126,7 +127,7 @@ func newMapSorter(m map[string]int) MapSorter {
 	return ms
 }
 
-func (ms MapSorter) SortInDescendingOrder()  {
+func (ms MapSorter) SortInDescendingOrder() {
 	logrus.Debugf("before bubble sorting, slice = %+v", ms)
 	for i := 0; i < ms.Len(); i++ {
 		for j := 0; j < ms.Len()-i-1; j++ {
@@ -150,12 +151,12 @@ func (ms MapSorter) Swap(i, j int) {
 }
 
 type eniFactory struct {
-	switches      []string
-	securityGroup string
-	instanceID    string
-	ecs           aliyun.ECS
-	vswitchIpCntMap map[string]int
-	tsExpireAt time.Time
+	switches               []string
+	securityGroup          string
+	instanceID             string
+	ecs                    aliyun.ECS
+	vswitchIpCntMap        map[string]int
+	tsExpireAt             time.Time
 	vswitchSelectionPolicy string
 	sync.RWMutex
 }
@@ -169,11 +170,11 @@ func newENIFactory(poolConfig *types.PoolConfig, ecs aliyun.ECS) (*eniFactory, e
 		poolConfig.SecurityGroup = securityGroup
 	}
 	return &eniFactory{
-		switches:      poolConfig.VSwitch,
-		securityGroup: poolConfig.SecurityGroup,
-		instanceID:    poolConfig.InstanceID,
-		ecs:           ecs,
-		vswitchIpCntMap: make(map[string]int),
+		switches:               poolConfig.VSwitch,
+		securityGroup:          poolConfig.SecurityGroup,
+		instanceID:             poolConfig.InstanceID,
+		ecs:                    ecs,
+		vswitchIpCntMap:        make(map[string]int),
 		vswitchSelectionPolicy: poolConfig.VSwitchSelectionPolicy,
 	}, nil
 }
@@ -193,7 +194,7 @@ func (f *eniFactory) GetVSwitches() ([]string, error) {
 		vSwitches = make([]string, vswCnt)
 		copy(vSwitches, f.switches)
 		rand.Seed(time.Now().UnixNano())
-		rand.Shuffle(vswCnt, func(i, j int){ vSwitches[i], vSwitches[j] = vSwitches[j], vSwitches[i] })
+		rand.Shuffle(vswCnt, func(i, j int) { vSwitches[i], vSwitches[j] = vSwitches[j], vSwitches[i] })
 		return vSwitches, nil
 	}
 
@@ -203,7 +204,7 @@ func (f *eniFactory) GetVSwitches() ([]string, error) {
 		// Use f.vswitchIpCntMap to track IP count + vswitch ID
 		var start = time.Now()
 		// If f.vswitchIpCntMap is empty, then fill in the map with switch + switch's available IP count.
-		if (len(f.vswitchIpCntMap) == 0 && f.tsExpireAt.IsZero()) || start.After(f.tsExpireAt)  {
+		if (len(f.vswitchIpCntMap) == 0 && f.tsExpireAt.IsZero()) || start.After(f.tsExpireAt) {
 			// Loop vswitch slice to get each vswitch's available IP count.
 			for _, vswitch := range f.switches {
 				availIpCount, err := f.ecs.DescribeVSwitch(vswitch)

--- a/pkg/aliyun/ecs.go
+++ b/pkg/aliyun/ecs.go
@@ -89,18 +89,17 @@ func (e *ecsImpl) DescribeVSwitch(vSwitch string) (availIpCount int, err error) 
 	vsw, _, err := e.clientSet.ecs.DescribeVSwitches(vSwitchArgs)
 	// For systems without RAM policy for VPC API permission, result is:
 	// vsw is an empty slice, err is nil.
-	// For systems which have RAM policy for VPC API permission, result is:
+	// For systems which have RAM policy for VPC API permission,
+	// (1) if vswitch indeed exists, result is:
 	// vsw is a slice with a single element, err is nil.
-	logrus.Debugf("result for DescribeVSwitch: vsw slice = %+v, err = %v", vsw, err)
-
-	if err == nil {
-		if len(vsw) > 0 {
-			return vsw[0].AvailableIpAddressCount, nil
-		} else {
-			return 0, ErrNoValidVSwitch
-		}
+	// (2) if vswitch doesn't exist, result is:
+	// vsw is an empty slice, err is not nil.
+	logrus.Debugf("result for DescribeVSwitches: vsw slice = %+v, err = %v", vsw, err)
+	if len(vsw) > 0 {
+		return vsw[0].AvailableIpAddressCount, nil
+	} else {
+		return 0, err
 	}
-	return 0, err
 }
 
 // AllocateENI for instance

--- a/pkg/aliyun/ecs.go
+++ b/pkg/aliyun/ecs.go
@@ -81,10 +81,10 @@ func NewECS(ak, sk string, region common.Region) (ECS, error) {
 }
 
 // DescribeVSwitch for vswitch
-func (e *ecsImpl) DescribeVSwitch(vSwitch string) (availIpCount int, err error)  {
+func (e *ecsImpl) DescribeVSwitch(vSwitch string) (availIpCount int, err error) {
 	vSwitchArgs := &ecs.DescribeVSwitchesArgs{
-		RegionId:             e.region,
-		VSwitchId:            vSwitch,
+		RegionId:  e.region,
+		VSwitchId: vSwitch,
 	}
 	vsw, _, err := e.clientSet.ecs.DescribeVSwitches(vSwitchArgs)
 	// For systems without RAM policy for VPC API permission, result is:

--- a/pkg/aliyun/ecs.go
+++ b/pkg/aliyun/ecs.go
@@ -22,8 +22,6 @@ const (
 	NetworkInterfaceTagCreatorValue = "terway"
 )
 
-var ErrNoValidVSwitch = errors.Errorf("No valid vswitch found.")
-
 // ECS the interface of ecs operation set
 type ECS interface {
 	AllocateENI(vSwitch string, securityGroup string, instanceID string) (*types.ENI, error)
@@ -39,7 +37,7 @@ type ECS interface {
 	GetInstanceMaxPrivateIP(intanceID string) (int, error)
 	GetENIMaxIP(instanceID string, eniID string) (int, error)
 	GetAttachedSecurityGroup(instanceID string) (string, error)
-	DescribeVSwitch(vSwitch string) (availIpCount int, err error)
+	DescribeVSwitch(vSwitch string) (availIPCount int, err error)
 }
 
 type ecsImpl struct {
@@ -81,7 +79,7 @@ func NewECS(ak, sk string, region common.Region) (ECS, error) {
 }
 
 // DescribeVSwitch for vswitch
-func (e *ecsImpl) DescribeVSwitch(vSwitch string) (availIpCount int, err error) {
+func (e *ecsImpl) DescribeVSwitch(vSwitch string) (availIPCount int, err error) {
 	vSwitchArgs := &ecs.DescribeVSwitchesArgs{
 		RegionId:  e.region,
 		VSwitchId: vSwitch,
@@ -97,9 +95,9 @@ func (e *ecsImpl) DescribeVSwitch(vSwitch string) (availIpCount int, err error) 
 	logrus.Debugf("result for DescribeVSwitches: vsw slice = %+v, err = %v", vsw, err)
 	if len(vsw) > 0 {
 		return vsw[0].AvailableIpAddressCount, nil
-	} else {
-		return 0, err
 	}
+	return 0, err
+
 }
 
 // AllocateENI for instance

--- a/pkg/aliyun/eni.go
+++ b/pkg/aliyun/eni.go
@@ -67,6 +67,12 @@ func (e *eniMetadata) GetENIConfigByMac(mac string) (*types.ENI, error) {
 	}
 	eni.Gateway = gateway
 
+	vswitch, err := metadataValue(fmt.Sprintf(metadataBase+eniVSwitchPath, mac))
+	if err != nil {
+		return nil, errors.Wrapf(err, "error get eni vswitch from metaserver, mac: %s", mac)
+	}
+	eni.VSwitch = vswitch
+
 	eni.Name, err = link.GetDeviceName(mac)
 	if err != nil {
 		logrus.Warnf("error get device name for eni: %v", err)

--- a/pkg/aliyun/metadata.go
+++ b/pkg/aliyun/metadata.go
@@ -12,6 +12,7 @@ import (
 	"github.com/denverdino/aliyungo/common"
 )
 
+// Reference https://help.aliyun.com/knowledge_detail/49122.html
 const (
 	metadataBase    = "http://100.100.100.200/latest/meta-data/"
 	mainEniPath     = "mac"
@@ -21,6 +22,7 @@ const (
 	eniNetmaskPath  = "network/interfaces/macs/%s/netmask"
 	eniGatewayPath  = "network/interfaces/macs/%s/gateway"
 	eniPrivateIPs   = "network/interfaces/macs/%s/private-ipv4s"
+	eniVSwitchPath  = "network/interfaces/macs/%s/vswitch-id"
 	instanceIDPath  = "instance-id"
 	regionIDPath    = "region-id"
 	zoneIDPath      = "zone-id"

--- a/pkg/pool/pool.go
+++ b/pkg/pool/pool.go
@@ -50,7 +50,7 @@ type ObjectFactory interface {
 
 type simpleObjectPool struct {
 	inuse      map[string]poolItem
-	idle       *priorityQeueu  // Todo: Fix this typo
+	idle       *priorityQeueu // Todo: Fix this typo
 	lock       sync.Mutex
 	factory    ObjectFactory
 	maxIdle    int

--- a/pkg/pool/pool.go
+++ b/pkg/pool/pool.go
@@ -50,7 +50,7 @@ type ObjectFactory interface {
 
 type simpleObjectPool struct {
 	inuse      map[string]poolItem
-	idle       *priorityQeueu
+	idle       *priorityQeueu  // Todo: Fix this typo
 	lock       sync.Mutex
 	factory    ObjectFactory
 	maxIdle    int

--- a/types/config.go
+++ b/types/config.go
@@ -18,6 +18,7 @@ type Configure struct {
 	HotPlug       string              `yaml:"hot_plug" json:"hot_plug"`
 	EniCapRatio   float64             `yaml:"eni_cap_ratio" json:"eni_cap_ratio"`
 	EniCapShift   int                 `yaml:"eni_cap_shift" json:"eni_cap_shift"`
+	VSwitchSelectionPolicy  string     `yaml:"vswitch_selection_policy" json:"vswitch_selection_policy"`
 }
 
 // PoolConfig configuration of pool and resource factory
@@ -37,4 +38,5 @@ type PoolConfig struct {
 	HotPlug       bool
 	EniCapRatio   float64
 	EniCapShift   int
+	VSwitchSelectionPolicy string
 }

--- a/types/config.go
+++ b/types/config.go
@@ -4,39 +4,39 @@ import "github.com/denverdino/aliyungo/common"
 
 // Configure configuration of terway daemon
 type Configure struct {
-	Version       string              `yaml:"version" json:"version"`
-	AccessID      string              `yaml:"access_key" json:"access_key"`
-	AccessSecret  string              `yaml:"access_secret" json:"access_secret"`
-	ServiceCIDR   string              `yaml:"service_cidr" json:"service_cidr"`
-	VSwitches     map[string][]string `yaml:"vswitches" json:"vswitches"`
-	MaxPoolSize   int                 `yaml:"max_pool_size" json:"max_pool_size"`
-	MinPoolSize   int                 `yaml:"min_pool_size" json:"min_pool_size"`
-	MinENI        int                 `yaml:"min_eni" json:"min_eni"`
-	MaxENI        int                 `yaml:"max_eni" json:"max_eni"`
-	Prefix        string              `yaml:"prefix" json:"prefix"`
-	SecurityGroup string              `yaml:"security_group" json:"security_group"`
-	HotPlug       string              `yaml:"hot_plug" json:"hot_plug"`
-	EniCapRatio   float64             `yaml:"eni_cap_ratio" json:"eni_cap_ratio"`
-	EniCapShift   int                 `yaml:"eni_cap_shift" json:"eni_cap_shift"`
-	VSwitchSelectionPolicy  string     `yaml:"vswitch_selection_policy" json:"vswitch_selection_policy"`
+	Version                string              `yaml:"version" json:"version"`
+	AccessID               string              `yaml:"access_key" json:"access_key"`
+	AccessSecret           string              `yaml:"access_secret" json:"access_secret"`
+	ServiceCIDR            string              `yaml:"service_cidr" json:"service_cidr"`
+	VSwitches              map[string][]string `yaml:"vswitches" json:"vswitches"`
+	MaxPoolSize            int                 `yaml:"max_pool_size" json:"max_pool_size"`
+	MinPoolSize            int                 `yaml:"min_pool_size" json:"min_pool_size"`
+	MinENI                 int                 `yaml:"min_eni" json:"min_eni"`
+	MaxENI                 int                 `yaml:"max_eni" json:"max_eni"`
+	Prefix                 string              `yaml:"prefix" json:"prefix"`
+	SecurityGroup          string              `yaml:"security_group" json:"security_group"`
+	HotPlug                string              `yaml:"hot_plug" json:"hot_plug"`
+	EniCapRatio            float64             `yaml:"eni_cap_ratio" json:"eni_cap_ratio"`
+	EniCapShift            int                 `yaml:"eni_cap_shift" json:"eni_cap_shift"`
+	VSwitchSelectionPolicy string              `yaml:"vswitch_selection_policy" json:"vswitch_selection_policy"`
 }
 
 // PoolConfig configuration of pool and resource factory
 type PoolConfig struct {
-	MaxPoolSize   int
-	MinPoolSize   int
-	MinENI        int
-	MaxENI        int
-	VPC           string
-	Zone          string
-	VSwitch       []string
-	Region        common.Region
-	SecurityGroup string
-	InstanceID    string
-	AccessID      string
-	AccessSecret  string
-	HotPlug       bool
-	EniCapRatio   float64
-	EniCapShift   int
+	MaxPoolSize            int
+	MinPoolSize            int
+	MinENI                 int
+	MaxENI                 int
+	VPC                    string
+	Zone                   string
+	VSwitch                []string
+	Region                 common.Region
+	SecurityGroup          string
+	InstanceID             string
+	AccessID               string
+	AccessSecret           string
+	HotPlug                bool
+	EniCapRatio            float64
+	EniCapShift            int
 	VSwitchSelectionPolicy string
 }

--- a/types/types.go
+++ b/types/types.go
@@ -14,7 +14,7 @@ const (
 
 // Vswitch Selection Policy
 const (
-	VSwitchSelectionPolicyRandom = "random"
+	VSwitchSelectionPolicyRandom  = "random"
 	VSwitchSelectionPolicyOrdered = "ordered"
 )
 

--- a/types/types.go
+++ b/types/types.go
@@ -21,6 +21,7 @@ type ENI struct {
 	Gateway      net.IP
 	DeviceNumber int32
 	MaxIPs       int
+	VSwitch      string
 }
 
 // GetResourceID return mac address of eni

--- a/types/types.go
+++ b/types/types.go
@@ -12,6 +12,12 @@ const (
 	ResourceTypeENIIP = "eniIp"
 )
 
+// Vswitch Selection Policy
+const (
+	VSwitchSelectionPolicyRandom = "random"
+	VSwitchSelectionPolicyOrdered = "ordered"
+)
+
 // ENI aliyun ENI resource
 type ENI struct {
 	ID           string


### PR DESCRIPTION
Hi all, 

Terway ENI's intelligent allocation feature for VSwitch/PodIP in multiple VSwitch scenario.

Changes inclue:
1. Add a new field - vswitch_selection_policy, in config file. Values include "ordered" and "random".
"ordered" means allocation for ENI Vswitch/PodIP will be based on the available IP count per vswitch; "random" means that based on random order. 
For new system using this feature, the default policy is "ordered", this will make the most use of IP resources of each VSwitch which has more available IP addresses.
For existing system, the default policy is "random" since existing systems don't have multiple VSwitches configured in their config file, actually "random" and "ordered" don't make much difference in this case.
2. The intelligent selection mechanism's implementation for above logic.

Nice Regards,
Jiaxu 
