### PR TITLE
Upgrade golangci/golangci-lint to v2.1.6

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -62,9 +62,9 @@ jobs:
         go-version-file: 'go.mod'
         cache: false
     - name: Run golangci-lint
-      uses: golangci/golangci-lint-action@v6
+      uses: golangci/golangci-lint-action@v8
       with:
-        version: v1.64.5
+        version: v2.1.6
         args: --config=.golangci.yml
 
   super-linter:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,28 +1,40 @@
+version: "2"
 run:
   concurrency: 4
-  timeout: 5m
-  tests: false
   build-tags:
-  - default_build
-  - privileged
-
-issues:
-  exclude-rules:
-  - path: _test\.go
-    linters:
-    - dupl
-    - goconst
+    - default_build
+    - privileged
+  tests: false
 linters:
   enable:
-  - goconst
-  - goimports
-  - govet
-  - errcheck
-  - ineffassign
-  - staticcheck
-  - goconst
-  - stylecheck
-  - misspell
-linters-settings:
-  errcheck:
-    check-blank: false
+    - goconst
+    - misspell
+    - staticcheck
+  settings:
+    errcheck:
+      check-blank: false
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - dupl
+          - goconst
+        path: _test\.go
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ GOLANGCI_LINT = $(LOCALBIN)/golangci-lint-$(GOLANGCI_LINT_VERSION)
 ## Tool Versions
 CONTROLLER_TOOLS_VERSION ?= v0.17.2
 ENVTEST_VERSION ?= latest
-GOLANGCI_LINT_VERSION ?= v1.64.5
+GOLANGCI_LINT_VERSION ?= v2.1.6
 
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.
@@ -142,6 +142,10 @@ $(ENVTEST): $(LOCALBIN)
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
 	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint,${GOLANGCI_LINT_VERSION})
+
+golangci-lint-docker:
+	docker run --rm -v $(shell pwd):/app -w /app golangci/golangci-lint:${GOLANGCI_LINT_VERSION} golangci-lint run -v
+
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary (ideally with version)

