### PR TITLE
refactor(terway-cli): kube-proxy replacement

### DIFF
--- a/cmd/terway-cli/node.go
+++ b/cmd/terway-cli/node.go
@@ -39,7 +39,6 @@ const eniOnlyCNI = `{
 
 const cniFilePath = "/etc/cni/net.d/10-terway.conflist"
 const nodeCapabilitiesFile = "/var/run/eni/node_capabilities"
-const kubeProxyCapabilitiesFile = "/var/run/kube-proxy/node_capabilities"
 
 type Task struct {
 	Name string
@@ -204,18 +203,7 @@ func enableKPR(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	kubeProxy := nodecap.NewFileNodeCapabilities(kubeProxyCapabilitiesFile)
-	err = kubeProxy.Load()
-	if err != nil {
-		return err
-	}
-
-	// depends on kube-proxy
-	if kubeProxy.Get(nodecap.NodeCapabilityKubeProxyReplacement) == True {
-		store.Set(nodecap.NodeCapabilityKubeProxyReplacement, True)
-	} else {
-		store.Set(nodecap.NodeCapabilityKubeProxyReplacement, False)
-	}
+	store.Set(nodecap.NodeCapabilityKubeProxyReplacement, True)
 
 	return store.Save()
 }

--- a/cmd/terway-cli/policy.go
+++ b/cmd/terway-cli/policy.go
@@ -225,6 +225,8 @@ func runCilium(cfg *PolicyConfig) error {
 
 		if cfg.EnableKPR {
 			args = append(args, "--kube-proxy-replacement=true")
+			args = append(args, "--bpf-lb-sock=true")
+			args = append(args, "--bpf-lb-sock-hostns-only=true")
 			args = append(args, "--enable-node-port=true")
 			args = append(args, "--enable-host-port=true")
 			args = append(args, "--enable-external-ips=true")

--- a/hack/init.sh
+++ b/hack/init.sh
@@ -46,6 +46,13 @@ cat $node_capabilities
 sysctl -w net.ipv4.conf.eth0.rp_filter=0
 modprobe sch_htb || true
 
+if grep -qE '\bkube_proxy_replacement\s*=\s*true\b' "$node_capabilities"; then
+  mkdir -p 0755 /host/var/run/cilium/cgroupv2
+  cp -f /bin/cilium-mount /host/opt/cni/bin/cilium-mount
+  nsenter --cgroup=/host/proc/1/ns/cgroup --mount=/host/proc/1/ns/mnt /opt/cni/bin/cilium-mount /var/run/cilium/cgroupv2;
+  rm -f /host/opt/cni/bin/cilium-mount
+fi
+
 set +o errexit
 
 chroot /host systemctl disable eni.service


### PR DESCRIPTION
- Simplify node capabilities handling by removing kube-proxy dependency check