### PR TITLE
fix: fix terway with cilium initialization script

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -29,8 +29,6 @@ cp -f /usr/bin/cilium-cni /opt/cni/bin/
 chmod +x /opt/cni/bin/terway
 chmod +x /opt/cni/bin/cilium-cni
 
-# init cni config
-cp /tmp/eni/eni_conf /etc/eni/eni.json
 
 terway-cli cni /tmp/eni/10-terway.conflist /tmp/eni/10-terway.conf --output /etc/cni/net.d/10-terway.conflist
 # remove legacy cni config


### PR DESCRIPTION
修复了terway with cilium 模式 initContainer 启动脚本
initContainer 中并没有/tmp/eni/eni_conf ,且/etc/eni/eni.json 已经挂载好无需init cni config