### PR TITLE
apiextensions.k8s.io/v1beta1 to v1 and upgrade image version to v1.2.3

### DIFF
--- a/terway-cilium.yml
+++ b/terway-cilium.yml
@@ -84,7 +84,7 @@ rules:
       - '*'
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: terway-binding
@@ -146,11 +146,11 @@ spec:
       labels:
         app: terway
       annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
+        priorityClassName: ''
     spec:
       hostPID: true
       nodeSelector:
-        beta.kubernetes.io/arch: amd64
+        kubernetes.io/arch: amd64
       tolerations:
         - operator: "Exists"
       terminationGracePeriodSeconds: 0
@@ -158,7 +158,7 @@ spec:
       hostNetwork: true
       initContainers:
         - name: terway-init
-          image: registry.cn-hangzhou.aliyuncs.com/acs/terway:v1.0.10.333-gfd2b7b8-aliyun
+          image: registry.cn-hangzhou.aliyuncs.com/acs/terway:v1.2.3
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -177,7 +177,7 @@ spec:
               name: host-root
       containers:
         - name: terway
-          image: registry.cn-hangzhou.aliyuncs.com/acs/terway:v1.0.10.333-gfd2b7b8-aliyun
+          image: registry.cn-hangzhou.aliyuncs.com/acs/terway:v1.2.3
           imagePullPolicy: IfNotPresent
           command: [ '/usr/bin/terwayd', '-log-level', 'debug', '-daemon-mode', 'ENIMultiIP' ]
           securityContext:
@@ -207,7 +207,7 @@ spec:
             - mountPath: /var/lib/kubelet/device-plugins
               name: device-plugin-path
         - name: policy
-          image: registry.cn-hangzhou.aliyuncs.com/acs/terway:v1.0.10.333-gfd2b7b8-aliyun
+          image: registry.cn-hangzhou.aliyuncs.com/acs/terway:v1.2.3
           imagePullPolicy: IfNotPresent
           command: [ "/bin/policyinit.sh" ]
           env:
@@ -327,14 +327,25 @@ spec:
 
 ---
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: felixconfigurations.crd.projectcalico.org
 spec:
   scope: Cluster
   group: crd.projectcalico.org
-  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            host:
+              type: string
+            port:
+              type: string
   names:
     kind: FelixConfiguration
     plural: felixconfigurations
@@ -342,14 +353,25 @@ spec:
 
 ---
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: bgpconfigurations.crd.projectcalico.org
 spec:
   scope: Cluster
   group: crd.projectcalico.org
-  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            host:
+              type: string
+            port:
+              type: string
   names:
     kind: BGPConfiguration
     plural: bgpconfigurations
@@ -357,14 +379,25 @@ spec:
 
 ---
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: ippools.crd.projectcalico.org
 spec:
   scope: Cluster
   group: crd.projectcalico.org
-  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            host:
+              type: string
+            port:
+              type: string
   names:
     kind: IPPool
     plural: ippools
@@ -372,14 +405,25 @@ spec:
 
 ---
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: hostendpoints.crd.projectcalico.org
 spec:
   scope: Cluster
   group: crd.projectcalico.org
-  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            host:
+              type: string
+            port:
+              type: string
   names:
     kind: HostEndpoint
     plural: hostendpoints
@@ -387,14 +431,25 @@ spec:
 
 ---
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clusterinformations.crd.projectcalico.org
 spec:
   scope: Cluster
   group: crd.projectcalico.org
-  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            host:
+              type: string
+            port:
+              type: string
   names:
     kind: ClusterInformation
     plural: clusterinformations
@@ -402,14 +457,25 @@ spec:
 
 ---
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: globalnetworkpolicies.crd.projectcalico.org
 spec:
   scope: Cluster
   group: crd.projectcalico.org
-  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            host:
+              type: string
+            port:
+              type: string
   names:
     kind: GlobalNetworkPolicy
     plural: globalnetworkpolicies
@@ -417,14 +483,25 @@ spec:
 
 ---
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: globalnetworksets.crd.projectcalico.org
 spec:
   scope: Cluster
   group: crd.projectcalico.org
-  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            host:
+              type: string
+            port:
+              type: string
   names:
     kind: GlobalNetworkSet
     plural: globalnetworksets
