### PR TITLE
fix err is override

### DIFF
--- a/plugin/terway/cni.go
+++ b/plugin/terway/cni.go
@@ -85,14 +85,14 @@ var networkDriver = driver.VethDriver
 var eniMultiIPDriver = driver.VethDriver
 var nicDriver = driver.NicDriver
 
-func cmdAdd(args *skel.CmdArgs) (err error) {
+func cmdAdd(args *skel.CmdArgs) error {
 	versionDecoder := &cniversion.ConfigDecoder{}
 	var (
 		confVersion string
 		cniNetns    ns.NetNS
 	)
 
-	confVersion, err = versionDecoder.Decode(args.StdinData)
+	confVersion, err := versionDecoder.Decode(args.StdinData)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
fix  https://github.com/AliyunContainerService/terway/issues/147

before

```log
default     17m         Warning   FailedCreatePodSandBox   pod/nginx-78c689dfdc-hjjjv       (combined from similar events): Failed to create pod sandbox: rpc error: code = Unknown desc = failed to set up sandbox container "be04b956aba0fd8edce89805d8364afc0d2ed5507f2f07e6fd5312457c8c56b4" network for pod "nginx-78c689dfdc-hjjjv": networkPlugin cni failed to set up pod "nginx-78c689dfdc-hjjjv_default" network: unexpected end of JSON input
```

after
```log
default     5m17s       Warning   FailedCreatePodSandBox   pod/nginx-78c689dfdc-qk7dv       (combined from similar events): Failed to create pod sandbox: rpc error: code = Unknown desc = failed to set up sandbox container "6554b530cd1ed87296bc7c039e28cd76b23b387b8f6c8aaa6a78dbd24aece10b" network for pod "nginx-78c689dfdc-qk7dv": networkPlugin cni failed to set up pod "nginx-78c689dfdc-qk7dv_default" network: add cmd: error alloc ip from grpc call, pod: default-nginx-78c689dfdc-qk7dv: rpc error: code = Unknown desc = pod default/nginx-78c689dfdc-qk7dv resource processing
```