### PR TITLE
build: improve error handling in init.sh

### DIFF
--- a/charts/terway/templates/terwayd/daemonset.yaml
+++ b/charts/terway/templates/terwayd/daemonset.yaml
@@ -61,6 +61,9 @@ spec:
                   key: disable_network_policy
                   optional: true
           volumeMounts:
+            - name: bpf-maps
+              mountPath: /sys/fs/bpf
+              mountPropagation: Bidirectional
             - name: eni-config
               mountPath: /etc/eni
             - mountPath: /var-run-eni
@@ -208,8 +211,13 @@ spec:
               name: cni
               readOnly: true
             # volumes use by cilium
-            - mountPath: /sys/fs
-              name: sys-fs
+            - name: bpf-maps
+              mountPath: /sys/fs/bpf
+              # Unprivileged containers can't set mount propagation to bidirectional
+              # in this case we will mount the bpf fs from an init container that
+              # is privileged and set the mount propagation from host to container
+              # in Cilium.
+              mountPropagation: HostToContainer
             - mountPath: /var/run/cilium
               name: cilium-run
               # Needed to be able to load kernel modules
@@ -255,10 +263,10 @@ spec:
             type: DirectoryOrCreate
           name: cilium-run
         # To keep state between restarts / upgrades for bpf maps
-        - hostPath:
-            path: /sys/fs/
+        - name: bpf-maps
+          hostPath:
+            path: /sys/fs/bpf
             type: DirectoryOrCreate
-          name: sys-fs
           # To access iptables concurrently with other processes (e.g. kube-proxy)
         - hostPath:
             path: /run/xtables.lock

--- a/cmd/terway-cli/cni.go
+++ b/cmd/terway-cli/cni.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"flag"
 	"fmt"
 	"os"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/Jeffail/gabs/v2"
 	"github.com/spf13/cobra"
+	"golang.org/x/sys/unix"
 
 	"github.com/AliyunContainerService/terway/pkg/utils/nodecap"
 )
@@ -282,22 +284,48 @@ func mergeConfigList(configs [][]byte, f *feature) (string, error) {
 	return g.StringIndent("", "  "), nil
 }
 
-const moundCmd = `nsenter -t 1 -m -- bash -c '
-		mount | grep "/sys/fs/bpf type bpf" || {
-		# Mount the filesystem until next reboot
-		echo "Mounting BPF filesystem..."
-		mount bpffs /sys/fs/bpf -t bpf
-
-		echo "Node initialization complete"
-	}'`
-
 func mountHostBpf() error {
-	out, err := exec.Command("/bin/sh", "-c", moundCmd).CombinedOutput()
+	target := "/sys/fs/bpf"
+
+	// 确保目标目录存在
+	err := os.MkdirAll(target, 0755)
 	if err != nil {
-		return fmt.Errorf("mount bpf failed: %v, %s", err, out)
+		return fmt.Errorf("failed to create mount point: %v", err)
 	}
-	_, _ = fmt.Fprint(os.Stdout, string(out))
+
+	// 检查是否已挂载
+	mounted, err := isMounted(target)
+	if err != nil {
+		return fmt.Errorf("failed to check mount status: %v", err)
+	}
+	if mounted {
+		return nil
+	}
+
+	// 执行 mount bpffs /sys/fs/bpf -t bpf
+	err = unix.Mount("bpffs", target, "bpf", 0, "")
+	if err != nil {
+		return fmt.Errorf("mount failed: %v", err)
+	}
+
 	return nil
+}
+
+func isMounted(path string) (bool, error) {
+	f, err := os.Open("/proc/mounts")
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		fields := strings.Split(scanner.Text(), " ")
+		if len(fields) >= 2 && fields[1] == path {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func storeRuntimeConfig(filePath string, container *gabs.Container) error {

--- a/hack/init.sh
+++ b/hack/init.sh
@@ -46,4 +46,7 @@ cat $node_capabilities
 sysctl -w net.ipv4.conf.eth0.rp_filter=0
 modprobe sch_htb || true
 
-chroot /host sh -c "systemctl disable eni.service; rm -f /etc/udev/rules.d/75-persistent-net-generator.rules /lib/udev/rules.d/60-net.rules /lib/udev/rules.d/61-eni.rules /lib/udev/write_net_rules"
+set +o errexit
+
+chroot /host systemctl disable eni.service
+chroot /host rm -f /etc/udev/rules.d/75-persistent-net-generator.rules /lib/udev/rules.d/60-net.rules /lib/udev/rules.d/61-eni.rules /lib/udev/write_net_rules


### PR DESCRIPTION
- Set +o errexit to prevent script termination on error
- Split chroot commands for better error identification
- Update daemonset to include BPF maps volume and mount