@@ -432,14 +509,25 @@ spec:
 
 ---
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: networkpolicies.crd.projectcalico.org
 spec:
   scope: Namespaced
   group: crd.projectcalico.org
-  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            host:
+              type: string
+            port:
+              type: string
   names:
     kind: NetworkPolicy
     plural: networkpolicies

--- a/terway-metric.yml
+++ b/terway-metric.yml
@@ -6,13 +6,13 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: terway
+      app: terway-metric-proxy
   template:
     metadata:
       labels:
         app: terway-metric-proxy
       annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
+        priorityClassName: ''
     spec:
       nodeSelector:
         beta.kubernetes.io/arch: amd64
@@ -194,7 +194,7 @@ metadata:
 
 ---
 # deploy
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: prometheus-terway
@@ -203,6 +203,9 @@ metadata:
     app: prometheus-terway
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: prometheus-terway
   template:
     metadata:
       name: prometheus-terway

--- a/terway-multiip.yml
+++ b/terway-multiip.yml
@@ -45,7 +45,7 @@ rules:
 
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: terway-binding
@@ -107,11 +107,11 @@ spec:
       labels:
         app: terway
       annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
+        priorityClassName: ''
     spec:
       hostPID: true
       nodeSelector:
-        beta.kubernetes.io/arch: amd64
+        kubernetes.io/arch: amd64
       tolerations:
         - operator: "Exists"
       terminationGracePeriodSeconds: 0
@@ -119,7 +119,7 @@ spec:
       hostNetwork: true
       initContainers:
         - name: terway-init
-          image: registry.aliyuncs.com/acs/terway:v1.0.10.333-gfd2b7b8-aliyun
+          image: registry.aliyuncs.com/acs/terway:v1.2.3
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true
@@ -145,7 +145,7 @@ spec:
               name: host-root
       containers:
         - name: terway
-          image: registry.aliyuncs.com/acs/terway:v1.0.10.333-gfd2b7b8-aliyun
+          image: registry.aliyuncs.com/acs/terway:v1.2.3
           imagePullPolicy: IfNotPresent
           command: [ '/usr/bin/terwayd', '-log-level', 'debug', '-daemon-mode', 'ENIMultiIP' ]
           securityContext:
@@ -175,7 +175,7 @@ spec:
             - mountPath: /var/lib/kubelet/device-plugins
               name: device-plugin-path
         - name: policy
-          image: registry.aliyuncs.com/acs/terway:v1.0.10.333-gfd2b7b8-aliyun
+          image: registry.aliyuncs.com/acs/terway:v1.2.3
           imagePullPolicy: IfNotPresent
           command: [ "/bin/policyinit.sh" ]
           env:
@@ -251,14 +251,25 @@ spec:
 
 ---
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: felixconfigurations.crd.projectcalico.org
 spec:
   scope: Cluster
   group: crd.projectcalico.org
-  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            host:
+              type: string
+            port:
+              type: string
   names:
     kind: FelixConfiguration
     plural: felixconfigurations
@@ -266,14 +277,25 @@ spec:
 
 ---
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: bgpconfigurations.crd.projectcalico.org
 spec:
   scope: Cluster
   group: crd.projectcalico.org
-  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            host:
+              type: string
+            port:
+              type: string
   names:
     kind: BGPConfiguration
     plural: bgpconfigurations
@@ -281,14 +303,25 @@ spec:
 
 ---
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: ippools.crd.projectcalico.org
 spec:
   scope: Cluster
   group: crd.projectcalico.org
-  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            host:
+              type: string
+            port:
+              type: string
   names:
     kind: IPPool
     plural: ippools
@@ -296,14 +329,25 @@ spec:
 
 ---
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: hostendpoints.crd.projectcalico.org
 spec:
   scope: Cluster
   group: crd.projectcalico.org
-  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            host:
+              type: string
+            port:
+              type: string
   names:
     kind: HostEndpoint
     plural: hostendpoints
@@ -311,14 +355,25 @@ spec:
 
 ---
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clusterinformations.crd.projectcalico.org
 spec:
   scope: Cluster
   group: crd.projectcalico.org
-  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            host:
+              type: string
+            port:
+              type: string
   names:
     kind: ClusterInformation
     plural: clusterinformations
@@ -326,14 +381,25 @@ spec:
 
 ---
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: globalnetworkpolicies.crd.projectcalico.org
 spec:
   scope: Cluster
   group: crd.projectcalico.org
