### PR TITLE
update policy image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG TERWAY_POLICY_IMAGE=registry.cn-hongkong.aliyuncs.com/acs/terway:policy-20231117-4da34c59@sha256:284658acf80bc10c4e82576028e450dbf0e12bd040cdd92e13ec1d74f4c0a2e0
+ARG TERWAY_POLICY_IMAGE=registry.cn-hongkong.aliyuncs.com/acs/terway:policy-20231127-4fac1ee7@sha256:0d0f47af6a0d6ef9c07f1af6791ff0a79c061489aaf0319494f0f8c289fd1e32
 ARG UBUNTU_IMAGE=registry.cn-hangzhou.aliyuncs.com/acs/ubuntu:20.04-update
 ARG CILIUM_LLVM_IMAGE=quay.io/cilium/cilium-llvm:547db7ec9a750b8f888a506709adb41f135b952e@sha256:4d6fa0aede3556c5fb5a9c71bc6b9585475ac9b1064f516d4c45c8fb691c9d9e
 ARG CILIUM_BPFTOOL_IMAGE=quay.io/cilium/cilium-bpftool:78448c1a37ff2b790d5e25c3d8b8ec3e96e6405f@sha256:99a9453a921a8de99899ef82e0822f0c03f65d97005c064e231c06247ad8597d

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ FROM --platform=$TARGETPLATFORM ${CILIUM_BPFTOOL_IMAGE} as bpftool-dist
 FROM --platform=$TARGETPLATFORM ${CILIUM_IPROUTE2_IMAGE} as iproute2-dist
 FROM --platform=$TARGETPLATFORM ${CILIUM_IPTABLES_IMAGE} as iptables-dist
 
-FROM --platform=$BUILDPLATFORM golang:1.20.6 as builder
+FROM --platform=$BUILDPLATFORM golang:1.21.3 as builder
 ARG GOPROXY
 ARG TARGETOS
 ARG TARGETARCH

--- a/Dockerfile.controlplane
+++ b/Dockerfile.controlplane
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.19.2 as builder
+FROM --platform=$BUILDPLATFORM golang:1.21.3 as builder
 ARG GOPROXY
 ARG TARGETOS
 ARG TARGETARCH

--- a/Dockerfile.policy
+++ b/Dockerfile.policy
@@ -29,10 +29,10 @@ RUN rm -rf cilium
 ENV GIT_TAG=v1.12.7
 ENV GIT_COMMIT=67190636f1d5a7a443ea0bda585b215e7650dd25
 RUN git clone -b $GIT_TAG --depth 1 https://github.com/cilium/cilium.git && \
-    cd cilium && \
+    cd cilium && git config --global user.email terway && git config --global user.name terway && \
     [ "`git rev-parse HEAD`" = "${GIT_COMMIT}" ]
 COPY policy/cilium /cilium_patch
