### PR TITLE
disable endpoint health check for chaining with cilium #135

### DIFF
--- a/policy/policyinit.sh
+++ b/policy/policyinit.sh
@@ -24,7 +24,7 @@ if [ -f "/etc/cni/net.d/10-terway.conflist" ] && grep -i ipvlan /etc/cni/net.d/1
     echo "using cilium as network routing & policy"
     exec cilium-agent --tunnel=disabled --masquerade=false --enable-ipv6=false --enable-policy=$ENABLE_POLICY \
          --agent-health-port=9099 --disable-envoy-version-check=true \
-         --enable-local-node-route=false --ipv4-range=169.254.10.0/30 \
+         --enable-local-node-route=false --ipv4-range=169.254.10.0/30 --enable-endpoint-health-checking=false \
          --ipam=cluster-pool --bpf-map-dynamic-size-ratio=0.0025
   fi
 fi


### PR DESCRIPTION
cilium add --enable-endpoint-health-checking option to disable health check when chaining with other cni to prevent cilium-health report timeout error on ip in cidr range which does not exist.