### PR TITLE
fix vpc mapping

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -855,7 +855,7 @@ func (networkService *networkService) GetResourceMapping() ([]tracing.PodMapping
 	case daemonModeENIMultiIP:
 		poolStats, err = networkService.eniIPResMgr.GetResourceMapping()
 	case daemonModeVPC:
-		poolStats, err = networkService.eniResMgr.GetResourceMapping()
+		return nil, nil
 	case daemonModeENIOnly:
 		poolStats, err = networkService.eniResMgr.GetResourceMapping()
 	}


### PR DESCRIPTION
vpc mode contain resource use without eni. so should ignore.

e2e ok
![image](https://user-images.githubusercontent.com/4043362/104985488-fedee680-5a4b-11eb-8b6c-ce31daa140bb.png)
