### PR TITLE
openapi: adapt the QuotaExceeded.PrivateIpAddress code

### DIFF
--- a/pkg/aliyun/client/errors/errors.go
+++ b/pkg/aliyun/client/errors/errors.go
@@ -17,6 +17,8 @@ const (
 	// Reference: https://help.aliyun.com/document_detail/85917.html
 	InvalidVSwitchIDIPNotEnough = "InvalidVSwitchId.IpNotEnough"
 
+	QuotaExceededPrivateIPAddress = "QuotaExceeded.PrivateIpAddress"
+
 	// ErrEniPerInstanceLimitExceeded CreateNetworkInterfaces const error message
 	// Reference: https://help.aliyun.com/document_detail/85917.html
 	ErrEniPerInstanceLimitExceeded = "EniPerInstanceLimitExceeded"

--- a/pkg/controller/multi-ip/node/pool.go
+++ b/pkg/controller/multi-ip/node/pool.go
@@ -1166,7 +1166,7 @@ func (n *ReconcileNode) createENI(ctx context.Context, node *networkv1beta1.Node
 
 	result, err := n.aliyun.CreateNetworkInterface(ctx, typeOption, createOpts)
 	if err != nil {
-		if apiErr.ErrorCodeIs(err, apiErr.InvalidVSwitchIDIPNotEnough) {
+		if apiErr.ErrorCodeIs(err, apiErr.InvalidVSwitchIDIPNotEnough, apiErr.QuotaExceededPrivateIPAddress) {
 			// block
 			n.vswpool.Block(createOpts.NetworkInterfaceOptions.VSwitchID)
 		}
@@ -1233,7 +1233,7 @@ func (n *ReconcileNode) assignIP(ctx context.Context, opt *eniOptions) error {
 			Backoff: &bo,
 		})
 		if err != nil {
-			if apiErr.ErrorCodeIs(err, apiErr.InvalidVSwitchIDIPNotEnough) {
+			if apiErr.ErrorCodeIs(err, apiErr.InvalidVSwitchIDIPNotEnough, apiErr.QuotaExceededPrivateIPAddress) {
 				// block
 				n.vswpool.Block(opt.eniRef.VSwitchID)
 			}
@@ -1262,7 +1262,7 @@ func (n *ReconcileNode) assignIP(ctx context.Context, opt *eniOptions) error {
 			Backoff: &bo,
 		})
 		if err != nil {
-			if apiErr.ErrorCodeIs(err, apiErr.InvalidVSwitchIDIPNotEnough) {
+			if apiErr.ErrorCodeIs(err, apiErr.InvalidVSwitchIDIPNotEnough, apiErr.QuotaExceededPrivateIPAddress) {
 				// block
 				n.vswpool.Block(opt.eniRef.VSwitchID)
 			}
@@ -1416,7 +1416,7 @@ func addIPToMap(in map[string]*networkv1beta1.IP, ip *networkv1beta1.IP) {
 }
 
 func isIPNotEnough(err error) bool {
-	if apiErr.ErrorCodeIs(err, apiErr.InvalidVSwitchIDIPNotEnough) {
+	if apiErr.ErrorCodeIs(err, apiErr.InvalidVSwitchIDIPNotEnough, apiErr.QuotaExceededPrivateIPAddress) {
 		return true
 	}
 	// can not find vsw

--- a/pkg/controller/pod/pod_controller.go
+++ b/pkg/controller/pod/pod_controller.go
@@ -608,7 +608,7 @@ func (m *ReconcilePod) createENI(ctx context.Context, allocs *[]*v1beta1.Allocat
 			eni, err := m.aliyun.CreateNetworkInterface(ctx, option)
 			if err != nil {
 
-				if apiErr.ErrorCodeIs(err, apiErr.InvalidVSwitchIDIPNotEnough) {
+				if apiErr.ErrorCodeIs(err, apiErr.InvalidVSwitchIDIPNotEnough, apiErr.QuotaExceededPrivateIPAddress) {
 					m.swPool.Block(alloc.ENI.VSwitchID)
 				}
 

--- a/pkg/eni/local.go
+++ b/pkg/eni/local.go
@@ -937,7 +937,7 @@ func (l *Local) errorHandleLocked(err error) {
 		}
 	}
 
-	if apiErr.ErrorCodeIs(err, apiErr.InvalidVSwitchIDIPNotEnough) {
+	if apiErr.ErrorCodeIs(err, apiErr.InvalidVSwitchIDIPNotEnough, apiErr.QuotaExceededPrivateIPAddress) {
 		next := time.Now().Add(10 * time.Minute)
 		if next.After(l.ipAllocInhibitExpireAt) {
 			l.ipAllocInhibitExpireAt = next

--- a/pkg/factory/aliyun/aliyun.go
+++ b/pkg/factory/aliyun/aliyun.go
@@ -120,7 +120,7 @@ func (a *Aliyun) CreateNetworkInterface(ipv4, ipv6 int, eniType string) (*daemon
 
 		eni, innerErr = a.openAPI.CreateNetworkInterface(ctx, option)
 		if innerErr != nil {
-			if apiErr.ErrorCodeIs(innerErr, apiErr.InvalidVSwitchIDIPNotEnough) {
+			if apiErr.ErrorCodeIs(innerErr, apiErr.InvalidVSwitchIDIPNotEnough, apiErr.QuotaExceededPrivateIPAddress) {
 				a.vsw.Block(vswID)
 				return false, nil
 			}


### PR DESCRIPTION
ECS typically returns `InvalidVSwitchId.IpNotEnough` but occasionally the error is `QuotaExceeded.PrivateIpAddress`

