### PR TITLE
fix: initialize zoneID before building ENIConfig

### DIFF
--- a/daemon/builder.go
+++ b/daemon/builder.go
@@ -248,16 +248,17 @@ func (b *NetworkServiceBuilder) setupENIManager() error {
 		nodeAnnotations = map[string]string{}
 	)
 
-	enableIPv4 := b.service.enableIPv4
-	enableIPv6 := b.service.enableIPv6
-	eniConfig := getENIConfig(b.config)
-	eniConfig.EnableIPv4 = enableIPv4
-	eniConfig.EnableIPv6 = enableIPv6
-
 	zoneID, err := instance.GetInstanceMeta().GetZoneID()
 	if err != nil {
 		return err
 	}
+
+	enableIPv4 := b.service.enableIPv4
+	enableIPv6 := b.service.enableIPv6
+	eniConfig := getENIConfig(b.config, zoneID)
+	eniConfig.EnableIPv4 = enableIPv4
+	eniConfig.EnableIPv6 = enableIPv6
+
 	instanceID, err := instance.GetInstanceMeta().GetInstanceID()
 	if err != nil {
 		return err

--- a/daemon/config.go
+++ b/daemon/config.go
@@ -24,7 +24,7 @@ func getDynamicConfig(ctx context.Context, k8s k8s.Kubernetes) (string, string, 
 	return cfg, label, err
 }
 
-func getENIConfig(cfg *daemon.Config) *daemon.ENIConfig {
+func getENIConfig(cfg *daemon.Config, zoneID string) *daemon.ENIConfig {
 	vswitchSelectionPolicy := vswitch.VSwitchSelectionPolicyRandom
 	switch cfg.VSwitchSelectionPolicy {
 	case "ordered":
@@ -39,6 +39,7 @@ func getENIConfig(cfg *daemon.Config) *daemon.ENIConfig {
 	}
 
 	eniConfig := &daemon.ENIConfig{
+		ZoneID:                 zoneID,
 		VSwitchOptions:         nil,
 		ENITags:                cfg.ENITags,
 		SecurityGroupIDs:       cfg.GetSecurityGroups(),

--- a/daemon/config_test.go
+++ b/daemon/config_test.go
@@ -93,7 +93,7 @@ func TestGetENIConfig(t *testing.T) {
 		},
 	}
 
-	eniConfig := getENIConfig(cfg)
+	eniConfig := getENIConfig(cfg, "zoneID")
 
 	assert.Equal(t, 1, len(eniConfig.ENITags))
 	assert.Equal(t, []string{"sg1", "sg2"}, eniConfig.SecurityGroupIDs)
@@ -101,4 +101,5 @@ func TestGetENIConfig(t *testing.T) {
 	assert.Equal(t, daemon.EniSelectionPolicyMostIPs, eniConfig.EniSelectionPolicy)
 	assert.Equal(t, "rgID", eniConfig.ResourceGroupID)
 	assert.Equal(t, daemon.Feat(3), eniConfig.EniTypeAttr)
+	assert.Equal(t, []string{"vswitch1", "vswitch2"}, eniConfig.VSwitchOptions)
 }


### PR DESCRIPTION
- Retrieve zoneID earlier in setupENIManager to ensure correct vswitch selection
- Pass zoneID to getENIConfig for proper ENI configuration
- Update related test assertions