### PR TITLE
feat: drop restrict for kube-system namespace

### DIFF
--- a/docs/terway-trunk.md
+++ b/docs/terway-trunk.md
@@ -94,7 +94,7 @@ kind: PodNetworking
 metadata:
   name: your-networking
 spec:
-  ipType:
+  allocationType:
     type: Elastic/Fixed
     releaseStrategy: TTL
     releaseAfter: "5m0s"
@@ -186,7 +186,7 @@ kind: PodNetworking
 metadata:
   name: stateless
 spec:
-  ipType:
+  allocationType:
     type: Elastic
   selector:
     podSelector:
@@ -238,7 +238,7 @@ kind: PodNetworking
 metadata:
   name: fixed-ip
 spec:
-  ipType:
+  allocationType:
     type: Fixed              <--- podIP 模式
     releaseStrategy: TTL
     releaseAfter: "5m0s"     <--- pod 删除后回收策略，golang 时间类型

--- a/pkg/controller/webhook/mutating.go
+++ b/pkg/controller/webhook/mutating.go
@@ -50,9 +50,6 @@ func MutatingHook(client client.Client) *webhook.Admission {
 		Handler: admission.HandlerFunc(func(ctx context.Context, req webhook.AdmissionRequest) webhook.AdmissionResponse {
 			switch req.Kind.Kind {
 			case "Pod":
-				if req.Namespace == "kube-system" {
-					return webhook.Allowed("namespace is kube-system")
-				}
 				return podWebhook(ctx, &req, client)
 			case "PodNetworking":
 				return podNetworkingWebhook(ctx, req, client)


### PR DESCRIPTION
If you prefer this feature not work on some namepace , you can config on webhook.