### PR TITLE
fix(BandwidthAnno): when k8s.aliyun.com/ingress-bandwidth is "" panic

### DIFF
--- a/daemon/k8s.go
+++ b/daemon/k8s.go
@@ -519,6 +519,10 @@ const (
 )
 
 func parseBandwidth(s string) (uint64, error) {
+	// when bandwidth is "", return
+	if len(s) == 0 {
+		return 0, fmt.Errorf("invalid bandwidth %s", s)
+	}
 
 	s = strings.TrimSpace(s)
 	s = strings.ToUpper(s)


### PR DESCRIPTION
fix : when `k8s.aliyun.com/ingress-bandwidth` or `k8s.aliyun.com/egress-bandwidth` is `""` will cause terway panic with error `panic: runtime error: slice bounds out of range [:-1]`, and other pod in the same node stuck in `ContainerCreating` status.