-  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            host:
+              type: string
+            port:
+              type: string
   names:
     kind: GlobalNetworkPolicy
     plural: globalnetworkpolicies
@@ -341,14 +407,25 @@ spec:
 
 ---
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: globalnetworksets.crd.projectcalico.org
 spec:
   scope: Cluster
   group: crd.projectcalico.org
-  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            host:
+              type: string
+            port:
+              type: string
   names:
     kind: GlobalNetworkSet
     plural: globalnetworksets
@@ -356,14 +433,25 @@ spec:
 
 ---
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: networkpolicies.crd.projectcalico.org
 spec:
   scope: Namespaced
   group: crd.projectcalico.org
-  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            host:
+              type: string
+            port:
+              type: string
   names:
     kind: NetworkPolicy
     plural: networkpolicies

--- a/terway-windows-eni.yml
+++ b/terway-windows-eni.yml
@@ -44,7 +44,7 @@ rules:
     verbs: [ "*" ]
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: terway-binding
@@ -99,7 +99,7 @@ spec:
       labels:
         app: terway-eni-windows
       annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ""
+        priorityClassName: ""
     spec:
       terminationGracePeriodSeconds: 0
       tolerations:
@@ -116,7 +116,7 @@ spec:
                     operator: NotIn
                     values:
                       - virtual-kubelet
-                  - key: beta.kubernetes.io/os
+                  - key: kubernetes.io/os
                     operator: In
                     values:
                       - windows
@@ -164,7 +164,7 @@ spec:
                   fieldPath: metadata.name
             - name: CONTAINER_NAME
               value: "terway"
-          image: registry.aliyuncs.com/acs/terway:v1.0.10.333-gfd2b7b8-aliyun
+          image: registry.aliyuncs.com/acs/terway:v1.2.3
           imagePullPolicy: Always
           resources:
             requests:

--- a/terway-windows-eniip.yml
+++ b/terway-windows-eniip.yml
@@ -44,7 +44,7 @@ rules:
     verbs: [ "*" ]
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: terway-binding
@@ -206,7 +206,7 @@ spec:
       labels:
         app: terway-eniip-windows
       annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ""
+        priorityClassName: ""
     spec:
       terminationGracePeriodSeconds: 0
       tolerations:
@@ -223,7 +223,7 @@ spec:
                     operator: NotIn
                     values:
                       - virtual-kubelet
-                  - key: beta.kubernetes.io/os
+                  - key: kubernetes.io/os
                     operator: In
                     values:
                       - windows
@@ -271,7 +271,7 @@ spec:
                   fieldPath: metadata.name
             - name: CONTAINER_NAME
               value: "terway"
-          image: registry.aliyuncs.com/acs/terway:v1.0.10.333-gfd2b7b8-aliyun
+          image: registry.aliyuncs.com/acs/terway:v1.2.3
           imagePullPolicy: Always
           resources:
             requests:
@@ -327,7 +327,7 @@ spec:
               value: 'application/vnd.kubernetes.protobuf'
             - name: FELIX_KUBECLIENTACCEPTCONTENTTYPES
               value: 'application/vnd.kubernetes.protobuf,application/json'
-          image: registry.aliyuncs.com/acs/terway:v1.0.10.333-gfd2b7b8-aliyun
+          image: registry.aliyuncs.com/acs/terway:v1.2.3
           imagePullPolicy: Always
           resources:
             requests:
@@ -391,112 +391,207 @@ spec:
             type: ''
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: felixconfigurations.crd.projectcalico.org
 spec:
   scope: Cluster
   group: crd.projectcalico.org
-  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            host:
+              type: string
+            port:
+              type: string
   names:
     kind: FelixConfiguration
     plural: felixconfigurations
     singular: felixconfiguration
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: bgpconfigurations.crd.projectcalico.org
 spec:
   scope: Cluster
   group: crd.projectcalico.org
-  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            host:
+              type: string
+            port:
+              type: string
   names:
     kind: BGPConfiguration
     plural: bgpconfigurations
     singular: bgpconfiguration
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: ippools.crd.projectcalico.org
 spec:
   scope: Cluster
   group: crd.projectcalico.org
