### PR TITLE
refactor(node_reconcile): add constant for config error event

### DIFF
--- a/types/k8s.go
+++ b/types/k8s.go
@@ -93,6 +93,8 @@ const (
 
 	EventSyncPodNetworkingSucceed = "SyncPodNetworkingSucceed"
 	EventSyncPodNetworkingFailed  = "SyncPodNetworkingFailed"
+
+	EventConfigError = "ConfigError"
 )
 
 // PodUseENI whether pod is use podENI cr res


### PR DESCRIPTION
- Introduce constant EventConfigError in types/k8s.go for consistent usage
- Update node_reconcile.go to use the new constant for configuration-related events- Improve error handling and logging in the reconciliation process