### PR TITLE
refactor(terway): optionalize node controller for centralized IPAM

### DIFF
--- a/cmd/terway-controlplane/terway-controlplane.go
+++ b/cmd/terway-controlplane/terway-controlplane.go
@@ -65,7 +65,6 @@ import (
 	_ "github.com/AliyunContainerService/terway/pkg/controller/all"
 	multiipnode "github.com/AliyunContainerService/terway/pkg/controller/multi-ip/node"
 	multiippod "github.com/AliyunContainerService/terway/pkg/controller/multi-ip/pod"
-	"github.com/AliyunContainerService/terway/pkg/controller/node"
 	"github.com/AliyunContainerService/terway/pkg/controller/preheating"
 	"github.com/AliyunContainerService/terway/pkg/controller/status"
 	"github.com/AliyunContainerService/terway/pkg/controller/webhook"
@@ -406,7 +405,7 @@ func detectMultiIP(ctx context.Context, directClient client.Client, cfg *control
 
 	cfg.Controllers = lo.Reject(cfg.Controllers, func(item string, index int) bool {
 		switch item {
-		case node.ControllerName, multiipnode.ControllerName, multiippod.ControllerName:
+		case multiipnode.ControllerName, multiippod.ControllerName:
 			return true
 		}
 		return false

--- a/cmd/terway-controlplane/terway-controlplane_test.go
+++ b/cmd/terway-controlplane/terway-controlplane_test.go
@@ -80,7 +80,7 @@ func Test_detectMultiIP(t *testing.T) {
 			wantErr: false,
 			checkFunc: func(t *testing.T, cfg *controlplane.Config) {
 				assert.False(t, lo.Contains(cfg.Controllers, "multi-ip-node"))
-				assert.False(t, lo.Contains(cfg.Controllers, "node"))
+				assert.True(t, lo.Contains(cfg.Controllers, "node"))
 				assert.False(t, lo.Contains(cfg.Controllers, "multi-ip-pod"))
 				assert.True(t, lo.Contains(cfg.Controllers, "foo"))
 			},


### PR DESCRIPTION
- Remove node controller import from terway-controlplane
- Update node controller to support centralized IPAM
- Modify Reconcile method to check for centralized IPAM before executing