### PR TITLE
fix: trunk quantity cal

### DIFF
--- a/pkg/controller/node/node.go
+++ b/pkg/controller/node/node.go
@@ -303,7 +303,7 @@ func (r *ReconcileNode) patchNodeRes(ctx context.Context, k8sNode *corev1.Node, 
 			})
 
 			if found {
-				members := node.Spec.NodeCap.TotalAdapters - node.Spec.NodeCap.Adapters
+				members := node.Spec.NodeCap.MemberAdapterLimit
 
 				// report rse only trunk eni is ready
 				num = resource.NewQuantity(int64(members), resource.DecimalSI)

--- a/pkg/eni/node_reconcile.go
+++ b/pkg/eni/node_reconcile.go
@@ -125,7 +125,7 @@ func (r *nodeReconcile) Reconcile(ctx context.Context, request reconcile.Request
 
 	if eniConfig.EnableENITrunking {
 		node.Spec.ENISpec.EnableTrunk = true
-		if node.Spec.NodeCap.TotalAdapters-node.Spec.NodeCap.Adapters <= 0 {
+		if node.Spec.NodeCap.MemberAdapterLimit <= 0 {
 			node.Spec.ENISpec.EnableTrunk = false
 			l.Info("instance is not support trunk")
 		}


### PR DESCRIPTION
some instance has member eni , but trunk is not supported