### PR TITLE
Shrink container image size fix

### DIFF
--- a/deploy/images/terway/Dockerfile
+++ b/deploy/images/terway/Dockerfile
@@ -44,7 +44,11 @@ RUN --mount=type=bind,from=iptables-dist,source=/iptables,target=/iptables \
     dpkg -i /iptables/*\.deb
 
 COPY ../../../policy/policyinit.sh ./../../policy/uninstall_policy.sh ../../../hack/init.sh /bin/
-COPY --from=policy-dist --exclude=cilium-operator-generic --exclude=cilium-health* /tmp/install/ /
+COPY --from=policy-dist \
+    --exclude=usr/bin/cilium-operator-generic \
+    --exclude=usr/bin/cilium-dbg \
+    --exclude=usr/bin/cilium-health* \
+    /tmp/install/ /
 COPY --from=builder /go/src/github.com/AliyunContainerService/terway/terwayd /go/src/github.com/AliyunContainerService/terway/terway /go/src/github.com/AliyunContainerService/terway/terway-cli /usr/bin/
 COPY ../../../hack/iptables-wrapper-installer.sh /iptables-wrapper-installer.sh
 RUN /iptables-wrapper-installer.sh --no-sanity-check


### PR DESCRIPTION
The previously added --exclude is not effective.
Also remove the unused cilium-dbg.

336M    old-terway.tar
272M    terway.tar

Together with the previous commit, we reduce the image size by 64M.
