### PR TITLE
refactor(network): rename CardIndex to NetworkCardIndex in ENI CRD

### DIFF
--- a/pkg/apis/crds/network.alibabacloud.com_networkinterfaces.yaml
+++ b/pkg/apis/crds/network.alibabacloud.com_networkinterfaces.yaml
@@ -151,8 +151,6 @@ spec:
             type: object
           status:
             properties:
-              cardIndex:
-                type: integer
               eniInfo:
                 properties:
                   id:
@@ -180,6 +178,8 @@ spec:
               instanceID:
                 description: InstanceID for ecs
                 type: string
+              networkCardIndex:
+                type: integer
               nodeName:
                 type: string
               phase:

--- a/pkg/apis/network.alibabacloud.com/v1beta1/eni.go
+++ b/pkg/apis/network.alibabacloud.com/v1beta1/eni.go
@@ -69,6 +69,6 @@ type NetworkInterfaceStatus struct {
 	// TrunkENIID is the trunk eni id
 	TrunkENIID string `json:"trunkENIID,omitempty"`
 
-	CardIndex *int   `json:"cardIndex,omitempty"`
-	NodeName  string `json:"nodeName,omitempty"`
+	NetworkCardIndex *int   `json:"networkCardIndex,omitempty"`
+	NodeName         string `json:"nodeName,omitempty"`
 }

--- a/pkg/apis/network.alibabacloud.com/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/network.alibabacloud.com/v1beta1/zz_generated.deepcopy.go
@@ -389,8 +389,8 @@ func (in *NetworkInterfaceSpec) DeepCopy() *NetworkInterfaceSpec {
 func (in *NetworkInterfaceStatus) DeepCopyInto(out *NetworkInterfaceStatus) {
 	*out = *in
 	in.ENIInfo.DeepCopyInto(&out.ENIInfo)
-	if in.CardIndex != nil {
-		in, out := &in.CardIndex, &out.CardIndex
+	if in.NetworkCardIndex != nil {
+		in, out := &in.NetworkCardIndex, &out.NetworkCardIndex
 		*out = new(int)
 		**out = **in
 	}

--- a/pkg/controller/common/eni.go
+++ b/pkg/controller/common/eni.go
@@ -79,7 +79,7 @@ func FromPodENI(podENI *v1beta1.PodENI) []*v1beta1.NetworkInterface {
 		networkInterface.Status.InstanceID = podENI.Status.InstanceID
 		networkInterface.Status.TrunkENIID = podENI.Status.TrunkENIID
 		networkInterface.Status.ENIInfo = podENI.Status.ENIInfos[eniID]
-		// CardIndex is not stored
+		// NetworkCardIndex is not stored
 	}
 	return result
 }
@@ -158,7 +158,7 @@ func Attach(ctx context.Context, c client.Client, option *AttachOption) error {
 	networkInterface.Status.InstanceID = option.InstanceID
 	networkInterface.Status.TrunkENIID = option.TrunkENIID
 	networkInterface.Status.NodeName = option.NodeName
-	networkInterface.Status.CardIndex = option.NetworkCardIndex
+	networkInterface.Status.NetworkCardIndex = option.NetworkCardIndex
 
 	err = c.Status().Update(ctx, networkInterface)
 	if err != nil {

--- a/pkg/controller/eni/eni.go
+++ b/pkg/controller/eni/eni.go
@@ -166,7 +166,7 @@ func (r *ReconcileNetworkInterface) attach(ctx context.Context, networkInterface
 					NetworkInterfaceID:     toPtr(networkInterface.Name),
 					InstanceID:             toPtr(networkInterface.Status.InstanceID),
 					TrunkNetworkInstanceID: toPtr(networkInterface.Status.TrunkENIID),
-					NetworkCardIndex:       networkInterface.Status.CardIndex,
+					NetworkCardIndex:       networkInterface.Status.NetworkCardIndex,
 				})
 				if err != nil {
 					return reconcile.Result{}, err
@@ -193,7 +193,7 @@ func (r *ReconcileNetworkInterface) attach(ctx context.Context, networkInterface
 				NetworkInterfaceID:     toPtr(networkInterface.Name),
 				InstanceID:             toPtr(networkInterface.Status.InstanceID),
 				TrunkNetworkInstanceID: toPtr(networkInterface.Status.TrunkENIID),
-				NetworkCardIndex:       networkInterface.Status.CardIndex,
+				NetworkCardIndex:       networkInterface.Status.NetworkCardIndex,
 			})
 			if err != nil {
 				return reconcile.Result{}, err
@@ -367,7 +367,7 @@ func (r *ReconcileNetworkInterface) detach(ctx context.Context, networkInterface
 		networkInterface.Status.InstanceID = ""
 		networkInterface.Status.TrunkENIID = ""
 		networkInterface.Status.NodeName = ""
-		networkInterface.Status.CardIndex = nil
+		networkInterface.Status.NetworkCardIndex = nil
 		networkInterface.Status.Phase = v1beta1.ENIPhaseUnbind
 		err = r.client.Status().Update(ctx, networkInterface)
 

--- a/pkg/controller/pod-eni/eni_controller.go
+++ b/pkg/controller/pod-eni/eni_controller.go
@@ -1107,7 +1107,7 @@ func migrate(ctx context.Context, c client.Client) error {
 			networkInterfaceCR.Status.TrunkENIID = podENI.Status.TrunkENIID
 			networkInterfaceCR.Status.Phase = podENI.Status.Phase
 			networkInterfaceCR.Status.ENIInfo = podENI.Status.ENIInfos[alloc.ENI.ID]
-			networkInterfaceCR.Status.CardIndex = networkInterfaceCR.Status.ENIInfo.NetworkCardIndex
+			networkInterfaceCR.Status.NetworkCardIndex = networkInterfaceCR.Status.ENIInfo.NetworkCardIndex
 
 			toCreateOrUpdate = append(toCreateOrUpdate, networkInterfaceCR)
 		}


### PR DESCRIPTION
- Update field name from CardIndex to NetworkCardIndex in NetworkInterface CRD
- Modify related code to use the new field name
- Update API definitions and controller logic to reflect the change