--- a/cmd/terway-controlplane/terway-controlplane.go
+++ b/cmd/terway-controlplane/terway-controlplane.go
@@ -164,7 +164,7 @@ func main() {
 	}
 
 	prov := provider.NewChainProvider(
-		provider.NewAccessKeyProvider(string(cfg.Credential.AccessKey), string(cfg.Credential.AccessSecret)),
+		provider.NewAccessKeyProvider(string(cfg.AccessKey), string(cfg.AccessSecret)),
 		provider.NewEncryptedFileProvider(provider.EncryptedFileProviderOptions{
 			FilePath:      cfg.CredentialPath,
 			RefreshPeriod: 30 * time.Minute,

--- a/pkg/controller/eni/eni.go
+++ b/pkg/controller/eni/eni.go
@@ -82,7 +82,7 @@ func (r *ReconcileNetworkInterface) Reconcile(ctx context.Context, request recon
 	err := r.client.Get(ctx, request.NamespacedName, eni)
 	if err != nil {
 		if k8sErr.IsNotFound(err) {
-			r.resourceBackoff.Del(request.NamespacedName.String())
+			r.resourceBackoff.Del(request.String())
 			return reconcile.Result{}, nil
 		}
 		return reconcile.Result{}, err
@@ -207,7 +207,7 @@ func (r *ReconcileNetworkInterface) attach(ctx context.Context, networkInterface
 				return reconcile.Result{}, err
 			}
 
-			if !(len(resp) == 1 && resp[0].Status == aliyunClient.ENIStatusInUse) {
+			if len(resp) != 1 || resp[0].Status != aliyunClient.ENIStatusInUse {
 				// wait next time
 				du, err := r.resourceBackoff.Get(networkInterface.Name, backoff.Backoff(backoff.WaitENIStatus))
 				if err != nil {

--- a/pkg/controller/pod/pod_controller.go
+++ b/pkg/controller/pod/pod_controller.go
@@ -544,11 +544,7 @@ func (m *ReconcilePod) createENI(ctx context.Context, allocs *[]*v1beta1.Allocat
 		g.Go(func() error {
 			alloc := (*allocs)[ii]
 			ctx := common.WithCtx(ctx, alloc)
-
-			deleteENIOnECSRelease := true
-			if alloc.AllocationType.Type == v1beta1.IPAllocTypeFixed {
-				deleteENIOnECSRelease = false
-			}
+			deleteENIOnECSRelease := alloc.AllocationType.Type != v1beta1.IPAllocTypeFixed
 			bo := backoff.Backoff(backoff.ENICreate)
 			option := &aliyunClient.CreateNetworkInterfaceOptions{
 				NetworkInterfaceOptions: &aliyunClient.NetworkInterfaceOptions{


### PR DESCRIPTION
Upgrade golangci/golangci-lint to v2.1.6 and fix several warnings

There are still a few warnings related to QF1003

```
$ make golangci-lint-docker
docker run --rm -v /Users/yili/go/src/github/AliyunContainerService/terway:/app -w /app golangci/golangci-lint:v2.1.6 golangci-lint run -v
level=info msg="golangci-lint has version 2.1.6 built with go1.24.2 from eabc2638 on 2025-05-04T15:41:19Z"
level=info msg="[config_reader] Config search paths: [./ /app / /root]"
level=info msg="[config_reader] Used config file .golangci.yml"
level=info msg="[config_reader] Module name \"github.com/AliyunContainerService/terway\""
level=info msg="[goenv] Read go env for 1.772546ms: map[string]string{\"GOCACHE\":\"/root/.cache/go-build\", \"GOROOT\":\"/usr/local/go\"}"
level=info msg="[lintersdb] Active 8 linters: [errcheck goconst goimports govet ineffassign misspell staticcheck unused]"
level=info msg="[loader] Using build tags: [default_build privileged]"
level=info msg="[loader] Go packages loading at mode 8767 (exports_file|name|types_sizes|compiled_files|deps|files|imports) took 53.296675972s"
level=info msg="[runner/filename_unadjuster] Pre-built 0 adjustments in 48.239965ms"
level=info msg="[linters_context/goanalysis] analyzers took 1m27.010014726s with top 10 stages: buildir: 1m8.96359581s, goimports: 4.28220326s, nilness: 1.878477217s, inspect: 1.277113217s, fact_deprecated: 1.092271467s, goconst: 1.04771448s, fact_purity: 914.245601ms, printf: 872.231804ms, ctrlflow: 855.660426ms, typedness: 592.350175ms"
level=info msg="[runner/exclusion_paths] Skipped 0 issues by pattern \"examples$\""
level=info msg="[runner/exclusion_paths] Skipped 0 issues by pattern \"third_party$\""
level=info msg="[runner/exclusion_paths] Skipped 0 issues by pattern \"builtin$\""
level=info msg="[runner/exclusion_rules] Skipped 0 issues by rules: [Path: \"_test\\\\.go\", Linters: \"dupl, goconst\"]"
level=info msg="[runner/exclusion_rules] Skipped 0 issues by rules: [Path: \"third_party$\", Linters: \"goimports\"]"
level=info msg="[runner/exclusion_rules] Skipped 0 issues by rules: [Path: \"builtin$\", Linters: \"goimports\"]"
level=info msg="[runner/exclusion_rules] Skipped 0 issues by rules: [Path: \"examples$\", Linters: \"goimports\"]"
level=info msg="[runner] Issues before processing: 65, after processing: 2"
level=info msg="[runner] Processors filtering stat (in/out): uniq_by_line: 2/2, path_prettifier: 2/2, sort_results: 2/2, cgo: 65/65, invalid_issue: 65/65, path_relativity: 65/65, max_per_file_from_linter: 2/2, max_same_issues: 2/2, source_code: 2/2, severity-rules: 2/2, filename_unadjuster: 65/65, diff: 2/2, max_from_linter: 2/2, path_shortener: 2/2, generated_file_filter: 65/19, exclusion_rules: 19/4, nolint_filter: 4/2, fixer: 2/2, path_absoluter: 65/65, exclusion_paths: 65/65"
level=info msg="[runner] processing took 19.448985ms with stages: generated_file_filter: 15.060107ms, nolint_filter: 3.371274ms, source_code: 787.319µs, exclusion_rules: 108.457µs, exclusion_paths: 71.79µs, cgo: 14.499µs, path_relativity: 12.667µs, invalid_issue: 5.124µs, path_absoluter: 4.209µs, max_same_issues: 3µs, sort_results: 2.833µs, uniq_by_line: 2.417µs, path_shortener: 1.541µs, filename_unadjuster: 1.5µs, fixer: 875ns, max_from_linter: 458ns, max_per_file_from_linter: 292ns, path_prettifier: 291ns, diff: 208ns, severity-rules: 124ns"
level=info msg="[runner] linters took 27.829221987s with stages: goanalysis_metalinter: 27.809673335s"
level=info msg="File cache stats: 2 entries of total size 16.9KiB"
daemon/builder.go:327:3: QF1003: could use tagged switch on b.daemonMode (staticcheck)
		if b.daemonMode == daemon.ModeENIMultiIP {
		^
examples/maxpods/maxpods.go:63:2: QF1003: could use tagged switch on mode (staticcheck)
	if mode == "terway-eniip" {
	^
2 issues:
* staticcheck: 2
level=info msg="Memory: 790 samples, avg is 462.2MB, max is 2237.6MB"
level=info msg="Execution took 1m21.176888952s"
make: *** [golangci-lint-docker] Error 1
```