### PR TITLE
feat(backoff): add initial delay support for backoff operations

### DIFF
--- a/pkg/backoff/backoff.go
+++ b/pkg/backoff/backoff.go
@@ -1,6 +1,7 @@
 package backoff
 
 import (
+	"context"
 	"time"
 
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -8,112 +9,210 @@ import (
 
 // backoff keys
 const (
-	DefaultKey            = ""
-	ENICreate             = "eni_create"
-	ENIOps                = "eni_ops"
-	ENIRelease            = "eni_release"
-	ENIIPOps              = "eni_ip_ops"
-	WaitENIStatus         = "wait_eni_status"
-	WaitLENIStatus        = "wait_leni_status"
-	WaitHDENIStatus       = "wait_hdeni_status"
-	WaitPodENIStatus      = "wait_podeni_status"
-	MetaAssignPrivateIP   = "meta_assign_private_ip"
-	MetaUnAssignPrivateIP = "meta_unassign_private_ip"
-	WaitStsTokenReady     = "wait_sts_token_ready"
-	WaitNodeStatus        = "wait_node_status"
+	DefaultKey                 = ""
+	ENICreate                  = "eni_create"
+	ENIOps                     = "eni_ops"
+	ENIRelease                 = "eni_release"
+	ENIIPOps                   = "eni_ip_ops"
+	WaitENIStatus              = "wait_eni_status"
+	WaitMemberENIStatus        = "wait_member_eni_status"
+	WaitLENIStatus             = "wait_leni_status"
+	WaitHDENIStatus            = "wait_hdeni_status"
+	WaitPodENIStatus           = "wait_podeni_status"
+	WaitNetworkInterfaceStatus = "wait_networkinterface_status"
+	MetaAssignPrivateIP        = "meta_assign_private_ip"
+	MetaUnAssignPrivateIP      = "meta_unassign_private_ip"
+	WaitStsTokenReady          = "wait_sts_token_ready"
+	WaitNodeStatus             = "wait_node_status"
 )
 
-var backoffMap = map[string]wait.Backoff{
-	DefaultKey: {
-		Duration: time.Second * 2,
-		Factor:   1.5,
-		Jitter:   0.3,
-		Steps:    6,
-	},
-	ENICreate: {
-		Duration: time.Second * 10,
-		Factor:   2,
-		Jitter:   0.3,
-		Steps:    2,
-	},
-	ENIOps: {
-		Duration: time.Second * 5,
-		Factor:   2,
-		Jitter:   0.3,
-		Steps:    6,
-	},
-	ENIRelease: {
-		Duration: time.Second * 4,
-		Factor:   2,
-		Jitter:   0.5,
-		Steps:    8,
-	},
-	ENIIPOps: {
-		Duration: time.Second * 5,
-		Factor:   1,
-		Jitter:   1.3,
-		Steps:    6,
-	},
-	WaitENIStatus: {
-		Duration: time.Second * 3,
-		Factor:   1.5,
-		Jitter:   0.5,
-		Steps:    8,
-	},
-	WaitLENIStatus: {
-		Duration: time.Second * 5,
-		Factor:   1.5,
-		Jitter:   0.5,
-		Steps:    8,
-	},
-	WaitHDENIStatus: {
-		Duration: time.Second * 5,
-		Factor:   1.5,
-		Jitter:   0.5,
-		Steps:    8,
-	},
-	WaitPodENIStatus: {
-		Duration: time.Second * 5,
-		Factor:   1,
-		Jitter:   0.3,
-		Steps:    20,
-	},
-	MetaAssignPrivateIP: {
-		Duration: time.Millisecond * 1100,
-		Factor:   1,
-		Jitter:   0.2,
-		Steps:    10,
-	},
-	MetaUnAssignPrivateIP: {
-		Duration: time.Millisecond * 1100,
-		Factor:   1,
-		Jitter:   0.2,
-		Steps:    10,
-	},
-	WaitStsTokenReady: {
-		Duration: time.Second,
-		Factor:   1,
-		Jitter:   0.2,
-		Steps:    60,
-	},
-	WaitNodeStatus: {
-		Duration: time.Second * 1,
-		Factor:   1,
-		Jitter:   0.3,
-		Steps:    90,
-	},
+// ExtendedBackoff extends the backoff configuration with initial delay support
+type ExtendedBackoff struct {
+	// InitialDelay is the initial wait time before starting retries
+	InitialDelay time.Duration
+	// Backoff is the original k8s backoff configuration
+	wait.Backoff
 }
 
-func OverrideBackoff(in map[string]wait.Backoff) {
-	for k, v := range in {
-		backoffMap[k] = v
+// NewExtendedBackoff creates a new extended backoff configuration
+func NewExtendedBackoff(initialDelay time.Duration, backoff wait.Backoff) ExtendedBackoff {
+	return ExtendedBackoff{
+		InitialDelay: initialDelay,
+		Backoff:      backoff,
 	}
 }
 
-func Backoff(key string) wait.Backoff {
+var backoffMap = map[string]ExtendedBackoff{
+	DefaultKey: {
+		InitialDelay: 0,
+		Backoff: wait.Backoff{
+			Duration: time.Second * 2,
+			Factor:   1.5,
+			Jitter:   0.3,
+			Steps:    6,
+		},
+	},
+	ENICreate: {
+		InitialDelay: 0,
+		Backoff: wait.Backoff{
+			Duration: time.Second * 10,
+			Factor:   2,
+			Jitter:   0.3,
+			Steps:    2,
+		},
+	},
+	ENIOps: {
+		InitialDelay: 0,
+		Backoff: wait.Backoff{
+			Duration: time.Second * 5,
+			Factor:   2,
+			Jitter:   0.3,
+			Steps:    6,
+		},
+	},
+	ENIRelease: {
+		InitialDelay: 0,
+		Backoff: wait.Backoff{
+			Duration: time.Second * 4,
+			Factor:   2,
+			Jitter:   0.5,
+			Steps:    8},
+	},
+	ENIIPOps: {
+		InitialDelay: 0,
+		Backoff: wait.Backoff{
+			Duration: time.Second * 5,
+			Factor:   1,
+			Jitter:   1.3,
+			Steps:    6,
+		},
+	},
+	WaitENIStatus: {
+		InitialDelay: 3 * time.Second,
+		Backoff: wait.Backoff{
+			Duration: time.Second * 3,
+			Factor:   1.5,
+			Jitter:   0.5,
+			Steps:    8,
+		},
+	},
+	WaitMemberENIStatus: {
+		InitialDelay: 2 * time.Second,
+		Backoff: wait.Backoff{
+			Duration: time.Second * 1,
+			Factor:   1.5,
+			Jitter:   0.5,
+			Steps:    8,
+		},
+	},
+	WaitLENIStatus: {
+		InitialDelay: 18 * time.Second,
+		Backoff: wait.Backoff{
+			Duration: time.Second * 5,
+			Factor:   1.5,
+			Jitter:   0.5,
+			Steps:    8,
+		},
+	},
+	WaitHDENIStatus: {
+		InitialDelay: 18 * time.Second,
+		Backoff: wait.Backoff{
+			Duration: time.Second * 5,
+			Factor:   1.5,
+			Jitter:   0.5,
+			Steps:    8,
+		},
+	},
+	WaitPodENIStatus: {
+		InitialDelay: 2 * time.Second,
+		Backoff: wait.Backoff{
+			Duration: time.Second * 1,
+			Factor:   1,
+			Jitter:   0.3,
+			Steps:    100,
+		},
+	},
+	WaitNetworkInterfaceStatus: {
+		InitialDelay: 2 * time.Second,
+		Backoff: wait.Backoff{
+			Duration: time.Second * 1,
+			Factor:   1,
+			Jitter:   0.3,
+			Steps:    120,
+		},
+	},
+	MetaAssignPrivateIP: {
+		InitialDelay: 0,
+		Backoff: wait.Backoff{
+			Duration: time.Millisecond * 1100,
+			Factor:   1,
+			Jitter:   0.2,
+			Steps:    10,
+		},
+	},
+	MetaUnAssignPrivateIP: {
+		InitialDelay: 0,
+		Backoff: wait.Backoff{
+			Duration: time.Millisecond * 1100,
+			Factor:   1,
+			Jitter:   0.2,
+			Steps:    10,
+		},
+	},
+	WaitStsTokenReady: {
+		InitialDelay: 0,
+		Backoff: wait.Backoff{
+			Duration: time.Second,
+			Factor:   1,
+			Jitter:   0.2,
+			Steps:    60,
+		},
+	},
+	WaitNodeStatus: {
+		InitialDelay: 0,
+		Backoff: wait.Backoff{
+			Duration: time.Second * 1,
+			Factor:   1,
+			Jitter:   0.3,
+			Steps:    90,
+		},
+	},
+}
+
+func OverrideBackoff(in map[string]ExtendedBackoff) {
+	for k, v := range in {
+		// set default for InitialDelay
+		if v.InitialDelay != 0 {
+			backoffMap[k] = v
+		} else {
+			if prev, ok := backoffMap[k]; ok {
+				v.InitialDelay = prev.InitialDelay
+			}
+			backoffMap[k] = v
+		}
+	}
+}
+
+func Backoff(key string) ExtendedBackoff {
 	b, ok := backoffMap[key]
 	if !ok {
 		return backoffMap[DefaultKey]
 	}
 	return b
+}
+
+// ExponentialBackoffWithInitialDelay extends ExponentialBackoffWithContext with initial delay support
+func ExponentialBackoffWithInitialDelay(ctx context.Context, extendedBackoff ExtendedBackoff, condition func(context.Context) (bool, error)) error {
+	// If there's an initial delay, wait first
+	if extendedBackoff.InitialDelay > 0 {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(extendedBackoff.InitialDelay):
+			// Initial delay completed, continue execution
+		}
+	}
+
+	// Use the original ExponentialBackoffWithContext
+	return wait.ExponentialBackoffWithContext(ctx, extendedBackoff.Backoff, condition)
 }

--- a/pkg/backoff/backoff_test.go
+++ b/pkg/backoff/backoff_test.go
@@ -1,10 +1,13 @@
 package backoff
 
 import (
+	"context"
+	"encoding/json"
 	"reflect"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
@@ -13,26 +16,32 @@ func TestBackoff(t *testing.T) {
 	tests := []struct {
 		name     string
 		key      string
-		expected wait.Backoff
+		expected ExtendedBackoff
 	}{
 		{
 			name: "Existing Key",
 			key:  ENICreate,
-			expected: wait.Backoff{
-				Duration: time.Second * 10,
-				Factor:   2,
-				Jitter:   0.3,
-				Steps:    2,
+			expected: ExtendedBackoff{
+				InitialDelay: 0,
+				Backoff: wait.Backoff{
+					Duration: time.Second * 10,
+					Factor:   2,
+					Jitter:   0.3,
+					Steps:    2,
+				},
 			},
 		},
 		{
 			name: "Non-existing Key",
 			key:  "non_existing_key",
-			expected: wait.Backoff{
-				Duration: time.Second * 2,
-				Factor:   1.5,
-				Jitter:   0.3,
-				Steps:    6,
+			expected: ExtendedBackoff{
+				InitialDelay: 0,
+				Backoff: wait.Backoff{
+					Duration: time.Second * 2,
+					Factor:   1.5,
+					Jitter:   0.3,
+					Steps:    6,
+				},
 			},
 		},
 	}
@@ -42,6 +51,182 @@ func TestBackoff(t *testing.T) {
 			result := Backoff(tt.key)
 			if !reflect.DeepEqual(result, tt.expected) {
 				t.Errorf("Test %s failed, expected %v, got %v", tt.name, tt.expected, result)
+			}
+		})
+	}
+}
+
+// TestExponentialBackoffWithInitialDelay tests the ExponentialBackoffWithInitialDelay function
+func TestExponentialBackoffWithInitialDelay(t *testing.T) {
+	ctx := context.Background()
+
+	// Test with initial delay
+	initialDelay := time.Millisecond * 100
+	extendedBackoff := NewExtendedBackoff(initialDelay, wait.Backoff{
+		Duration: time.Millisecond * 50,
+		Factor:   1.0,
+		Jitter:   0.0,
+		Steps:    2,
+	})
+
+	startTime := time.Now()
+	called := false
+
+	err := ExponentialBackoffWithInitialDelay(ctx, extendedBackoff, func(ctx context.Context) (bool, error) {
+		called = true
+		return true, nil
+	})
+
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+
+	if !called {
+		t.Error("Expected condition function to be called")
+	}
+
+	// Check that initial delay was respected
+	elapsed := time.Since(startTime)
+	if elapsed < initialDelay {
+		t.Errorf("Expected at least %v elapsed time, got %v", initialDelay, elapsed)
+	}
+}
+
+// TestExponentialBackoffWithInitialDelayFromKey tests the ExponentialBackoffWithInitialDelayFromKey function
+
+// TestExponentialBackoffWithInitialDelayContextCancellation tests context cancellation
+func TestExponentialBackoffWithInitialDelayContextCancellation(t *testing.T) {
+	initialDelay := time.Second * 10
+	extendedBackoff := NewExtendedBackoff(initialDelay, wait.Backoff{
+		Duration: time.Millisecond * 50,
+		Factor:   1.0,
+		Jitter:   0.0,
+		Steps:    2,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Cancel context immediately
+	cancel()
+
+	startTime := time.Now()
+	err := ExponentialBackoffWithInitialDelay(ctx, extendedBackoff, func(ctx context.Context) (bool, error) {
+		return true, nil
+	})
+
+	if err != context.Canceled {
+		t.Errorf("Expected context.Canceled error, got %v", err)
+	}
+
+	// Check that function returned quickly due to context cancellation
+	elapsed := time.Since(startTime)
+	if elapsed > time.Millisecond*100 {
+		t.Errorf("Expected quick return due to context cancellation, but took %v", elapsed)
+	}
+}
+
+// TestExponentialBackoffWithInitialDelayZeroDelay tests with zero initial delay
+func TestExponentialBackoffWithInitialDelayZeroDelay(t *testing.T) {
+	ctx := context.Background()
+
+	// Test with zero initial delay
+	extendedBackoff := NewExtendedBackoff(0, wait.Backoff{
+		Duration: time.Millisecond * 50,
+		Factor:   1.0,
+		Jitter:   0.0,
+		Steps:    2,
+	})
+
+	startTime := time.Now()
+	called := false
+
+	err := ExponentialBackoffWithInitialDelay(ctx, extendedBackoff, func(ctx context.Context) (bool, error) {
+		called = true
+		return true, nil
+	})
+
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+
+	if !called {
+		t.Error("Expected condition function to be called")
+	}
+
+	// Check that no initial delay was applied
+	elapsed := time.Since(startTime)
+	if elapsed > time.Millisecond*100 {
+		t.Errorf("Expected no initial delay, but took %v", elapsed)
+	}
+}
+
+func TestConfig(t *testing.T) {
+	type Config struct {
+		BackoffOverride map[string]ExtendedBackoff `json:"backoffOverride,omitempty"`
+	}
+
+	data := `
+{
+	"backoffOverride": {
+		"wait_node_status": {
+			"Duration": 1000000000,
+			"Factor": 1.1,
+			"Jitter": 1.2,
+			"Steps": 10
+		}
+	}
+}
+`
+	cfg := &Config{}
+	err := json.Unmarshal([]byte(data), cfg)
+	assert.NoError(t, err)
+
+	assert.Equal(t, time.Duration(1000000000), cfg.BackoffOverride["wait_node_status"].Backoff.Duration)
+	assert.Equal(t, 1.1, cfg.BackoffOverride["wait_node_status"].Backoff.Factor)
+}
+
+func TestOverrideBackoff(t *testing.T) {
+	backoffMap = make(map[string]ExtendedBackoff)
+
+	tests := []struct {
+		name     string
+		input    map[string]ExtendedBackoff
+		expected map[string]ExtendedBackoff
+	}{
+		{
+			name: "Normal input",
+			input: map[string]ExtendedBackoff{
+				"key1": {InitialDelay: 10},
+				"key2": {InitialDelay: 0},
+			},
+			expected: map[string]ExtendedBackoff{
+				"key1": {InitialDelay: 10},
+				"key2": {InitialDelay: 0},
+			},
+		},
+		{
+			name:     "Empty input",
+			input:    map[string]ExtendedBackoff{},
+			expected: map[string]ExtendedBackoff{},
+		},
+		{
+			name: "Uninitialized backoffMap",
+			input: map[string]ExtendedBackoff{
+				"key1": {InitialDelay: 5},
+			},
+			expected: map[string]ExtendedBackoff{
+				"key1": {InitialDelay: 5},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			OverrideBackoff(tt.input)
+			for k, v := range tt.expected {
+				if backoffMap[k].InitialDelay != v.InitialDelay {
+					t.Errorf("Test %s failed: expected %v, got %v", tt.name, v, backoffMap[k])
+				}
 			}
 		})
 	}

--- a/pkg/controller/common/eni_test.go
+++ b/pkg/controller/common/eni_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	networkv1beta1 "github.com/AliyunContainerService/terway/pkg/apis/network.alibabacloud.com/v1beta1"
+	"github.com/AliyunContainerService/terway/pkg/backoff"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	k8sErr "k8s.io/apimachinery/pkg/api/errors"
@@ -209,10 +210,12 @@ var _ = Describe("Common ENI Operations", func() {
 			result, err := WaitStatus(ctx, k8sClient, &DescribeOption{
 				NetworkInterfaceID: "eni-wait",
 				ExpectPhase:        ptr.To(networkv1beta1.Phase(networkv1beta1.ENIPhaseBind)),
-				BackOff: wait.Backoff{
-					Duration: 100 * time.Millisecond,
-					Factor:   1.0,
-					Steps:    5,
+				BackOff: backoff.ExtendedBackoff{
+					Backoff: wait.Backoff{
+						Duration: 100 * time.Millisecond,
+						Factor:   1.0,
+						Steps:    5,
+					},
 				},
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -223,10 +226,12 @@ var _ = Describe("Common ENI Operations", func() {
 			_, err := WaitStatus(ctx, k8sClient, &DescribeOption{
 				NetworkInterfaceID: "nonexistent-eni",
 				IgnoreNotExist:     false,
-				BackOff: wait.Backoff{
-					Duration: 100 * time.Millisecond,
-					Factor:   1.0,
-					Steps:    1,
+				BackOff: backoff.ExtendedBackoff{
+					Backoff: wait.Backoff{
+						Duration: 100 * time.Millisecond,
+						Factor:   1.0,
+						Steps:    1,
+					},
 				},
 			})
 			Expect(err).To(HaveOccurred())
@@ -237,10 +242,12 @@ var _ = Describe("Common ENI Operations", func() {
 			result, err := WaitStatus(ctx, k8sClient, &DescribeOption{
 				NetworkInterfaceID: "nonexistent-eni",
 				IgnoreNotExist:     true,
-				BackOff: wait.Backoff{
-					Duration: 100 * time.Millisecond,
-					Factor:   1.0,
-					Steps:    1,
+				BackOff: backoff.ExtendedBackoff{
+					Backoff: wait.Backoff{
+						Duration: 100 * time.Millisecond,
+						Factor:   1.0,
+						Steps:    1,
+					},
 				},
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -261,10 +268,12 @@ var _ = Describe("Common ENI Operations", func() {
 			_, err = WaitStatus(ctx, k8sClient, &DescribeOption{
 				NetworkInterfaceID: "eni-mismatch",
 				ExpectPhase:        ptr.To(networkv1beta1.Phase(networkv1beta1.ENIPhaseBind)),
-				BackOff: wait.Backoff{
-					Duration: 100 * time.Millisecond,
-					Factor:   1.0,
-					Steps:    1,
+				BackOff: backoff.ExtendedBackoff{
+					Backoff: wait.Backoff{
+						Duration: 100 * time.Millisecond,
+						Factor:   1.0,
+						Steps:    1,
+					},
 				},
 			})
 			Expect(err).To(HaveOccurred())
@@ -285,10 +294,12 @@ var _ = Describe("Common ENI Operations", func() {
 			_, err = WaitStatus(ctx, k8sClient, &DescribeOption{
 				NetworkInterfaceID: "eni-timeout",
 				ExpectPhase:        ptr.To(networkv1beta1.Phase(networkv1beta1.ENIPhaseBind)),
-				BackOff: wait.Backoff{
-					Duration: 100 * time.Millisecond,
-					Factor:   1.0,
-					Steps:    2,
+				BackOff: backoff.ExtendedBackoff{
+					Backoff: wait.Backoff{
+						Duration: 100 * time.Millisecond,
+						Factor:   1.0,
+						Steps:    2,
+					},
 				},
 			})
 			Expect(err).To(HaveOccurred())

--- a/pkg/controller/eni/eni.go
+++ b/pkg/controller/eni/eni.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
-	"github.com/AliyunContainerService/terway/pkg/controller/common"
 	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -28,6 +28,7 @@ import (
 	"github.com/AliyunContainerService/terway/pkg/apis/network.alibabacloud.com/v1beta1"
 	"github.com/AliyunContainerService/terway/pkg/backoff"
 	register "github.com/AliyunContainerService/terway/pkg/controller"
+	"github.com/AliyunContainerService/terway/pkg/controller/common"
 	"github.com/AliyunContainerService/terway/types"
 	"github.com/AliyunContainerService/terway/types/controlplane"
 )
@@ -173,7 +174,7 @@ func (r *ReconcileNetworkInterface) attach(ctx context.Context, networkInterface
 				}
 				fallthrough
 			case aliyunClient.LENIStatusExecuting, aliyunClient.LENIStatusAttaching, aliyunClient.LENIStatusDetaching:
-				du, err := r.resourceBackoff.Get(networkInterface.Name, backoff.Backoff(backoff.WaitLENIStatus))
+				du, err := r.resourceBackoff.Get(networkInterface.Name, backoff.Backoff(backoff.WaitLENIStatus).Backoff)
 				if err != nil {
 					return reconcile.Result{}, err
 				}
@@ -199,6 +200,12 @@ func (r *ReconcileNetworkInterface) attach(ctx context.Context, networkInterface
 				return reconcile.Result{}, err
 			}
 
+			if networkInterface.Status.TrunkENIID == "" {
+				time.Sleep(backoff.Backoff(backoff.WaitENIStatus).InitialDelay)
+			} else {
+				time.Sleep(backoff.Backoff(backoff.WaitMemberENIStatus).InitialDelay)
+			}
+
 			resp, err = r.aliyun.DescribeNetworkInterfaceV2(ctx, &aliyunClient.DescribeNetworkInterfaceOptions{
 				NetworkInterfaceIDs: &[]string{networkInterface.Name},
 				RawStatus:           ptr.To(true),
@@ -209,7 +216,7 @@ func (r *ReconcileNetworkInterface) attach(ctx context.Context, networkInterface
 
 			if len(resp) != 1 || resp[0].Status != aliyunClient.ENIStatusInUse {
 				// wait next time
-				du, err := r.resourceBackoff.Get(networkInterface.Name, backoff.Backoff(backoff.WaitENIStatus))
+				du, err := r.resourceBackoff.Get(networkInterface.Name, backoff.Backoff(backoff.WaitENIStatus).Backoff)
 				if err != nil {
 					return reconcile.Result{}, err
 				}
@@ -316,7 +323,7 @@ func (r *ReconcileNetworkInterface) detach(ctx context.Context, networkInterface
 					}
 					fallthrough
 				case aliyunClient.LENIStatusExecuting, aliyunClient.LENIStatusDetaching:
-					du, err := r.resourceBackoff.Get(networkInterface.Name, backoff.Backoff(backoff.WaitLENIStatus))
+					du, err := r.resourceBackoff.Get(networkInterface.Name, backoff.Backoff(backoff.WaitLENIStatus).Backoff)
 					if err != nil {
 						return reconcile.Result{}, err
 					}
@@ -338,6 +345,12 @@ func (r *ReconcileNetworkInterface) detach(ctx context.Context, networkInterface
 				return reconcile.Result{}, err
 			}
 
+			if networkInterface.Status.TrunkENIID == "" {
+				time.Sleep(backoff.Backoff(backoff.WaitENIStatus).InitialDelay)
+			} else {
+				time.Sleep(backoff.Backoff(backoff.WaitMemberENIStatus).InitialDelay)
+			}
+
 			enis, err := r.aliyun.DescribeNetworkInterfaceV2(ctx, &aliyunClient.DescribeNetworkInterfaceOptions{
 				NetworkInterfaceIDs: &[]string{networkInterface.Name},
 				RawStatus:           ptr.To(true),
@@ -348,7 +361,7 @@ func (r *ReconcileNetworkInterface) detach(ctx context.Context, networkInterface
 
 			if len(enis) > 0 && enis[0].Status != aliyunClient.ENIStatusAvailable {
 				// wait next time
-				du, err := r.resourceBackoff.Get(networkInterface.Name, backoff.Backoff(backoff.WaitENIStatus))
+				du, err := r.resourceBackoff.Get(networkInterface.Name, backoff.Backoff(backoff.WaitENIStatus).Backoff)
 				if err != nil {
 					return reconcile.Result{}, err
 				}

--- a/pkg/controller/eni/eni_test.go
+++ b/pkg/controller/eni/eni_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"time"
 
-	aliyunClient "github.com/AliyunContainerService/terway/pkg/aliyun/client"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/mock"
@@ -17,8 +16,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	networkv1beta1 "github.com/AliyunContainerService/terway/pkg/apis/network.alibabacloud.com/v1beta1"
+	aliyunClient "github.com/AliyunContainerService/terway/pkg/aliyun/client"
 	"github.com/AliyunContainerService/terway/pkg/aliyun/client/mocks"
+	networkv1beta1 "github.com/AliyunContainerService/terway/pkg/apis/network.alibabacloud.com/v1beta1"
 )
 
 var _ = Describe("Eni controller", func() {

--- a/pkg/controller/multi-ip/node/pool.go
+++ b/pkg/controller/multi-ip/node/pool.go
@@ -1099,7 +1099,7 @@ func (n *ReconcileNode) handleStatus(ctx context.Context, node *networkv1beta1.N
 					log.Error(err, "run gc failed")
 					continue
 				}
-				_, err = n.aliyun.WaitForNetworkInterfaceV2(ctx, eni.ID, aliyunClient.ENIStatusAvailable, backoff.Backoff(backoff.WaitENIStatus), true)
+				_, err = n.aliyun.WaitForNetworkInterfaceV2(ctx, eni.ID, aliyunClient.ENIStatusAvailable, backoff.Backoff(backoff.WaitENIStatus).Backoff, true)
 				if err != nil {
 					if !errors.Is(err, apiErr.ErrNotFound) {
 						log.Error(err, "run gc failed")
@@ -1284,7 +1284,7 @@ func (n *ReconcileNode) createENI(ctx context.Context, node *networkv1beta1.Node
 			InstanceID:       node.Spec.NodeMetadata.InstanceID,
 		},
 
-		Backoff: &bo,
+		Backoff: &bo.Backoff,
 	}
 
 	result, err := n.aliyun.CreateNetworkInterfaceV2(ctx, typeOption, createOpts)
@@ -1345,7 +1345,7 @@ func (n *ReconcileNode) createENI(ctx context.Context, node *networkv1beta1.Node
 		time.Sleep(3 * time.Second)
 	}
 
-	eni, err := n.aliyun.WaitForNetworkInterfaceV2(ctx, result.NetworkInterfaceID, aliyunClient.ENIStatusInUse, backoff.Backoff(backoff.WaitENIStatus), false)
+	eni, err := n.aliyun.WaitForNetworkInterfaceV2(ctx, result.NetworkInterfaceID, aliyunClient.ENIStatusInUse, backoff.Backoff(backoff.WaitENIStatus).Backoff, false)
 	if err != nil {
 		return err
 	}
@@ -1382,7 +1382,7 @@ func (n *ReconcileNode) assignIP(ctx context.Context, opt *eniOptions) error {
 				NetworkInterfaceID: opt.eniRef.ID,
 				IPCount:            opt.addIPv4N,
 			},
-			Backoff: &bo,
+			Backoff: &bo.Backoff,
 		})
 
 		if err != nil {
@@ -1430,7 +1430,7 @@ func (n *ReconcileNode) assignIP(ctx context.Context, opt *eniOptions) error {
 				NetworkInterfaceID: opt.eniRef.ID,
 				IPv6Count:          opt.addIPv6N,
 			},
-			Backoff: &bo,
+			Backoff: &bo.Backoff,
 		})
 		if err != nil {
 			if apiErr.ErrorCodeIs(err, apiErr.InvalidVSwitchIDIPNotEnough, apiErr.QuotaExceededPrivateIPAddress) {

--- a/pkg/controller/multi-ip/node/pool_test.go
+++ b/pkg/controller/multi-ip/node/pool_test.go
@@ -1999,7 +1999,7 @@ var _ = Describe("Test ReconcileNode", func() {
 					NetworkInterfaceID: "eni-1",
 					IPCount:            1,
 				},
-				Backoff: &bo1,
+				Backoff: &bo1.Backoff,
 			}).Return([]aliyunClient.IPSet{
 				{
 					Primary:   false,
@@ -2013,7 +2013,7 @@ var _ = Describe("Test ReconcileNode", func() {
 					NetworkInterfaceID: "eni-2",
 					IPCount:            1,
 				},
-				Backoff: &bo2,
+				Backoff: &bo2.Backoff,
 			}).Return([]aliyunClient.IPSet{
 				{
 					Primary:   false,

--- a/pkg/controller/pod-eni/eni_controller.go
+++ b/pkg/controller/pod-eni/eni_controller.go
@@ -719,7 +719,7 @@ func (m *ReconcilePodENI) attachENI(ctx context.Context, podENI *v1beta1.PodENI,
 			// TODO: watch the eni change
 			eni, err := common.WaitStatus(ctx, m.client, &common.DescribeOption{
 				NetworkInterfaceID: alloc.ENI.ID,
-				BackOff:            backoff.Backoff(backoff.WaitENIStatus),
+				BackOff:            backoff.Backoff(backoff.WaitNetworkInterfaceStatus),
 				ExpectPhase:        (*v1beta1.Phase)(ptr.To(v1beta1.ENIPhaseBind)),
 				IgnoreNotExist:     false,
 			})
@@ -783,7 +783,7 @@ func (m *ReconcilePodENI) detachMemberENI(ctx context.Context, podENI *v1beta1.P
 		}
 
 		_, err = common.WaitStatus(ctx, m.client, &common.DescribeOption{
-			BackOff:            backoff.Backoff(backoff.WaitENIStatus),
+			BackOff:            backoff.Backoff(backoff.WaitNetworkInterfaceStatus),
 			IgnoreNotExist:     true,
 			NetworkInterfaceID: alloc.ENI.ID,
 			ExpectPhase:        ptr.To(v1beta1.Phase(v1beta1.ENIPhaseUnbind)),

--- a/pkg/controller/pod/pod_controller.go
+++ b/pkg/controller/pod/pod_controller.go
@@ -569,7 +569,7 @@ func (m *ReconcilePod) createENI(ctx context.Context, allocs *[]*v1beta1.Allocat
 					VPCID:      vpcID,
 					InstanceID: nodeInfo.InstanceID,
 				},
-				Backoff: &bo,
+				Backoff: &bo.Backoff,
 			}
 			eni, err := m.aliyun.CreateNetworkInterfaceV2(ctx, option)
 			if err != nil {
@@ -595,7 +595,7 @@ func (m *ReconcilePod) createENI(ctx context.Context, allocs *[]*v1beta1.Allocat
 				// delete the eni, as we can not store the eni info
 				rollbackCtx := context.Background()
 
-				innerErr := retry.OnError(backoff.Backoff(backoff.ENIRelease), func(err error) bool {
+				innerErr := retry.OnError(backoff.Backoff(backoff.ENIRelease).Backoff, func(err error) bool {
 					return true
 				}, func() error {
 					innerErr := m.aliyun.DeleteNetworkInterfaceV2(rollbackCtx, eni.NetworkInterfaceID)

--- a/pkg/eni/crdv2.go
+++ b/pkg/eni/crdv2.go
@@ -233,7 +233,7 @@ func (r *CRDV2) multiIP(ctx context.Context, cni *daemon.CNI, request ResourceRe
 		allocResp := &AllocResp{}
 
 		var err error
-		err = wait.ExponentialBackoffWithContext(ctx, backoff.Backoff(backoff.WaitPodENIStatus), func(ctx context.Context) (bool, error) {
+		err = backoff.ExponentialBackoffWithInitialDelay(ctx, backoff.Backoff(backoff.WaitPodENIStatus), func(ctx context.Context) (bool, error) {
 			err = r.client.Get(ctx, client.ObjectKey{Name: r.nodeName}, node)
 			if err != nil {
 				l.Error(err, "get node failed")
@@ -380,7 +380,7 @@ func (r *CRDV2) getTrunkENI(ctx context.Context) (*daemon.ENI, error) {
 	var trunkENI *daemon.ENI
 
 	var innerErr error
-	err := wait.ExponentialBackoffWithContext(ctx, backoff.Backoff(backoff.WaitPodENIStatus), func(ctx context.Context) (bool, error) {
+	err := backoff.ExponentialBackoffWithInitialDelay(ctx, backoff.Backoff(backoff.WaitPodENIStatus), func(ctx context.Context) (bool, error) {
 		node = &networkv1beta1.Node{}
 		innerErr = r.client.Get(ctx, client.ObjectKey{Name: r.nodeName}, node)
 		if innerErr != nil {

--- a/pkg/eni/crdv2_test.go
+++ b/pkg/eni/crdv2_test.go
@@ -20,13 +20,15 @@ import (
 
 func TestGetTrunkENIReturnsErrorWhenNodeNotInitialized(t *testing.T) {
 	backoff.Backoff(backoff.WaitPodENIStatus)
-	backoff.OverrideBackoff(map[string]wait.Backoff{
+	backoff.OverrideBackoff(map[string]backoff.ExtendedBackoff{
 		backoff.WaitPodENIStatus: {
-			Duration: 0,
-			Factor:   0,
-			Jitter:   0,
-			Steps:    1,
-			Cap:      0,
+			Backoff: wait.Backoff{
+				Duration: 0,
+				Factor:   0,
+				Jitter:   0,
+				Steps:    1,
+				Cap:      0,
+			},
 		},
 	})
 
@@ -49,13 +51,15 @@ func TestGetTrunkENIReturnsErrorWhenNodeNotInitialized(t *testing.T) {
 
 func TestGetTrunkENIReturnsErrorWhenTrunkNotEnabled(t *testing.T) {
 	backoff.Backoff(backoff.WaitPodENIStatus)
-	backoff.OverrideBackoff(map[string]wait.Backoff{
+	backoff.OverrideBackoff(map[string]backoff.ExtendedBackoff{
 		backoff.WaitPodENIStatus: {
-			Duration: 0,
-			Factor:   0,
-			Jitter:   0,
-			Steps:    1,
-			Cap:      0,
+			Backoff: wait.Backoff{
+				Duration: 0,
+				Factor:   0,
+				Jitter:   0,
+				Steps:    1,
+				Cap:      0,
+			},
 		},
 	})
 
@@ -77,13 +81,15 @@ func TestGetTrunkENIReturnsErrorWhenTrunkNotEnabled(t *testing.T) {
 
 func TestGetTrunkENIReturnsErrorWhenTrunkIDNotFound(t *testing.T) {
 	backoff.Backoff(backoff.WaitPodENIStatus)
-	backoff.OverrideBackoff(map[string]wait.Backoff{
+	backoff.OverrideBackoff(map[string]backoff.ExtendedBackoff{
 		backoff.WaitPodENIStatus: {
-			Duration: 0,
-			Factor:   0,
-			Jitter:   0,
-			Steps:    1,
-			Cap:      0,
+			Backoff: wait.Backoff{
+				Duration: 0,
+				Factor:   0,
+				Jitter:   0,
+				Steps:    1,
+				Cap:      0,
+			},
 		},
 	})
 
@@ -112,13 +118,15 @@ func TestGetTrunkENIReturnsErrorWhenTrunkIDNotFound(t *testing.T) {
 
 func TestGetTrunkENIReturnsValidENI(t *testing.T) {
 	backoff.Backoff(backoff.WaitPodENIStatus)
-	backoff.OverrideBackoff(map[string]wait.Backoff{
+	backoff.OverrideBackoff(map[string]backoff.ExtendedBackoff{
 		backoff.WaitPodENIStatus: {
-			Duration: 0,
-			Factor:   0,
-			Jitter:   0,
-			Steps:    1,
-			Cap:      0,
+			Backoff: wait.Backoff{
+				Duration: 0,
+				Factor:   0,
+				Jitter:   0,
+				Steps:    1,
+				Cap:      0,
+			},
 		},
 	})
 

--- a/pkg/eni/remote.go
+++ b/pkg/eni/remote.go
@@ -7,7 +7,6 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -134,7 +133,7 @@ func (r *Remote) Allocate(ctx context.Context, cni *daemon.CNI, request Resource
 
 		var podENI *podENITypes.PodENI
 		var err, innerErr error
-		err = wait.ExponentialBackoffWithContext(ctx, backoff.Backoff(backoff.WaitPodENIStatus), func(ctx context.Context) (bool, error) {
+		err = backoff.ExponentialBackoffWithInitialDelay(ctx, backoff.Backoff(backoff.WaitPodENIStatus), func(ctx context.Context) (bool, error) {
 			podENI, innerErr = getPodENI(ctx, r.client, cni.PodNamespace, cni.PodName)
 			if innerErr != nil {
 				innerErr = &types.Error{

--- a/types/controlplane/config_default.go
+++ b/types/controlplane/config_default.go
@@ -19,9 +19,8 @@ limitations under the License.
 package controlplane
 
 import (
+	"github.com/AliyunContainerService/terway/pkg/backoff"
 	"github.com/AliyunContainerService/terway/types/secret"
-
-	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 type Config struct {
@@ -71,9 +70,9 @@ type Config struct {
 
 	CustomStatefulWorkloadKinds []string `json:"customStatefulWorkloadKinds" yaml:"customStatefulWorkloadKinds"`
 
-	BackoffOverride map[string]wait.Backoff `json:"backoffOverride,omitempty" yaml:"backoffOverride,omitempty"`
-	IPAMType        string                  `json:"ipamType" yaml:"ipamType"`
-	CentralizedIPAM bool                    `json:"centralizedIPAM,omitempty" yaml:"centralizedIPAM,omitempty"`
+	BackoffOverride map[string]backoff.ExtendedBackoff `json:"backoffOverride,omitempty" yaml:"backoffOverride,omitempty"`
+	IPAMType        string                             `json:"ipamType" yaml:"ipamType"`
+	CentralizedIPAM bool                               `json:"centralizedIPAM,omitempty" yaml:"centralizedIPAM,omitempty"`
 
 	RateLimit map[string]int `json:"rateLimit" yaml:"rateLimit"`
 

--- a/types/daemon/config.go
+++ b/types/daemon/config.go
@@ -6,16 +6,15 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/AliyunContainerService/terway/pkg/backoff"
 	"github.com/AliyunContainerService/terway/pkg/vswitch"
+	"github.com/AliyunContainerService/terway/types"
+	"github.com/AliyunContainerService/terway/types/route"
 	"github.com/AliyunContainerService/terway/types/secret"
 
 	jsonpatch "github.com/evanphx/json-patch"
 	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/apimachinery/pkg/util/wait"
-
-	"github.com/AliyunContainerService/terway/types"
-	"github.com/AliyunContainerService/terway/types/route"
 )
 
 const (
@@ -28,40 +27,40 @@ var addonSecretRootPath = addonSecretPath
 
 // Config configuration of terway daemon
 type Config struct {
-	Version                     string                  `yaml:"version" json:"version"`
-	AccessID                    secret.Secret           `yaml:"access_key" json:"access_key"`
-	AccessSecret                secret.Secret           `yaml:"access_secret" json:"access_secret"`
-	RegionID                    string                  `yaml:"region_id" json:"region_id"`
-	CredentialPath              string                  `yaml:"credential_path" json:"credential_path"`
-	ServiceCIDR                 string                  `yaml:"service_cidr" json:"service_cidr"`
-	VSwitches                   map[string][]string     `yaml:"vswitches" json:"vswitches"`
-	ENITags                     map[string]string       `yaml:"eni_tags" json:"eni_tags"`
-	MaxPoolSize                 int                     `yaml:"max_pool_size" json:"max_pool_size"`
-	MinPoolSize                 int                     `yaml:"min_pool_size" json:"min_pool_size"`
-	MinENI                      int                     `yaml:"min_eni" json:"min_eni"`
-	MaxENI                      int                     `yaml:"max_eni" json:"max_eni"`
-	Prefix                      string                  `yaml:"prefix" json:"prefix"`
-	SecurityGroup               string                  `yaml:"security_group" json:"security_group"`
-	SecurityGroups              []string                `yaml:"security_groups" json:"security_groups"`
-	EniCapRatio                 float64                 `yaml:"eni_cap_ratio" json:"eni_cap_ratio" mod:"default=1"`
-	EniCapShift                 int                     `yaml:"eni_cap_shift" json:"eni_cap_shift"`
-	VSwitchSelectionPolicy      string                  `yaml:"vswitch_selection_policy" json:"vswitch_selection_policy" mod:"default=random"`
-	EniSelectionPolicy          string                  `yaml:"eni_selection_policy" json:"eni_selection_policy" mod:"default=most_ips"`
-	IPStack                     string                  `yaml:"ip_stack" json:"ip_stack" validate:"oneof=ipv4 ipv6 dual" mod:"default=ipv4"` // default ipv4 , support ipv4 dual
-	EnableENITrunking           bool                    `yaml:"enable_eni_trunking" json:"enable_eni_trunking"`
-	EnableERDMA                 bool                    `yaml:"enable_erdma" json:"enable_erdma"`
-	CustomStatefulWorkloadKinds []string                `yaml:"custom_stateful_workload_kinds" json:"custom_stateful_workload_kinds"`
-	IPAMType                    types.IPAMType          `yaml:"ipam_type" json:"ipam_type"` // crd or default
-	BackoffOverride             map[string]wait.Backoff `json:"backoff_override,omitempty"`
-	ExtraRoutes                 []route.Route           `json:"extra_routes,omitempty"`
-	DisableDevicePlugin         bool                    `json:"disable_device_plugin"`
-	ENITagFilter                map[string]string       `json:"eni_tag_filter"` // if set , only enis match filter, will be managed
-	KubeClientQPS               float32                 `json:"kube_client_qps"`
-	KubeClientBurst             int                     `json:"kube_client_burst"`
-	ResourceGroupID             string                  `json:"resource_group_id"`
-	RateLimit                   map[string]int          `json:"rate_limit"`
-	EnablePatchPodIPs           *bool                   `json:"enable_patch_pod_ips,omitempty"  mod:"default=true"`
-	IPPoolSyncPeriod            string                  `json:"ip_pool_sync_period"`
+	Version                     string                             `yaml:"version" json:"version"`
+	AccessID                    secret.Secret                      `yaml:"access_key" json:"access_key"`
+	AccessSecret                secret.Secret                      `yaml:"access_secret" json:"access_secret"`
+	RegionID                    string                             `yaml:"region_id" json:"region_id"`
+	CredentialPath              string                             `yaml:"credential_path" json:"credential_path"`
+	ServiceCIDR                 string                             `yaml:"service_cidr" json:"service_cidr"`
+	VSwitches                   map[string][]string                `yaml:"vswitches" json:"vswitches"`
+	ENITags                     map[string]string                  `yaml:"eni_tags" json:"eni_tags"`
+	MaxPoolSize                 int                                `yaml:"max_pool_size" json:"max_pool_size"`
+	MinPoolSize                 int                                `yaml:"min_pool_size" json:"min_pool_size"`
+	MinENI                      int                                `yaml:"min_eni" json:"min_eni"`
+	MaxENI                      int                                `yaml:"max_eni" json:"max_eni"`
+	Prefix                      string                             `yaml:"prefix" json:"prefix"`
+	SecurityGroup               string                             `yaml:"security_group" json:"security_group"`
+	SecurityGroups              []string                           `yaml:"security_groups" json:"security_groups"`
+	EniCapRatio                 float64                            `yaml:"eni_cap_ratio" json:"eni_cap_ratio" mod:"default=1"`
+	EniCapShift                 int                                `yaml:"eni_cap_shift" json:"eni_cap_shift"`
+	VSwitchSelectionPolicy      string                             `yaml:"vswitch_selection_policy" json:"vswitch_selection_policy" mod:"default=random"`
+	EniSelectionPolicy          string                             `yaml:"eni_selection_policy" json:"eni_selection_policy" mod:"default=most_ips"`
+	IPStack                     string                             `yaml:"ip_stack" json:"ip_stack" validate:"oneof=ipv4 ipv6 dual" mod:"default=ipv4"` // default ipv4 , support ipv4 dual
+	EnableENITrunking           bool                               `yaml:"enable_eni_trunking" json:"enable_eni_trunking"`
+	EnableERDMA                 bool                               `yaml:"enable_erdma" json:"enable_erdma"`
+	CustomStatefulWorkloadKinds []string                           `yaml:"custom_stateful_workload_kinds" json:"custom_stateful_workload_kinds"`
+	IPAMType                    types.IPAMType                     `yaml:"ipam_type" json:"ipam_type"` // crd or default
+	BackoffOverride             map[string]backoff.ExtendedBackoff `json:"backoff_override,omitempty"`
+	ExtraRoutes                 []route.Route                      `json:"extra_routes,omitempty"`
+	DisableDevicePlugin         bool                               `json:"disable_device_plugin"`
+	ENITagFilter                map[string]string                  `json:"eni_tag_filter"` // if set , only enis match filter, will be managed
+	KubeClientQPS               float32                            `json:"kube_client_qps"`
+	KubeClientBurst             int                                `json:"kube_client_burst"`
+	ResourceGroupID             string                             `json:"resource_group_id"`
+	RateLimit                   map[string]int                     `json:"rate_limit"`
+	EnablePatchPodIPs           *bool                              `json:"enable_patch_pod_ips,omitempty"  mod:"default=true"`
+	IPPoolSyncPeriod            string                             `json:"ip_pool_sync_period"`
 }
 
 func (c *Config) GetSecurityGroups() []string {


### PR DESCRIPTION
- Introduce ExtendedBackoff struct to support initial delay
- Update backoff map to use ExtendedBackoff instead of wait.Backoff
- Modify ExponentialBackoffWithContext to include initial delay
- Update affected packages to use the new ExtendedBackoff structure
- Add tests for the new initial delay functionality