### PR TITLE
enable auto switch to datapathv2

### DIFF
--- a/pkg/feature/feature.go
+++ b/pkg/feature/feature.go
@@ -17,5 +17,5 @@ const (
 )
 
 var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	AutoDataPathV2: {Default: false, PreRelease: featuregate.Alpha},
+	AutoDataPathV2: {Default: true, PreRelease: featuregate.Alpha},
 }


### PR DESCRIPTION
We have decided to deprecate ipvlan datapath. This change allows to enable datapathv2 automatically.