### PR TITLE
check and fix eni security group

### DIFF
--- a/daemon/eni-multi-ip.go
+++ b/daemon/eni-multi-ip.go
@@ -18,6 +18,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -677,6 +678,14 @@ func (f *eniIPFactory) GetResource() (map[string]types.FactoryResIf, error) {
 	}
 
 	return mapping, nil
+}
+
+func (f *eniIPFactory) Reconcile() {
+	// check security group
+	err := f.eniFactory.ecs.FixEniSecurityGroup([]string{f.eniFactory.securityGroup})
+	if err != nil {
+		_ = tracing.RecordNodeEvent(corev1.EventTypeWarning, "ResourceInvalid", fmt.Sprintf("eni has misconfiged security group. %s", err.Error()))
+	}
 }
 
 type eniIPResourceManager struct {

--- a/daemon/eni.go
+++ b/daemon/eni.go
@@ -8,15 +8,15 @@ import (
 	"sync"
 	"time"
 
-	"github.com/AliyunContainerService/terway/pkg/tracing"
-
 	"github.com/AliyunContainerService/terway/deviceplugin"
-	"github.com/AliyunContainerService/terway/pkg/pool"
-	"github.com/AliyunContainerService/terway/types"
-	"github.com/sirupsen/logrus"
-
 	"github.com/AliyunContainerService/terway/pkg/aliyun"
+	"github.com/AliyunContainerService/terway/pkg/pool"
+	"github.com/AliyunContainerService/terway/pkg/tracing"
+	"github.com/AliyunContainerService/terway/types"
+
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -180,11 +180,11 @@ type eniFactory struct {
 
 func newENIFactory(poolConfig *types.PoolConfig, ecs aliyun.ECS) (*eniFactory, error) {
 	if poolConfig.SecurityGroup == "" {
-		securityGroup, err := ecs.GetAttachedSecurityGroup(poolConfig.InstanceID)
+		securityGroups, err := ecs.GetAttachedSecurityGroups(poolConfig.InstanceID)
 		if err != nil {
 			return nil, errors.Wrapf(err, "error get security group on factory init")
 		}
-		poolConfig.SecurityGroup = securityGroup
+		poolConfig.SecurityGroup = securityGroups[0]
 	}
 	return &eniFactory{
 		name:                   factoryNameENI,
@@ -338,4 +338,12 @@ func (f *eniFactory) GetResource() (map[string]types.FactoryResIf, error) {
 	}
 
 	return mapping, nil
+}
+
+func (f *eniFactory) Reconcile() {
+	// check security group
+	err := f.ecs.FixEniSecurityGroup([]string{f.securityGroup})
+	if err != nil {
+		_ = tracing.RecordNodeEvent(corev1.EventTypeWarning, "ResourceInvalid", fmt.Sprintf("eni has misconfiged security group. %s", err.Error()))
+	}
 }

--- a/pkg/pool/pool.go
+++ b/pkg/pool/pool.go
@@ -103,6 +103,7 @@ type ObjectFactory interface {
 	Dispose(types.NetworkResource) error
 	GetResource() (map[string]types.FactoryResIf, error)
 	Get(types.NetworkResource) (types.NetworkResource, error)
+	Reconcile()
 }
 
 type simpleObjectPool struct {
@@ -222,6 +223,7 @@ func (p *simpleObjectPool) startCheckIdleTicker() {
 			p.checkResSync() // make sure pool is synced
 			p.checkIdle()
 			p.checkInsufficient()
+			p.factory.Reconcile()
 		case <-p.notifyCh:
 			p.checkIdle()
 			p.checkInsufficient()

--- a/pkg/pool/pool_test.go
+++ b/pkg/pool/pool_test.go
@@ -81,6 +81,8 @@ func (f *mockObjectFactory) Get(in types.NetworkResource) (types.NetworkResource
 	return in, nil
 }
 
+func (f *mockObjectFactory) Reconcile() {}
+
 func (f *mockObjectFactory) getTotalDisposed() int {
 	f.lock.Lock()
 	defer f.lock.Unlock()

--- a/types/types.go
+++ b/types/types.go
@@ -21,14 +21,15 @@ const (
 
 // ENI aliyun ENI resource
 type ENI struct {
-	ID           string
-	Name         string
-	Address      net.IPNet
-	MAC          string
-	Gateway      net.IP
-	DeviceNumber int32
-	MaxIPs       int
-	VSwitch      string
+	ID               string
+	Name             string
+	Address          net.IPNet
+	MAC              string
+	Gateway          net.IP
+	DeviceNumber     int32
+	MaxIPs           int
+	VSwitch          string
+	SecurityGroupIDs []string
 }
 
 // GetResourceID return mac address of eni


### PR DESCRIPTION
period check eni's security group is consistent with ecs's security group and try to fix is.
if fix failed ,a event is raised.

this is designed to solve user join node to cluster with previous cluster's node (which  may have residue resource ) 


![image](https://user-images.githubusercontent.com/4043362/102188290-1298a980-3ef0-11eb-8c5b-d57c6b4d16de.png)

![image](https://user-images.githubusercontent.com/4043362/102188732-a0749480-3ef0-11eb-921a-01f1806ec260.png)

