### PR TITLE
test(datapath): add unit test for Vlan data path with MultiNetwork fe…

### DIFF
--- a/pkg/tc/tc_test.go
+++ b/pkg/tc/tc_test.go
@@ -1,0 +1,336 @@
+/*
+Copyright 2022 The Terway Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tc
+
+import (
+	"net"
+	"testing"
+
+	"github.com/vishvananda/netlink"
+)
+
+func TestTrafficShapingRule_Validation(t *testing.T) {
+	tests := []struct {
+		name    string
+		rate    uint64
+		wantErr bool
+	}{
+		{
+			name:    "valid rate",
+			rate:    1000000, // 1MB/s
+			wantErr: false,
+		},
+		{
+			name:    "zero rate",
+			rate:    0,
+			wantErr: true,
+		},
+		{
+			name:    "large rate",
+			rate:    1000000000, // 1GB/s
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rule := &TrafficShapingRule{
+				Rate: tt.rate,
+			}
+
+			// Create a dummy link for testing
+			dummyLink := &netlink.Dummy{
+				LinkAttrs: netlink.LinkAttrs{
+					Name:  "test-dummy",
+					MTU:   1500,
+					Index: 1,
+				},
+			}
+
+			err := SetRule(dummyLink, rule)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SetRule() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestTrafficShapingRule_HelperFunctions(t *testing.T) {
+	// Test burst calculation
+	rate := uint64(1000000) // 1MB/s
+	mtu := 1500
+	expectedBurst := burst(rate, mtu)
+	if expectedBurst <= 0 {
+		t.Errorf("burst() returned invalid value: %d", expectedBurst)
+	}
+
+	// Test buffer calculation
+	expectedBuffer := buffer(rate, expectedBurst)
+	if expectedBuffer <= 0 {
+		t.Errorf("buffer() returned invalid value: %d", expectedBuffer)
+	}
+
+	// Test limit calculation
+	latency := latencyInUsec(latencyInMillis)
+	expectedLimit := limit(rate, latency, expectedBuffer)
+	if expectedLimit <= 0 {
+		t.Errorf("limit() returned invalid value: %d", expectedLimit)
+	}
+
+	// Test time2Tick conversion
+	time := uint32(1000)
+	ticks := time2Tick(time)
+	if ticks <= 0 {
+		t.Errorf("time2Tick() returned invalid value: %d", ticks)
+	}
+
+	// Test latency conversion
+	latencyMs := 25.0
+	latencyUs := latencyInUsec(latencyMs)
+	if latencyUs <= 0 {
+		t.Errorf("latencyInUsec() returned invalid value: %f", latencyUs)
+	}
+}
+
+func TestTrafficShapingRule_Integration(t *testing.T) {
+	// Test integration with a valid rule
+	rule := &TrafficShapingRule{
+		Rate: 500000, // 500KB/s
+	}
+
+	// Create a dummy link for testing
+	dummyLink := &netlink.Dummy{
+		LinkAttrs: netlink.LinkAttrs{
+			Name:  "test-dummy-integration",
+			MTU:   1500,
+			Index: 2,
+		},
+	}
+
+	// Test that SetRule can be called without panicking
+	// Note: This test may fail on systems without proper netlink support
+	// but it should at least not panic
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("SetRule() panicked: %v", r)
+		}
+	}()
+
+	// This call may fail due to lack of netlink permissions or dummy interface
+	// but it should not panic and should handle errors gracefully
+	err := SetRule(dummyLink, rule)
+	if err != nil {
+		// Error is expected in test environment, just log it
+		t.Logf("SetRule() returned expected error in test environment: %v", err)
+	}
+}
+
+func TestMatchSrc(t *testing.T) {
+	tests := []struct {
+		name   string
+		ipNet  *net.IPNet
+		expect int // expected number of keys
+	}{
+		{
+			name: "IPv4 single IP",
+			ipNet: &net.IPNet{
+				IP:   net.ParseIP("192.168.1.1"),
+				Mask: net.CIDRMask(32, 32),
+			},
+			expect: 1,
+		},
+		{
+			name: "IPv4 subnet",
+			ipNet: &net.IPNet{
+				IP:   net.ParseIP("192.168.1.0"),
+				Mask: net.CIDRMask(24, 32),
+			},
+			expect: 1,
+		},
+		{
+			name: "IPv6 single IP",
+			ipNet: &net.IPNet{
+				IP:   net.ParseIP("fd00::1"),
+				Mask: net.CIDRMask(128, 128),
+			},
+			expect: 4,
+		},
+		{
+			name: "IPv6 subnet",
+			ipNet: &net.IPNet{
+				IP:   net.ParseIP("fd00::"),
+				Mask: net.CIDRMask(64, 128),
+			},
+			expect: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u32 := &netlink.U32{}
+
+			// Test MatchSrc function
+			MatchSrc(u32, tt.ipNet)
+
+			// Verify that Sel is created
+			if u32.Sel == nil {
+				t.Errorf("MatchSrc() did not create Sel")
+				return
+			}
+
+			// Verify the number of keys matches expectation
+			if len(u32.Sel.Keys) != tt.expect {
+				t.Errorf("MatchSrc() created %d keys, expected %d", len(u32.Sel.Keys), tt.expect)
+			}
+
+			// Verify Nkeys is set correctly
+			if u32.Sel.Nkeys != uint8(len(u32.Sel.Keys)) {
+				t.Errorf("MatchSrc() Nkeys = %d, expected %d", u32.Sel.Nkeys, len(u32.Sel.Keys))
+			}
+
+			// Verify Flags is set
+			if u32.Sel.Flags == 0 {
+				t.Errorf("MatchSrc() Flags not set")
+			}
+		})
+	}
+}
+
+func TestU32MatchSrc(t *testing.T) {
+	tests := []struct {
+		name   string
+		ipNet  *net.IPNet
+		expect int // expected number of keys
+	}{
+		{
+			name: "IPv4 single IP",
+			ipNet: &net.IPNet{
+				IP:   net.ParseIP("10.0.0.1"),
+				Mask: net.CIDRMask(32, 32),
+			},
+			expect: 1,
+		},
+		{
+			name: "IPv4 subnet /24",
+			ipNet: &net.IPNet{
+				IP:   net.ParseIP("10.0.0.0"),
+				Mask: net.CIDRMask(24, 32),
+			},
+			expect: 1,
+		},
+		{
+			name: "IPv4 subnet /16",
+			ipNet: &net.IPNet{
+				IP:   net.ParseIP("10.0.0.0"),
+				Mask: net.CIDRMask(16, 32),
+			},
+			expect: 1,
+		},
+		{
+			name: "IPv6 single IP",
+			ipNet: &net.IPNet{
+				IP:   net.ParseIP("2001:db8::1"),
+				Mask: net.CIDRMask(128, 128),
+			},
+			expect: 4,
+		},
+		{
+			name: "IPv6 subnet /64",
+			ipNet: &net.IPNet{
+				IP:   net.ParseIP("2001:db8::"),
+				Mask: net.CIDRMask(64, 128),
+			},
+			expect: 2,
+		},
+		{
+			name: "IPv6 subnet /32",
+			ipNet: &net.IPNet{
+				IP:   net.ParseIP("2001:db8::"),
+				Mask: net.CIDRMask(32, 128),
+			},
+			expect: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			keys := U32MatchSrc(tt.ipNet)
+
+			// Verify the number of keys matches expectation
+			if len(keys) != tt.expect {
+				t.Errorf("U32MatchSrc() returned %d keys, expected %d", len(keys), tt.expect)
+			}
+
+			// Verify each key has valid values
+			for i, key := range keys {
+				if key.Mask == 0 {
+					t.Errorf("U32MatchSrc() key[%d] has zero mask", i)
+				}
+				if key.Off < 0 {
+					t.Errorf("U32MatchSrc() key[%d] has negative offset: %d", i, key.Off)
+				}
+			}
+
+			// For IPv4, verify offset is 12
+			if tt.ipNet.IP.To4() != nil {
+				if len(keys) > 0 && keys[0].Off != 12 {
+					t.Errorf("U32MatchSrc() IPv4 key has wrong offset: %d, expected 12", keys[0].Off)
+				}
+			}
+
+			// For IPv6, verify offsets are in sequence
+			if tt.ipNet.IP.To4() == nil {
+				for i, key := range keys {
+					expectedOff := int32(8 + 4*i)
+					if key.Off != expectedOff {
+						t.Errorf("U32MatchSrc() IPv6 key[%d] has wrong offset: %d, expected %d", i, key.Off, expectedOff)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestMatchSrc_WithExistingSel(t *testing.T) {
+	// Test MatchSrc with existing Sel
+	u32 := &netlink.U32{
+		Sel: &netlink.TcU32Sel{
+			Keys: []netlink.TcU32Key{
+				{Mask: 0xffffffff, Val: 0x0a000001, Off: 12}, // 10.0.0.1
+			},
+			Nkeys: 1,
+			Flags: 0x10, // Some existing flags
+		},
+	}
+
+	initialKeyCount := len(u32.Sel.Keys)
+
+	// Add another match
+	ipNet := &net.IPNet{
+		IP:   net.ParseIP("192.168.1.1"),
+		Mask: net.CIDRMask(32, 32),
+	}
+
+	MatchSrc(u32, ipNet)
+
+	// Verify that keys were appended
+	if len(u32.Sel.Keys) != initialKeyCount+1 {
+		t.Errorf("MatchSrc() did not append keys correctly: got %d, expected %d", len(u32.Sel.Keys), initialKeyCount+1)
+	}
+
+	// Verify Nkeys was updated
+	if u32.Sel.Nkeys != uint8(len(u32.Sel.Keys)) {
+		t.Errorf("MatchSrc() did not update Nkeys correctly: got %d, expected %d", u32.Sel.Nkeys, len(u32.Sel.Keys))
+	}
+}

--- a/plugin/datapath/exclusive_eni_linux_test.go
+++ b/plugin/datapath/exclusive_eni_linux_test.go
@@ -171,3 +171,235 @@ func TestDataPathExclusiveENI(t *testing.T) {
 	_, ok = err.(netlink.LinkNotFoundError)
 	assert.True(t, ok)
 }
+
+func TestDataPathExclusiveENIMultiNetwork(t *testing.T) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	var err error
+	hostNS, err := testutils.NewNS()
+	assert.NoError(t, err)
+
+	containerNS, err := testutils.NewNS()
+	assert.NoError(t, err)
+
+	err = hostNS.Set()
+	assert.NoError(t, err)
+
+	defer func() {
+		err := containerNS.Close()
+		assert.NoError(t, err)
+
+		err = testutils.UnmountNS(containerNS)
+		assert.NoError(t, err)
+
+		err = hostNS.Close()
+		assert.NoError(t, err)
+
+		err = testutils.UnmountNS(hostNS)
+		assert.NoError(t, err)
+	}()
+
+	err = netlink.LinkAdd(&netlink.Dummy{
+		LinkAttrs: netlink.LinkAttrs{Name: "eni"},
+	})
+	assert.NoError(t, err)
+	eni, err := netlink.LinkByName("eni")
+	assert.NoError(t, err)
+
+	cfg := &types2.SetupConfig{
+		HostVETHName:    "hostveth",
+		ContainerIfName: "eth0",
+		ContainerIPNet: &terwayTypes.IPNetSet{
+			IPv4: containerIPNet,
+			IPv6: containerIPNetIPv6,
+		},
+		GatewayIP: &terwayTypes.IPSet{
+			IPv4: ipv4GW,
+			IPv6: ipv6GW,
+		},
+		MTU:       1499,
+		ENIIndex:  eni.Attrs().Index,
+		StripVlan: false,
+		ServiceCIDR: &terwayTypes.IPNetSet{
+			IPv4: serviceCIDR,
+			IPv6: serviceCIDRIPv6,
+		},
+		HostIPSet: &terwayTypes.IPNetSet{
+			IPv4: eth0IPNet,
+			IPv6: eth0IPNetIPv6,
+		},
+		DefaultRoute: true,
+		MultiNetwork: true, // Enable MultiNetwork feature
+	}
+
+	d := NewExclusiveENIDriver()
+	err = d.Setup(context.Background(), cfg, containerNS)
+	assert.NoError(t, err)
+
+	_ = containerNS.Do(func(netNS ns.NetNS) error {
+		// check eth0
+		containerLink, err := netlink.LinkByName(cfg.ContainerIfName)
+		if assert.NoError(t, err) {
+			assert.Equal(t, cfg.MTU, containerLink.Attrs().MTU)
+			assert.True(t, containerLink.Attrs().Flags&net.FlagUp != 0)
+
+			//ok, err := FindIP(containerLink, utils.NewIPNet(cfg.ContainerIPNet))
+			//if assert.NoError(t, err) {
+			//	assert.True(t, ok, "expect ip %s", cfg.ContainerIPNet.String())
+			//}
+		}
+
+		// check veth1
+		vethLink, err := netlink.LinkByName("veth1")
+		if assert.NoError(t, err) {
+			assert.Equal(t, cfg.MTU, vethLink.Attrs().MTU)
+			assert.True(t, vethLink.Attrs().Flags&net.FlagUp != 0)
+			assert.Equal(t, "veth", vethLink.Type())
+
+			//ok, err := FindIP(vethLink, utils.NewIPNet(cfg.ContainerIPNet))
+			//assert.NoError(t, err)
+			//assert.True(t, ok)
+		}
+
+		// Check routing rules - MultiNetwork mode should have specific routing rules
+		table := utils.GetRouteTableID(eni.Attrs().Index)
+
+		// Check IPv4 routing rules
+		if cfg.ContainerIPNet.IPv4 != nil {
+			// Check source IP routing rules
+			v4 := utils.NewIPNetWithMaxMask(cfg.ContainerIPNet.IPv4)
+			rules, err := netlink.RuleList(netlink.FAMILY_V4)
+			assert.NoError(t, err)
+
+			foundSrcRule := false
+			foundOifRule := false
+			for _, rule := range rules {
+				t.Logf("rule: %+v\n", rule)
+				if rule.Src != nil && rule.Src.String() == v4.String() && rule.Table == table && rule.Priority == toContainerPriority {
+					foundSrcRule = true
+				}
+				if rule.OifName == cfg.ContainerIfName && rule.Table == table && rule.Priority == toContainerPriority {
+					foundOifRule = true
+				}
+			}
+			assert.True(t, foundSrcRule, "should find source IP rule for IPv4")
+			assert.True(t, foundOifRule, "should find output interface rule for IPv4")
+		}
+
+		// Check IPv6 routing rules
+		if cfg.ContainerIPNet.IPv6 != nil {
+			v6 := utils.NewIPNetWithMaxMask(cfg.ContainerIPNet.IPv6)
+			rules, err := netlink.RuleList(netlink.FAMILY_V6)
+			assert.NoError(t, err)
+
+			foundSrcRule := false
+			foundOifRule := false
+			for _, rule := range rules {
+				t.Logf("rule: %+v\n", rule)
+				if rule.Src != nil && rule.Src.String() == v6.String() && rule.Table == table && rule.Priority == toContainerPriority {
+					foundSrcRule = true
+				}
+				if rule.Table == table && rule.Priority == toContainerPriority {
+					foundOifRule = true
+				}
+			}
+			assert.True(t, foundSrcRule, "should find source IP rule for IPv6")
+			assert.True(t, foundOifRule, "should find output interface rule for IPv6")
+		}
+
+		// Check default route in routing table
+		routes, err := netlink.RouteListFiltered(netlink.FAMILY_V4, &netlink.Route{
+			Table: table,
+		}, netlink.RT_FILTER_TABLE)
+		assert.NoError(t, err)
+
+		foundDefaultRoute := false
+		for _, route := range routes {
+			if route.Dst == nil && route.Gw != nil && route.Gw.String() == ipv4GW.String() {
+				foundDefaultRoute = true
+				break
+			}
+		}
+		assert.True(t, foundDefaultRoute, "should find default route in custom table")
+
+		// default via gw dev eth0
+		routes, err = netlink.RouteListFiltered(netlink.FAMILY_V4, &netlink.Route{
+			Dst: nil,
+		}, netlink.RT_FILTER_DST)
+		if assert.NoError(t, err) {
+			assert.Equal(t, len(routes), 1)
+			assert.Equal(t, ipv4GW.String(), routes[0].Gw.String())
+		}
+
+		return nil
+	})
+
+	// eni should be moved to container
+	_, err = netlink.LinkByName(eni.Attrs().Name)
+	assert.Error(t, err)
+	_, ok := err.(netlink.LinkNotFoundError)
+	assert.True(t, ok)
+
+	// host veth link
+	hostVETHLink, err := netlink.LinkByName(cfg.HostVETHName)
+	assert.NoError(t, err)
+	assert.Equal(t, cfg.MTU, hostVETHLink.Attrs().MTU)
+	assert.True(t, hostVETHLink.Attrs().Flags&net.FlagUp != 0)
+
+	// ip 169.254.1.1/32
+	ok, err = FindIP(hostVETHLink, &terwayTypes.IPNetSet{
+		IPv4: LinkIPNet,
+		IPv6: LinkIPNetv6,
+	})
+	assert.NoError(t, err)
+	assert.True(t, ok)
+
+	// route 169.10.0.10 dev hostVETH
+	routes, err := netlink.RouteListFiltered(netlink.FAMILY_V4, &netlink.Route{
+		Dst: &net.IPNet{
+			IP:   cfg.ContainerIPNet.IPv4.IP,
+			Mask: net.CIDRMask(32, 32),
+		},
+		LinkIndex: hostVETHLink.Attrs().Index,
+	}, netlink.RT_FILTER_DST|netlink.RT_FILTER_OIF)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(routes))
+
+	// add some ip rule make sure we don't delete it
+	dummyRule := netlink.NewRule()
+	dummyRule.Priority = toContainerPriority
+	dummyRule.Table = unix.RT_TABLE_MAIN
+	dummyRule.Dst = &net.IPNet{
+		IP:   cfg.ContainerIPNet.IPv4.IP,
+		Mask: net.CIDRMask(24, 32),
+	}
+	err = netlink.RuleAdd(dummyRule)
+	assert.NoError(t, err)
+
+	err = d.Check(context.Background(), &types2.CheckConfig{
+		DP:              0,
+		RecordPodEvent:  nil,
+		NetNS:           containerNS,
+		HostVETHName:    "",
+		ContainerIfName: "eth0",
+		ContainerIPNet:  nil,
+		HostIPSet:       nil,
+		GatewayIP:       nil,
+		ENIIndex:        0,
+		TrunkENI:        false,
+		MTU:             1499,
+		DefaultRoute:    false,
+		MultiNetwork:    false,
+	})
+	assert.NoError(t, err)
+
+	// tear down
+	err = utils.GenericTearDown(context.Background(), containerNS)
+	assert.NoError(t, err)
+
+	_, err = netlink.LinkByName(cfg.HostVETHName)
+	assert.Error(t, err)
+	_, ok = err.(netlink.LinkNotFoundError)
+	assert.True(t, ok)
+}

--- a/plugin/datapath/ipvlan_linux_test.go
+++ b/plugin/datapath/ipvlan_linux_test.go
@@ -316,3 +316,274 @@ func TestDataPathIPvlanL2(t *testing.T) {
 	}, containerNS)
 	assert.NoError(t, err)
 }
+
+func TestDataPathIPvlanL2MultiNetwork(t *testing.T) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	var err error
+	hostNS, err := testutils.NewNS()
+	assert.NoError(t, err)
+
+	containerNS, err := testutils.NewNS()
+	assert.NoError(t, err)
+
+	err = hostNS.Set()
+	assert.NoError(t, err)
+
+	defer func() {
+		err := containerNS.Close()
+		assert.NoError(t, err)
+
+		err = testutils.UnmountNS(containerNS)
+		assert.NoError(t, err)
+
+		err = hostNS.Close()
+		assert.NoError(t, err)
+
+		err = testutils.UnmountNS(hostNS)
+		assert.NoError(t, err)
+	}()
+
+	err = netlink.LinkAdd(&netlink.Dummy{
+		LinkAttrs: netlink.LinkAttrs{Name: "eni"},
+	})
+	assert.NoError(t, err)
+	eni, err := netlink.LinkByName("eni")
+	assert.NoError(t, err)
+
+	cfg := &types2.SetupConfig{
+		HostVETHName:    "hostipvl",
+		ContainerIfName: "eth0",
+		ContainerIPNet: &types.IPNetSet{
+			IPv4: containerIPNet,
+			IPv6: containerIPNetIPv6,
+		},
+		GatewayIP: &types.IPSet{
+			IPv4: ipv4GW,
+			IPv6: ipv6GW,
+		},
+		MTU:            1499,
+		ENIIndex:       eni.Attrs().Index,
+		StripVlan:      false,
+		HostStackCIDRs: nil,
+		Ingress:        0,
+		Egress:         0,
+		ServiceCIDR: &types.IPNetSet{
+			IPv4: serviceCIDR,
+			IPv6: serviceCIDRIPv6,
+		},
+		HostIPSet: &types.IPNetSet{
+			IPv4: eth0IPNet,
+			IPv6: eth0IPNetIPv6,
+		},
+		DefaultRoute: true,
+		MultiNetwork: true, // Enable MultiNetwork feature
+	}
+	d := NewIPVlanDriver()
+
+	err = d.Setup(context.Background(), cfg, containerNS)
+	assert.NoError(t, err)
+
+	_ = containerNS.Do(func(netNS ns.NetNS) error {
+		// addr
+		containerLink, err := netlink.LinkByName(cfg.ContainerIfName)
+		assert.NoError(t, err)
+		assert.Equal(t, cfg.MTU, containerLink.Attrs().MTU)
+
+		ok, err := FindIP(containerLink, cfg.ContainerIPNet)
+		assert.NoError(t, err)
+		assert.True(t, ok)
+
+		// Check routing rules - MultiNetwork mode should have specific routing rules
+		table := utils.GetRouteTableID(eni.Attrs().Index)
+
+		// Check IPv4 routing rules
+		if cfg.ContainerIPNet.IPv4 != nil {
+			// Check source IP routing rules
+			v4 := utils.NewIPNetWithMaxMask(cfg.ContainerIPNet.IPv4)
+			rules, err := netlink.RuleList(netlink.FAMILY_V4)
+			assert.NoError(t, err)
+
+			foundSrcRule := false
+			foundOifRule := false
+			for _, rule := range rules {
+				t.Logf("rule: %+v\n", rule)
+				if rule.Src != nil && rule.Src.String() == v4.String() && rule.Table == table && rule.Priority == toContainerPriority {
+					foundSrcRule = true
+				}
+				if rule.OifName == cfg.ContainerIfName && rule.Table == table && rule.Priority == toContainerPriority {
+					foundOifRule = true
+				}
+			}
+			assert.True(t, foundSrcRule, "should find source IP rule for IPv4")
+			assert.True(t, foundOifRule, "should find output interface rule for IPv4")
+		}
+
+		// Check IPv6 routing rules
+		if cfg.ContainerIPNet.IPv6 != nil {
+			v6 := utils.NewIPNetWithMaxMask(cfg.ContainerIPNet.IPv6)
+			rules, err := netlink.RuleList(netlink.FAMILY_V6)
+			assert.NoError(t, err)
+
+			foundSrcRule := false
+			foundOifRule := false
+			for _, rule := range rules {
+				t.Logf("rule: %+v\n", rule)
+				if rule.Src != nil && rule.Src.String() == v6.String() && rule.Table == table && rule.Priority == toContainerPriority {
+					foundSrcRule = true
+				}
+				if rule.Table == table && rule.Priority == toContainerPriority {
+					foundOifRule = true
+				}
+			}
+			assert.True(t, foundSrcRule, "should find source IP rule for IPv6")
+			assert.True(t, foundOifRule, "should find output interface rule for IPv6")
+		}
+
+		// Check default route in routing table
+		routes, err := netlink.RouteListFiltered(netlink.FAMILY_V4, &netlink.Route{
+			Table: table,
+		}, netlink.RT_FILTER_TABLE)
+		assert.NoError(t, err)
+
+		foundDefaultRoute := false
+		for _, route := range routes {
+			if route.Dst == nil && route.Gw != nil && route.Gw.String() == ipv4GW.String() {
+				foundDefaultRoute = true
+				break
+			}
+		}
+		assert.True(t, foundDefaultRoute, "should find default route in custom table")
+
+		// default via 169.10.10.253 dev eth0
+		routes, err = netlink.RouteListFiltered(netlink.FAMILY_V4, &netlink.Route{
+			Dst: nil,
+		}, netlink.RT_FILTER_DST)
+		assert.NoError(t, err)
+		assert.Equal(t, len(routes), 1)
+
+		assert.Equal(t, ipv4GW.String(), routes[0].Gw.String())
+
+		// neigh should be added
+		ok, err = FindNeigh(containerLink, eth0IPNet.IP, eni.Attrs().HardwareAddr)
+		assert.NoError(t, err)
+		assert.True(t, ok)
+
+		ok, err = FindNeigh(containerLink, eth0IPNetIPv6.IP, eni.Attrs().HardwareAddr)
+		assert.NoError(t, err)
+		assert.True(t, ok)
+
+		return nil
+	})
+
+	// check eni
+	eni, err = netlink.LinkByIndex(eni.Attrs().Index)
+	assert.NoError(t, err)
+	assert.True(t, eni.Attrs().Flags&net.FlagUp != 0)
+
+	addrs, err := netlink.AddrList(eni, netlink.FAMILY_V4)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(addrs))
+
+	// check slave link (ipvl_x)
+	slaveName := d.initSlaveName(eni.Attrs().Index)
+	slaveLink, err := netlink.LinkByName(slaveName)
+	assert.NoError(t, err)
+	assert.Equal(t, cfg.MTU, slaveLink.Attrs().MTU)
+	assert.True(t, slaveLink.Attrs().Flags&net.FlagUp != 0)
+
+	// eth0's ip 169.20.20.10/32 dev ipvl_x
+	ok, err := FindIP(slaveLink, &types.IPNetSet{
+		IPv4: &net.IPNet{
+			IP:   cfg.HostIPSet.IPv4.IP,
+			Mask: net.CIDRMask(32, 32),
+		},
+		IPv6: &net.IPNet{
+			IP:   cfg.HostIPSet.IPv6.IP,
+			Mask: net.CIDRMask(128, 128),
+		},
+	})
+	assert.NoError(t, err)
+	assert.True(t, ok)
+
+	// route 169.10.0.10 dev ipvl_x
+	routes, err := netlink.RouteListFiltered(netlink.FAMILY_V4, &netlink.Route{
+		Dst: &net.IPNet{
+			IP:   cfg.ContainerIPNet.IPv4.IP,
+			Mask: net.CIDRMask(32, 32),
+		},
+		LinkIndex: slaveLink.Attrs().Index,
+	}, netlink.RT_FILTER_DST|netlink.RT_FILTER_OIF)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(routes))
+
+	// add some route make sure we don't delete it
+	dummyRoute := &netlink.Route{
+		LinkIndex: slaveLink.Attrs().Index,
+		Dst: &net.IPNet{
+			IP:   net.ParseIP("169.99.0.10"),
+			Mask: net.CIDRMask(32, 32),
+		},
+	}
+	err = netlink.RouteAdd(dummyRoute)
+	assert.NoError(t, err)
+
+	err = d.Check(context.Background(), &types2.CheckConfig{
+		DP:              0,
+		RecordPodEvent:  nil,
+		NetNS:           containerNS,
+		HostVETHName:    "",
+		ContainerIfName: "eth0",
+		ContainerIPNet:  nil,
+		HostIPSet:       nil,
+		GatewayIP:       nil,
+		ENIIndex:        0,
+		TrunkENI:        false,
+		MTU:             1499,
+		DefaultRoute:    false,
+		MultiNetwork:    false,
+	})
+	assert.NoError(t, err)
+
+	// tear down
+	err = utils.GenericTearDown(context.Background(), containerNS)
+	assert.NoError(t, err)
+
+	err = d.Teardown(context.Background(), &types2.TeardownCfg{
+		HostVETHName:    cfg.HostVETHName,
+		ContainerIfName: cfg.ContainerIfName,
+		ContainerIPNet: &types.IPNetSet{
+			IPv4: containerIPNet,
+			IPv6: containerIPNetIPv6,
+		},
+		ENIIndex: eni.Attrs().Index,
+	}, containerNS)
+	assert.NoError(t, err)
+
+	// check ipvl_x is up
+	slaveLink, err = netlink.LinkByIndex(slaveLink.Attrs().Index)
+	assert.NoError(t, err)
+	assert.True(t, slaveLink.Attrs().Flags&net.FlagUp != 0)
+
+	// route 169.10.0.10 dev ipvl_x should be removed
+	routes, err = utils.FoundRoutes(&netlink.Route{
+		Dst: &net.IPNet{
+			IP:   cfg.ContainerIPNet.IPv4.IP,
+			Mask: net.CIDRMask(32, 32),
+		},
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(routes))
+
+	err = d.Teardown(context.Background(), &types2.TeardownCfg{
+		HostVETHName:    cfg.HostVETHName,
+		ContainerIfName: cfg.ContainerIfName,
+		ContainerIPNet: &types.IPNetSet{
+			IPv4: containerIPNet,
+			IPv6: containerIPNetIPv6,
+		},
+		ENIIndex: 0,
+	}, containerNS)
+	assert.NoError(t, err)
+}

--- a/plugin/datapath/policy_router_linux_test.go
+++ b/plugin/datapath/policy_router_linux_test.go
@@ -215,3 +215,265 @@ func TestDataPathPolicyRoute(t *testing.T) {
 	}, containerNS)
 	assert.NoError(t, err)
 }
+
+func TestDataPathPolicyRouteMultiNetwork(t *testing.T) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	var err error
+	hostNS, err := testutils.NewNS()
+	assert.NoError(t, err)
+
+	containerNS, err := testutils.NewNS()
+	assert.NoError(t, err)
+
+	err = hostNS.Set()
+	assert.NoError(t, err)
+
+	defer func() {
+		err := containerNS.Close()
+		assert.NoError(t, err)
+
+		err = testutils.UnmountNS(containerNS)
+		assert.NoError(t, err)
+
+		err = hostNS.Close()
+		assert.NoError(t, err)
+
+		err = testutils.UnmountNS(hostNS)
+		assert.NoError(t, err)
+	}()
+
+	err = netlink.LinkAdd(&netlink.Dummy{
+		LinkAttrs: netlink.LinkAttrs{Name: "eni"},
+	})
+	assert.NoError(t, err)
+	eni, err := netlink.LinkByName("eni")
+	assert.NoError(t, err)
+
+	cfg := &types.SetupConfig{
+		HostVETHName:    "hostveth",
+		ContainerIfName: "eth0",
+		ContainerIPNet: &terwayTypes.IPNetSet{
+			IPv4: containerIPNet,
+			IPv6: containerIPNetIPv6,
+		},
+		GatewayIP: &terwayTypes.IPSet{
+			IPv4: ipv4GW,
+			IPv6: ipv6GW,
+		},
+		MTU:       1499,
+		ENIIndex:  eni.Attrs().Index,
+		StripVlan: false,
+		ServiceCIDR: &terwayTypes.IPNetSet{
+			IPv4: serviceCIDR,
+			IPv6: serviceCIDRIPv6,
+		},
+		HostIPSet: &terwayTypes.IPNetSet{
+			IPv4: eth0IPNet,
+			IPv6: eth0IPNetIPv6,
+		},
+		DefaultRoute: true,
+		MultiNetwork: true, // Enable MultiNetwork feature
+	}
+
+	d := &PolicyRoute{}
+
+	err = d.Setup(context.Background(), cfg, containerNS)
+	assert.NoError(t, err)
+
+	_ = containerNS.Do(func(netNS ns.NetNS) error {
+		// addr
+		containerLink, err := netlink.LinkByName(cfg.ContainerIfName)
+		assert.NoError(t, err)
+		assert.Equal(t, cfg.MTU, containerLink.Attrs().MTU)
+		assert.True(t, containerLink.Attrs().Flags&net.FlagUp != 0)
+
+		ok, err := FindIP(containerLink, utils.NewIPNet(cfg.ContainerIPNet))
+		assert.NoError(t, err)
+		assert.True(t, ok)
+
+		// Check routing rules - MultiNetwork mode should have specific routing rules
+		table := utils.GetRouteTableID(eni.Attrs().Index)
+
+		// Check IPv4 routing rules
+		if cfg.ContainerIPNet.IPv4 != nil {
+			// Check source IP routing rules
+			v4 := utils.NewIPNetWithMaxMask(cfg.ContainerIPNet.IPv4)
+			rules, err := netlink.RuleList(netlink.FAMILY_V4)
+			assert.NoError(t, err)
+
+			foundSrcRule := false
+			foundOifRule := false
+			for _, rule := range rules {
+				t.Logf("rule: %+v\n", rule)
+				if rule.Src != nil && rule.Src.String() == v4.String() && rule.Table == table && rule.Priority == toContainerPriority {
+					foundSrcRule = true
+				}
+				if rule.OifName == cfg.ContainerIfName && rule.Table == table && rule.Priority == toContainerPriority {
+					foundOifRule = true
+				}
+			}
+			assert.True(t, foundSrcRule, "should find source IP rule for IPv4")
+			assert.True(t, foundOifRule, "should find output interface rule for IPv4")
+		}
+
+		// Check IPv6 routing rules
+		if cfg.ContainerIPNet.IPv6 != nil {
+			v6 := utils.NewIPNetWithMaxMask(cfg.ContainerIPNet.IPv6)
+			rules, err := netlink.RuleList(netlink.FAMILY_V6)
+			assert.NoError(t, err)
+
+			foundSrcRule := false
+			foundOifRule := false
+			for _, rule := range rules {
+				t.Logf("rule: %+v\n", rule)
+				if rule.Src != nil && rule.Src.String() == v6.String() && rule.Table == table && rule.Priority == toContainerPriority {
+					foundSrcRule = true
+				}
+				if rule.Table == table && rule.Priority == toContainerPriority {
+					foundOifRule = true
+				}
+			}
+			assert.True(t, foundSrcRule, "should find source IP rule for IPv6")
+			assert.True(t, foundOifRule, "should find output interface rule for IPv6")
+		}
+
+		// Check default route in routing table
+		routes, err := netlink.RouteListFiltered(netlink.FAMILY_V4, &netlink.Route{
+			Table: table,
+		}, netlink.RT_FILTER_TABLE)
+		assert.NoError(t, err)
+
+		foundDefaultRoute := false
+		for _, route := range routes {
+			if route.Dst == nil && route.Gw != nil && route.Gw.String() == ipv4GW.String() {
+				foundDefaultRoute = true
+				break
+			}
+		}
+		assert.True(t, foundDefaultRoute, "should find default route in custom table")
+
+		return nil
+	})
+
+	// check eni
+	eniLink, err := netlink.LinkByName("eni")
+	assert.NoError(t, err)
+	assert.Equal(t, cfg.MTU, eniLink.Attrs().MTU)
+	assert.True(t, eniLink.Attrs().Flags&net.FlagUp != 0)
+
+	// check host veth
+
+	hostVETHLink, err := netlink.LinkByName(cfg.HostVETHName)
+	assert.NoError(t, err)
+	assert.Equal(t, cfg.MTU, hostVETHLink.Attrs().MTU)
+
+	addrs, err := netlink.AddrList(hostVETHLink, netlink.FAMILY_V4)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(addrs))
+
+	// 169.10.0.10 dev hostVETH
+	routes, err := netlink.RouteListFiltered(netlink.FAMILY_V4, &netlink.Route{
+		Dst: &net.IPNet{
+			IP:   cfg.ContainerIPNet.IPv4.IP,
+			Mask: net.CIDRMask(32, 32),
+		},
+		LinkIndex: hostVETHLink.Attrs().Index,
+	}, netlink.RT_FILTER_DST|netlink.RT_FILTER_OIF)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(routes))
+
+	// 512 from all to 169.10.0.10 look up main
+	rule := netlink.NewRule()
+	rule.Priority = toContainerPriority
+	rule.Table = unix.RT_TABLE_MAIN
+	rule.Dst = &net.IPNet{
+		IP:   cfg.ContainerIPNet.IPv4.IP,
+		Mask: net.CIDRMask(32, 32),
+	}
+
+	rules, err := netlink.RuleListFiltered(netlink.FAMILY_V4, rule, netlink.RT_FILTER_TABLE|netlink.RT_FILTER_DST|netlink.RT_FILTER_PRIORITY)
+	assert.NoError(t, err)
+	assert.Equal(t, len(rules), 1)
+	assert.Nil(t, rules[0].Src)
+
+	// 2048 from 169.10.0.10 lookup table
+	rule = netlink.NewRule()
+	rule.Priority = fromContainerPriority
+	rule.Table = utils.GetRouteTableID(eni.Attrs().Index)
+	rule.Src = &net.IPNet{
+		IP:   cfg.ContainerIPNet.IPv4.IP,
+		Mask: net.CIDRMask(32, 32),
+	}
+	rules, err = netlink.RuleListFiltered(netlink.FAMILY_V4, rule, netlink.RT_FILTER_TABLE|netlink.RT_FILTER_SRC|netlink.RT_FILTER_PRIORITY|netlink.RT_FILTER_IIF)
+	assert.NoError(t, err)
+	assert.Equal(t, len(rules), 1)
+
+	// add some ip rule make sure we don't delete it
+	dummyRule := netlink.NewRule()
+	dummyRule.Priority = toContainerPriority
+	dummyRule.Table = unix.RT_TABLE_MAIN
+	dummyRule.Dst = &net.IPNet{
+		IP:   cfg.ContainerIPNet.IPv4.IP,
+		Mask: net.CIDRMask(24, 32),
+	}
+	err = netlink.RuleAdd(dummyRule)
+	assert.NoError(t, err)
+
+	err = d.Check(context.Background(), &types.CheckConfig{
+		DP:              0,
+		RecordPodEvent:  nil,
+		NetNS:           containerNS,
+		HostVETHName:    "",
+		ContainerIfName: "eth0",
+		ContainerIPNet:  nil,
+		HostIPSet:       nil,
+		GatewayIP:       nil,
+		ENIIndex:        0,
+		TrunkENI:        false,
+		MTU:             1499,
+		DefaultRoute:    false,
+		MultiNetwork:    false,
+	})
+	assert.NoError(t, err)
+
+	// tear down
+	err = utils.GenericTearDown(context.Background(), containerNS)
+	assert.NoError(t, err)
+
+	err = d.Teardown(context.Background(), &types.TeardownCfg{
+		HostVETHName:    cfg.HostVETHName,
+		ContainerIfName: cfg.ContainerIfName,
+		ContainerIPNet: &terwayTypes.IPNetSet{
+			IPv4: containerIPNet,
+			IPv6: containerIPNetIPv6,
+		},
+		ENIIndex: eni.Attrs().Index,
+	}, containerNS)
+	assert.NoError(t, err)
+
+	_, err = netlink.LinkByName(cfg.HostVETHName)
+	assert.Error(t, err)
+	_, ok := err.(netlink.LinkNotFoundError)
+	assert.True(t, ok)
+
+	rules, err = netlink.RuleList(netlink.FAMILY_V4)
+	assert.NoError(t, err)
+	assert.Equal(t, 4, len(rules))
+
+	for _, r := range rules {
+		t.Logf("%s %#v ", r, r)
+	}
+
+	err = d.Teardown(context.Background(), &types.TeardownCfg{
+		HostVETHName:    cfg.HostVETHName,
+		ContainerIfName: cfg.ContainerIfName,
+		ContainerIPNet: &terwayTypes.IPNetSet{
+			IPv4: containerIPNet,
+			IPv6: containerIPNetIPv6,
+		},
+		ENIIndex: 0,
+	}, containerNS)
+	assert.NoError(t, err)
+}

--- a/plugin/datapath/vlan_linux_test.go
+++ b/plugin/datapath/vlan_linux_test.go
@@ -145,3 +145,199 @@ func TestVlanDataPath(t *testing.T) {
 	_, err = netlink.LinkByName(cfg.HostVETHName)
 	assert.Error(t, err)
 }
+
+func TestVlanDataPathMultiNetwork(t *testing.T) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	var err error
+	hostNS, err := testutils.NewNS()
+	assert.NoError(t, err)
+
+	containerNS, err := testutils.NewNS()
+	assert.NoError(t, err)
+
+	err = hostNS.Set()
+	assert.NoError(t, err)
+
+	defer func() {
+		err := containerNS.Close()
+		assert.NoError(t, err)
+
+		err = testutils.UnmountNS(containerNS)
+		assert.NoError(t, err)
+
+		err = hostNS.Close()
+		assert.NoError(t, err)
+
+		err = testutils.UnmountNS(hostNS)
+		assert.NoError(t, err)
+	}()
+
+	err = netlink.LinkAdd(&netlink.Dummy{
+		LinkAttrs: netlink.LinkAttrs{Name: "eni"},
+	})
+	assert.NoError(t, err)
+	eni, err := netlink.LinkByName("eni")
+	assert.NoError(t, err)
+
+	cfg := &types.SetupConfig{
+		HostVETHName:    "hostveth",
+		ContainerIfName: "eth0",
+		ContainerIPNet: &terwayTypes.IPNetSet{
+			IPv4: containerIPNet,
+			IPv6: containerIPNetIPv6,
+		},
+		GatewayIP: &terwayTypes.IPSet{
+			IPv4: ipv4GW,
+			IPv6: ipv6GW,
+		},
+		MTU:       1499,
+		ENIIndex:  eni.Attrs().Index,
+		Vid:       100,
+		StripVlan: false,
+		ExtraRoutes: []cniTypes.Route{
+			{
+				Dst: net.IPNet{
+					IP:   net.ParseIP("169.254.1.0"),
+					Mask: net.CIDRMask(24, 32),
+				},
+				GW: net.ParseIP("169.254.1.1"),
+			},
+		},
+		ServiceCIDR:    nil,
+		HostStackCIDRs: nil,
+		Ingress:        0,
+		Egress:         0,
+		HostIPSet: &terwayTypes.IPNetSet{
+			IPv4: eth0IPNet,
+			IPv6: eth0IPNetIPv6,
+		},
+		DefaultRoute: true,
+		MultiNetwork: true, // Enable MultiNetwork feature
+	}
+
+	d := &Vlan{}
+
+	err = d.Setup(context.Background(), cfg, containerNS)
+	assert.NoError(t, err)
+
+	_ = containerNS.Do(func(netNS ns.NetNS) error {
+		// addr
+		containerLink, err := netlink.LinkByName(cfg.ContainerIfName)
+		assert.NoError(t, err)
+		assert.Equal(t, cfg.MTU, containerLink.Attrs().MTU)
+		assert.True(t, containerLink.Attrs().Flags&net.FlagUp != 0)
+
+		t.Logf("container link %s, ip %s", containerLink.Attrs().Name, cfg.ContainerIPNet.String())
+
+		// 169.10.0.10/24
+		ok, err := FindIP(containerLink, cfg.ContainerIPNet)
+		assert.NoError(t, err)
+		assert.True(t, ok)
+
+		// Check routing rules - MultiNetwork mode should have specific routing rules
+		table := utils.GetRouteTableID(eni.Attrs().Index)
+
+		// Check IPv4 routing rules
+		if cfg.ContainerIPNet.IPv4 != nil {
+			// Check source IP routing rules
+			v4 := utils.NewIPNetWithMaxMask(cfg.ContainerIPNet.IPv4)
+			rules, err := netlink.RuleList(netlink.FAMILY_V4)
+			assert.NoError(t, err)
+
+			foundSrcRule := false
+			foundOifRule := false
+			for _, rule := range rules {
+				t.Logf("rule: %+v\n", rule)
+				if rule.Src != nil && rule.Src.String() == v4.String() && rule.Table == table && rule.Priority == toContainerPriority {
+					foundSrcRule = true
+				}
+				if rule.OifName == cfg.ContainerIfName && rule.Table == table && rule.Priority == toContainerPriority {
+					foundOifRule = true
+				}
+			}
+			assert.True(t, foundSrcRule, "should find source IP rule for IPv4")
+			assert.True(t, foundOifRule, "should find output interface rule for IPv4")
+		}
+
+		// Check IPv6 routing rules
+		if cfg.ContainerIPNet.IPv6 != nil {
+			v6 := utils.NewIPNetWithMaxMask(cfg.ContainerIPNet.IPv6)
+			rules, err := netlink.RuleList(netlink.FAMILY_V6)
+			assert.NoError(t, err)
+
+			foundSrcRule := false
+			foundOifRule := false
+			for _, rule := range rules {
+				t.Logf("rule: %+v\n", rule)
+				if rule.Src != nil && rule.Src.String() == v6.String() && rule.Table == table && rule.Priority == toContainerPriority {
+					foundSrcRule = true
+				}
+				if rule.Table == table && rule.Priority == toContainerPriority {
+					foundOifRule = true
+				}
+			}
+			assert.True(t, foundSrcRule, "should find source IP rule for IPv6")
+			assert.True(t, foundOifRule, "should find output interface rule for IPv6")
+		}
+
+		// Check default route in routing table
+		routes, err := netlink.RouteListFiltered(netlink.FAMILY_V4, &netlink.Route{
+			Table: table,
+		}, netlink.RT_FILTER_TABLE)
+		assert.NoError(t, err)
+
+		foundDefaultRoute := false
+		for _, route := range routes {
+			if route.Dst == nil && route.Gw != nil && route.Gw.String() == ipv4GW.String() {
+				foundDefaultRoute = true
+				break
+			}
+		}
+		assert.True(t, foundDefaultRoute, "should find default route in custom table")
+
+		// check extra routes
+		extraRoutes, err := netlink.RouteListFiltered(netlink.FAMILY_V4, &netlink.Route{
+			Dst: &net.IPNet{
+				IP:   net.ParseIP("169.254.1.0"),
+				Mask: net.CIDRMask(24, 32),
+			},
+		}, netlink.RT_FILTER_DST)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(extraRoutes))
+		assert.Equal(t, net.ParseIP("169.254.1.1").String(), extraRoutes[0].Gw.String())
+
+		return nil
+	})
+
+	err = d.Check(context.Background(), &types.CheckConfig{
+		DP:              0,
+		RecordPodEvent:  nil,
+		NetNS:           containerNS,
+		HostVETHName:    "",
+		ContainerIfName: "eth0",
+		ContainerIPNet:  nil,
+		HostIPSet:       nil,
+		GatewayIP:       nil,
+		ENIIndex:        0,
+		TrunkENI:        false,
+		MTU:             1499,
+		DefaultRoute:    false,
+		MultiNetwork:    true,
+	})
+	assert.NoError(t, err)
+	// check eni
+	eniLink, err := netlink.LinkByName("eni")
+	assert.NoError(t, err)
+	assert.Equal(t, cfg.MTU, eniLink.Attrs().MTU)
+	assert.True(t, eniLink.Attrs().Flags&net.FlagUp != 0)
+
+	// tear down
+	err = utils.GenericTearDown(context.Background(), containerNS)
+	assert.NoError(t, err)
+
+	// verify cleanup
+	_, err = netlink.LinkByName(cfg.HostVETHName)
+	assert.Error(t, err)
+}


### PR DESCRIPTION
…ature

- Implement a new test case, TestVlanDataPathMultiNetwork, to verify VLAN data path setup with MultiNetwork enabled
- Create and configure network namespaces for host and container
- Add dummy interface to simulate ENI (Elastic Network Interface)
- Configure VLAN interface and verify IP assignment, routing rules, and extra routes
- Test both IPv4 and IPv6 configurations
- Verify cleanup after test completion