### PR TITLE
fix(aliyun): handle not found error for eni delete operation

### DIFF
--- a/pkg/aliyun/client/ecs.go
+++ b/pkg/aliyun/client/ecs.go
@@ -224,6 +224,11 @@ func (a *ECSService) DeleteNetworkInterface(ctx context.Context, eniID string) e
 	metric.OpenAPILatency.WithLabelValues(APIDeleteNetworkInterface, fmt.Sprint(err != nil)).Observe(metric.MsSince(start))
 	if err != nil {
 		err = apiErr.WarpError(err)
+
+		if apiErr.ErrorCodeIs(err, apiErr.ErrInvalidENINotFound) {
+			l.WithValues(LogFieldRequestID, apiErr.ErrRequestID(err)).Info("succeed, %s", apiErr.ErrInvalidENINotFound)
+			return nil
+		}
 		l.WithValues(LogFieldRequestID, apiErr.ErrRequestID(err)).Error(err, "delete eni failed")
 		return err
 	}


### PR DESCRIPTION
- Add error handling for 'InvalidEniId.NotFound' in the ENI delete operation
- Log a success message and return nil when the ENI is already deleted
- Improve error logging by including the request ID