-  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            host:
+              type: string
+            port:
+              type: string
   names:
     kind: IPPool
     plural: ippools
     singular: ippool
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: hostendpoints.crd.projectcalico.org
 spec:
   scope: Cluster
   group: crd.projectcalico.org
-  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            host:
+              type: string
+            port:
+              type: string
   names:
     kind: HostEndpoint
     plural: hostendpoints
     singular: hostendpoint
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clusterinformations.crd.projectcalico.org
 spec:
   scope: Cluster
   group: crd.projectcalico.org
-  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            host:
+              type: string
+            port:
+              type: string
   names:
     kind: ClusterInformation
     plural: clusterinformations
     singular: clusterinformation
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: globalnetworkpolicies.crd.projectcalico.org
 spec:
   scope: Cluster
   group: crd.projectcalico.org
-  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            host:
+              type: string
+            port:
+              type: string
   names:
     kind: GlobalNetworkPolicy
     plural: globalnetworkpolicies
     singular: globalnetworkpolicy
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: globalnetworksets.crd.projectcalico.org
 spec:
   scope: Cluster
   group: crd.projectcalico.org
-  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            host:
+              type: string
+            port:
+              type: string
   names:
     kind: GlobalNetworkSet
     plural: globalnetworksets
     singular: globalnetworkset
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: networkpolicies.crd.projectcalico.org
 spec:
   scope: Namespaced
   group: crd.projectcalico.org
-  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            host:
+              type: string
+            port:
+              type: string
   names:
     kind: NetworkPolicy
     plural: networkpolicies

--- a/terway-windows.yml
+++ b/terway-windows.yml
@@ -44,7 +44,7 @@ rules:
     verbs: [ "*" ]
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: terway-binding
@@ -100,7 +100,7 @@ spec:
       labels:
         app: terway-windows
       annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ""
+        priorityClassName: ""
     spec:
       terminationGracePeriodSeconds: 0
       tolerations:
@@ -117,7 +117,7 @@ spec:
                     operator: NotIn
                     values:
                       - virtual-kubelet
-                  - key: beta.kubernetes.io/os
+                  - key: kubernetes.io/os
                     operator: In
                     values:
                       - windows
@@ -165,7 +165,7 @@ spec:
                   fieldPath: metadata.name
             - name: CONTAINER_NAME
               value: "terway"
-          image: registry.aliyuncs.com/acs/terway:v1.0.10.333-gfd2b7b8-aliyun
+          image: registry.aliyuncs.com/acs/terway:v1.2.3
           imagePullPolicy: Always
           resources:
             requests:
@@ -221,7 +221,7 @@ spec:
               value: 'application/vnd.kubernetes.protobuf'
             - name: FELIX_KUBECLIENTACCEPTCONTENTTYPES
               value: 'application/vnd.kubernetes.protobuf,application/json'
-          image: registry.aliyuncs.com/acs/terway:v1.0.10.333-gfd2b7b8-aliyun
+          image: registry.aliyuncs.com/acs/terway:v1.2.3
           imagePullPolicy: Always
           resources:
             requests:
@@ -285,112 +285,207 @@ spec:
             type: ''
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: felixconfigurations.crd.projectcalico.org
 spec:
   scope: Cluster
   group: crd.projectcalico.org
-  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            host:
+              type: string
+            port:
+              type: string
   names:
     kind: FelixConfiguration
     plural: felixconfigurations
     singular: felixconfiguration
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: bgpconfigurations.crd.projectcalico.org
 spec:
   scope: Cluster
   group: crd.projectcalico.org
-  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            host:
+              type: string
+            port:
+              type: string
   names:
     kind: BGPConfiguration
     plural: bgpconfigurations
     singular: bgpconfiguration
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: ippools.crd.projectcalico.org
 spec:
   scope: Cluster
   group: crd.projectcalico.org
-  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            host:
+              type: string
+            port:
+              type: string
   names:
     kind: IPPool
     plural: ippools
     singular: ippool
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: hostendpoints.crd.projectcalico.org
 spec:
   scope: Cluster
   group: crd.projectcalico.org
-  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            host:
+              type: string
+            port:
+              type: string
   names:
     kind: HostEndpoint
     plural: hostendpoints
     singular: hostendpoint
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clusterinformations.crd.projectcalico.org
 spec:
   scope: Cluster
   group: crd.projectcalico.org