-RUN cd cilium && git apply /cilium_patch/*.patch
+RUN cd cilium && git am /cilium_patch/*.patch
 ARG NOSTRIP
 ARG LOCKDEBUG
 ARG V

--- a/policy/cilium/0016-endpoint-Reduce-CPU-and-memory-usage-of-function-mov.patch
+++ b/policy/cilium/0016-endpoint-Reduce-CPU-and-memory-usage-of-function-mov.patch
@@ -1,0 +1,234 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ryan Drew <ryan.drew@isovalent.com>
+Date: Wed, 14 Jun 2023 12:40:49 -0600
+Subject: endpoint: Reduce CPU and memory usage of function moveNewFilesTo
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+This commit makes changes to the function moveNewFilesTo to reduce its
+complexity from O(n^2) to O(n) and decrease its CPU and memory usage.
+The function moveNewFilesTo is a utility function that may be called
+in the endpoint regeneration hot path. This commit makes the
+following changes to speed it up and reduce memory allocations:
+
+* Use a map to look up if a file from the source directory exists in
+  the destination directory. Before this commit, this lookup was done
+  using a nested for loop, looping over slices that contain files
+  in the source and destination directories.
+* Use `os.File.Readdirnames` instead of os.ReadDir. The function
+  `os.ReadDir` sorts the slice of returned files, which is not needed
+  for this use case. Additionally, Readdirnames returns a string slice
+  of file names, rather than a slice of `os.DirEntry` structs, meaning
+  the name of each file does need to be accessed using an accessor
+  method.
+
+The benefits of these changes will pay off in scale. The variables
+impacting the resource consumption of this function are:
+
+* The number of files to move between two the directories.
+* Rate of endpoint regeneration, which is impacted by policy churn,
+  pod churn, node churn, label updates, among others.
+
+Even if these changes save 0.1% of CPU time, this adds up to a core
+of savings just by creating 1000 pods (10 pods per node in a 100 node
+cluster).
+
+In the future, more work can be done to look at the higher-level
+context of how an endpoint's eBPF programs are regenerated, to find
+greater optimizations.
+
+This commit additionally introduces benchmark tests. Here are results
+comparing the implementation of moveNewFilesTo before and after this
+commit using benchstat. Each benchmark was executed 10 times.
+
+```
+goos: linux
+goarch: amd64
+pkg: github.com/cilium/cilium/pkg/endpoint
+cpu: 12th Gen Intel(R) Core(TM) i7-12700H
+                   │ MoveNewFilesTo1.txt │     MoveNewFilesTo1-after.txt      │
+                   │       sec/op        │   sec/op     vs base               │
+MoveNewFilesTo1-20           5.583µ ± 1%   5.514µ ± 1%  -1.24% (p=0.000 n=10)
+
+                   │ MoveNewFilesTo1.txt │     MoveNewFilesTo1-after.txt      │
+                   │        B/op         │    B/op     vs base                │
+MoveNewFilesTo1-20            486.0 ± 0%   373.0 ± 0%  -23.25% (p=0.000 n=10)
+
+                   │ MoveNewFilesTo1.txt │     MoveNewFilesTo1-after.txt      │
+                   │      allocs/op      │ allocs/op   vs base                │
+MoveNewFilesTo1-20            13.00 ± 0%   10.00 ± 0%  -23.08% (p=0.000 n=10)
+goos: linux
+goarch: amd64
+pkg: github.com/cilium/cilium/pkg/endpoint
+cpu: 12th Gen Intel(R) Core(TM) i7-12700H
+                   │ MoveNewFilesTo5.txt │     MoveNewFilesTo5-after.txt      │
+                   │       sec/op        │   sec/op     vs base               │
+MoveNewFilesTo5-20           6.878µ ± 1%   6.383µ ± 1%  -7.20% (p=0.000 n=10)
+
+                   │ MoveNewFilesTo5.txt │     MoveNewFilesTo5-after.txt      │
+                   │        B/op         │    B/op     vs base                │
+MoveNewFilesTo5-20           1137.0 ± 0%   641.0 ± 0%  -43.62% (p=0.000 n=10)
+
+                   │ MoveNewFilesTo5.txt │     MoveNewFilesTo5-after.txt      │
+                   │      allocs/op      │ allocs/op   vs base                │
+MoveNewFilesTo5-20            29.00 ± 0%   19.00 ± 0%  -34.48% (p=0.000 n=10)
+goos: linux
+goarch: amd64
+pkg: github.com/cilium/cilium/pkg/endpoint
+cpu: 12th Gen Intel(R) Core(TM) i7-12700H
+                    │ MoveNewFilesTo10.txt │     MoveNewFilesTo10-after.txt      │
+                    │        sec/op        │   sec/op     vs base                │
+MoveNewFilesTo10-20            9.173µ ± 1%   7.644µ ± 1%  -16.67% (p=0.000 n=10)
+
+                    │ MoveNewFilesTo10.txt │      MoveNewFilesTo10-after.txt      │
+                    │         B/op         │     B/op      vs base                │
+MoveNewFilesTo10-20           1.992Ki ± 0%   1.322Ki ± 0%  -33.63% (p=0.000 n=10)
+
+                    │ MoveNewFilesTo10.txt │     MoveNewFilesTo10-after.txt     │
+                    │      allocs/op       │ allocs/op   vs base                │
+MoveNewFilesTo10-20             48.00 ± 0%   30.00 ± 0%  -37.50% (p=0.000 n=10)
+```
+
+The use of goroutines was purposefully omitted from these changes for
+two reasons:
+
+1. The expected number of files in the source directory given to
+   moveNewFilesTo is four. The max number of extra goroutines that
+   could be expected on a given machine running Cilium is four times
+   the number of endpoints on the node. The impact of these extra
+   goroutines is difficult to predict and debated.
+2. Using goroutines to parallelize renames didn't make a substantial
+   difference in the amount of CPU time saved, while increasing overall
+   memory usage due to the overhead of goroutine creation.
+
+Signed-off-by: Ryan Drew <ryan.drew@isovalent.com>
+---
+ pkg/endpoint/directory.go      | 38 +++++++++++++++++++---------
+ pkg/endpoint/directory_test.go | 45 ++++++++++++++++++++++++++++++++++
+ 2 files changed, 72 insertions(+), 11 deletions(-)
+
+diff --git a/pkg/endpoint/directory.go b/pkg/endpoint/directory.go
+index 2db97ee589..f21317cc41 100644
+--- a/pkg/endpoint/directory.go
++++ b/pkg/endpoint/directory.go
+@@ -48,27 +48,43 @@ func (e *Endpoint) backupDirectoryPath() string {
+ 
+ // moveNewFilesTo copies all files, that do not exist in newDir, from oldDir.
+ func moveNewFilesTo(oldDir, newDir string) error {
+-	oldFiles, err := os.ReadDir(oldDir)
++	var err error
++
++	oldDirFile, err := os.Open(oldDir)
++	if err != nil {
++		return err
++	}
++	defer oldDirFile.Close()
++
++	oldFiles, err := oldDirFile.Readdirnames(-1)
++	if err != nil {
++		return err
++	}
++
++	newDirFile, err := os.Open(newDir)
+ 	if err != nil {
+ 		return err
+ 	}
+-	newFiles, err := os.ReadDir(newDir)
++	defer newDirFile.Close()
++
++	newFiles, err := newDirFile.Readdirnames(-1)
+ 	if err != nil {
+ 		return err
+ 	}
+ 
++	newFilesHash := make(map[string]struct{}, len(newFiles))
++	for _, f := range newFiles {
++		newFilesHash[f] = struct{}{}
++	}
++
++	var ok bool
++
+ 	for _, oldFile := range oldFiles {
+-		exists := false
+-		for _, newFile := range newFiles {
+-			if oldFile.Name() == newFile.Name() {
+-				exists = true
+-				break
+-			}
+-		}
+-		if !exists {
+-			os.Rename(filepath.Join(oldDir, oldFile.Name()), filepath.Join(newDir, oldFile.Name()))
++		if _, ok = newFilesHash[oldFile]; !ok {
++			os.Rename(filepath.Join(oldDir, oldFile), filepath.Join(newDir, oldFile))
+ 		}
+ 	}
++
+ 	return nil
+ }
+ 
+diff --git a/pkg/endpoint/directory_test.go b/pkg/endpoint/directory_test.go
+index 610f12b2b9..eb67238b58 100644
+--- a/pkg/endpoint/directory_test.go
++++ b/pkg/endpoint/directory_test.go
+@@ -6,8 +6,11 @@
+ package endpoint
+ 
+ import (
++	"fmt"
++	"math"
+ 	"os"
+ 	"path/filepath"
++	"testing"
+ 
+ 	"gopkg.in/check.v1"
+ 
+@@ -78,3 +81,45 @@ func (s *EndpointSuite) TestMoveNewFilesTo(c *check.C) {
+ 		}
+ 	}
+ }
++
++func benchmarkMoveNewFilesTo(b *testing.B, numFiles int) {
++	oldDir := b.TempDir()
++	newDir := b.TempDir()
++	numDuplicates := int(math.Round(float64(numFiles) * 0.25))
++
++	for n := 0; n < numFiles; n++ {
++		name := fmt.Sprintf("file%d", n)
++		if err := os.WriteFile(filepath.Join(oldDir, name), []byte{}, os.FileMode(0644)); err != nil {
++			b.Fatal(err)
++		}
++
++		if n < numDuplicates {
++			if err := os.WriteFile(filepath.Join(newDir, name), []byte{}, os.FileMode(0644)); err != nil {
++				b.Fatal(err)
++			}
++		}
++	}
++
++	b.ResetTimer()
++	for i := 0; i < b.N; i++ {
++		if err := moveNewFilesTo(oldDir, newDir); err != nil {
++			b.Fatal(err)
++		}
++	}
++	b.StopTimer()
++
++	os.RemoveAll(oldDir)
++	os.RemoveAll(newDir)
++}
++
++func BenchmarkMoveNewFilesTo1(b *testing.B) {
++	benchmarkMoveNewFilesTo(b, 1)
++}
++
++func BenchmarkMoveNewFilesTo5(b *testing.B) {
++	benchmarkMoveNewFilesTo(b, 5)
++}
++
++func BenchmarkMoveNewFilesTo10(b *testing.B) {
++	benchmarkMoveNewFilesTo(b, 10)
++}
+-- 
+2.42.1
+

--- a/policy/cilium/0017-fix-endpoint-is-lost-during-restore.patch
+++ b/policy/cilium/0017-fix-endpoint-is-lost-during-restore.patch
@@ -1,0 +1,59 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: l1b0k <libokang.lbk@alibaba-inc.com>
+Date: Tue, 21 Nov 2023 14:58:21 +0800
+Subject: fix endpoint is lost during restore
+
+Signed-off-by: l1b0k <libokang.lbk@alibaba-inc.com>
+---
+ pkg/endpoint/restore.go | 22 ++++++++++++++++++----
+ 1 file changed, 18 insertions(+), 4 deletions(-)
+
+diff --git a/pkg/endpoint/restore.go b/pkg/endpoint/restore.go
+index 21124db6fb..b02803db11 100644
+--- a/pkg/endpoint/restore.go
++++ b/pkg/endpoint/restore.go
+@@ -113,8 +113,24 @@ func ReadEPsFromDirNames(ctx context.Context, owner regeneration.Owner, policyGe
+ 		}
+
+ 		if err := headerFileExists(); err != nil {
+-			scopedLog.WithError(err).Warn("C header file not found. Ignoring endpoint")
+-			continue
++			// synchronizeDirectories() logic would rename origDir (xxx) to backupDir (xxx_stale)
++			// is is possible previous is a not complete restore directory
++			// try restore if backup exists
++			backupDir := epDir + backupDirectorySuffix
++			origDir := epDir
++			_, err = os.Stat(backupDir)
++			if err != nil {
++				scopedLog.WithError(err).Warn("C header file not found. Ignoring endpoint")
++				continue
++			}
++			log.Warnf("unable to locate C header file %s. Trying to restore from backup", cHeaderFile)
++
++			_ = os.Mkdir(origDir, os.ModeDir)
++			err = moveNewFilesTo(backupDir, origDir)
++			if err != nil {
++				log.WithError(err).Warnf("unable to copy old bpf object "+
++					"files from %s into the new directory %s.", backupDir, origDir)
++			}
+ 		}
+ 
+ 		// This symlink is only needed when upgrading from a pre-1.11 Cilium
+@@ -407,14 +423,12 @@ func (e *Endpoint) toSerializedEndpoint() *serializableEndpoint {
+ // serializableEndpoint contains the fields from an Endpoint which are needed to be
+ // restored if cilium-agent restarts.
+ //
+-//
+ // WARNING - STABLE API
+ // This structure is written as JSON to StateDir/{ID}/ep_config.h to allow to
+ // restore endpoints when the agent is being restarted. The restore operation
+ // will read the file and re-create all endpoints with all fields which are not
+ // marked as private to JSON marshal. Do NOT modify this structure in ways which
+ // is not JSON forward compatible.
+-//
+ type serializableEndpoint struct {
+ 	// ID of the endpoint, unique in the scope of the node
+ 	ID uint16
+-- 
+2.42.1
+

--- a/policy/policyinit.sh
+++ b/policy/policyinit.sh
@@ -29,13 +29,15 @@ if [ "$(terway_config_val 'eniip_virtual_type' | tr '[:upper:]' '[:lower:]')" = 
   # kernel version equal and above 4.19
   if { [ "$KERNEL_MAJOR_VERSION" -eq 4 ] && [ "$KERNEL_MINOR_VERSION" -ge 19 ]; } ||
      [ "$KERNEL_MAJOR_VERSION" -gt 4 ]; then
+
+    extra_args=$(terway_config_val 'cilium_args')
     if [ -z "$DISABLE_POLICY" ] || [ "$DISABLE_POLICY" = "false" ] || [ "$DISABLE_POLICY" = "0" ]; then
       ENABLE_POLICY="default"
     else
       ENABLE_POLICY="never"
+      extra_args="${extra_args} --labels=k8s:io\\.kubernetes\\.pod\\.namespace "
     fi
 
-    extra_args=$(terway_config_val 'cilium_args')
     if [[ $extra_args != *"bpf-map-dynamic-size-ratio"* ]]; then
       extra_args="${extra_args} --bpf-map-dynamic-size-ratio=0.0025"
     fi


### PR DESCRIPTION
- fix endpoint may lost during restart cilium
- add a label filter to limit the number of ciliumidentity be generated, user may required to re-create all pods if networkpolicy enforcement is made