### PR TITLE
test(node): implement unit tests for node controller with centralized…

### DIFF
--- a/pkg/controller/node/suite_test.go
+++ b/pkg/controller/node/suite_test.go
@@ -19,6 +19,7 @@ package node
 import (
 	"os"
 	"path/filepath"
+	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -39,6 +40,12 @@ import (
 var cfg *rest.Config
 var k8sClient client.Client
 var testEnv *envtest.Environment
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "Controller Suite")
+}
 
 var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))


### PR DESCRIPTION
… IPAM

- Add unit tests for node controller with centralized IPAM enabled
- Mock ECS and EFLO client responses for testing
- Verify node creation and reconciliation in various scenarios- Update test suite to include new test cases