-  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            host:
+              type: string
+            port:
+              type: string
   names:
     kind: ClusterInformation
     plural: clusterinformations
     singular: clusterinformation
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: globalnetworkpolicies.crd.projectcalico.org
 spec:
   scope: Cluster
   group: crd.projectcalico.org
-  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            host:
+              type: string
+            port:
+              type: string
   names:
     kind: GlobalNetworkPolicy
     plural: globalnetworkpolicies
     singular: globalnetworkpolicy
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: globalnetworksets.crd.projectcalico.org
 spec:
   scope: Cluster
   group: crd.projectcalico.org
-  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            host:
+              type: string
+            port:
+              type: string
   names:
     kind: GlobalNetworkSet
     plural: globalnetworksets
     singular: globalnetworkset
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: networkpolicies.crd.projectcalico.org
 spec:
   scope: Namespaced
   group: crd.projectcalico.org
-  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            host:
+              type: string
+            port:
+              type: string
   names:
     kind: NetworkPolicy
     plural: networkpolicies

--- a/terway.yml
+++ b/terway.yml
@@ -45,7 +45,7 @@ rules:
 
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: terway-binding
@@ -100,11 +100,11 @@ spec:
       labels:
         app: terway
       annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
+        priorityClassName: ''
     spec:
       hostPID: true
       nodeSelector:
-        beta.kubernetes.io/arch: amd64
+        kubernetes.io/arch: amd64
       tolerations:
       - operator: "Exists"
       terminationGracePeriodSeconds: 0
@@ -230,14 +230,25 @@ spec:
 
 ---
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: felixconfigurations.crd.projectcalico.org
 spec:
   scope: Cluster
   group: crd.projectcalico.org
-  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            host:
+              type: string
+            port:
+              type: string
   names:
     kind: FelixConfiguration
     plural: felixconfigurations
@@ -245,14 +256,25 @@ spec:
 
 ---
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: bgpconfigurations.crd.projectcalico.org
 spec:
   scope: Cluster
   group: crd.projectcalico.org
-  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            host:
+              type: string
+            port:
+              type: string
   names:
     kind: BGPConfiguration
     plural: bgpconfigurations
@@ -260,14 +282,25 @@ spec:
 
 ---
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: ippools.crd.projectcalico.org
 spec:
   scope: Cluster
   group: crd.projectcalico.org
-  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            host:
+              type: string
+            port:
+              type: string
   names:
     kind: IPPool
     plural: ippools
@@ -275,14 +308,25 @@ spec:
 
 ---
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: hostendpoints.crd.projectcalico.org
 spec:
   scope: Cluster
   group: crd.projectcalico.org
-  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            host:
+              type: string
+            port:
+              type: string
   names:
     kind: HostEndpoint
     plural: hostendpoints
@@ -290,14 +334,25 @@ spec:
 
 ---
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clusterinformations.crd.projectcalico.org
 spec:
   scope: Cluster
   group: crd.projectcalico.org
-  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            host:
+              type: string
+            port:
+              type: string
   names:
     kind: ClusterInformation
     plural: clusterinformations
@@ -305,14 +360,25 @@ spec:
 
 ---
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: globalnetworkpolicies.crd.projectcalico.org
 spec:
   scope: Cluster
   group: crd.projectcalico.org
-  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            host:
+              type: string
+            port:
+              type: string
   names:
     kind: GlobalNetworkPolicy
     plural: globalnetworkpolicies
@@ -320,14 +386,25 @@ spec:
 
 ---
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: globalnetworksets.crd.projectcalico.org
 spec:
   scope: Cluster
   group: crd.projectcalico.org
-  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            host:
+              type: string
+            port:
+              type: string
   names:
     kind: GlobalNetworkSet
     plural: globalnetworksets
@@ -335,14 +412,25 @@ spec:
 
 ---
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: networkpolicies.crd.projectcalico.org
 spec:
   scope: Namespaced
   group: crd.projectcalico.org
-  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            host:
+              type: string
+            port:
+              type: string
   names:
     kind: NetworkPolicy
     plural: networkpolicies


### PR DESCRIPTION
1. [isusse](https://github.com/AliyunContainerService/terway/issues/370): The apiextensions.k8s.io/v1beta1 API version of CustomResourceDefinition is no longer served as of v1.22
2.  upgrade terway image to v1.2.3, to fix error: plugin terway does not support config version "0.3.1"