### PR TITLE
fix(builder): handle instance limit retrieval error

### DIFF
--- a/daemon/builder.go
+++ b/daemon/builder.go
@@ -194,7 +194,7 @@ func (b *NetworkServiceBuilder) initInstanceLimit() error {
 	} else {
 		limit, err := provider.GetLimitFromAnno(node.Annotations)
 		if err != nil {
-			return err
+			serviceLog.Error(err, "unable to get instance limit from annotation")
 		}
 		if limit == nil || instance.GetInstanceMeta().InstanceType != limit.InstanceTypeID {
 			limit, err = provider.GetLimit(b.aliyunClient, instance.GetInstanceMeta().InstanceType)


### PR DESCRIPTION
- Add error logging when unable to get instance limit from annotation
- Improve error handling and maintain the existing logic flow