### PR TITLE
Implement adaptive rate limiting for aliyun client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -81,6 +81,8 @@ require (
 	github.com/alibabacloud-go/endpoint-util v1.1.0 // indirect
 	github.com/alibabacloud-go/openapi-util v0.1.1 // indirect
 	github.com/alibabacloud-go/tea-utils/v2 v2.0.7 // indirect
+	github.com/aws/aws-sdk-go-v2 v1.38.3 // indirect
+	github.com/aws/smithy-go v1.23.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -166,6 +166,10 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkY
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/atomicgo/cursor v0.0.1/go.mod h1:cBON2QmmrysudxNBFthvMtN32r3jxVRIvzkUiF/RuIk=
 github.com/aws/aws-sdk-go v1.15.11/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=
+github.com/aws/aws-sdk-go-v2 v1.38.3 h1:B6cV4oxnMs45fql4yRH+/Po/YU+597zgWqvDpYMturk=
+github.com/aws/aws-sdk-go-v2 v1.38.3/go.mod h1:sDioUELIUO9Znk23YVmIk86/9DOpkbyyVb1i/gUNFXY=
+github.com/aws/smithy-go v1.23.0 h1:8n6I3gXzWJB2DxBDnfxgBaSX6oe0d/t10qGz7OKqMCE=
+github.com/aws/smithy-go v1.23.0/go.mod h1:t1ufH5HMublsJYulve2RKmHDC15xu1f26kHCp/HgceI=
 github.com/beorn7/perks v0.0.0-20160804104726-4c0e84591b9a/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=

--- a/pkg/aliyun/client/ratelimit.go
+++ b/pkg/aliyun/client/ratelimit.go
@@ -2,10 +2,11 @@ package client
 
 import (
 	"context"
-	"math"
-	"sync"
+	"fmt"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/AliyunContainerService/terway/pkg/metric"
@@ -50,199 +51,59 @@ const (
 	longThrottleLatency = 5 * time.Second
 )
 
-// adaptiveTokenBucket implements a token bucket for adaptive rate limiting
-type adaptiveTokenBucket struct {
-	capacity float64
-	tokens   float64
-	mu       sync.Mutex
+// AliyunThrottleError represents a throttle error from Aliyun API
+type AliyunThrottleError struct {
+	Code    string
+	Message string
 }
 
-func newAdaptiveTokenBucket(capacity float64) *adaptiveTokenBucket {
-	return &adaptiveTokenBucket{
-		capacity: capacity,
-		tokens:   capacity,
+func (e *AliyunThrottleError) Error() string {
+	return fmt.Sprintf("throttle error: %s - %s", e.Code, e.Message)
+}
+
+// IsThrottleError checks if an error is a throttle error
+func IsThrottleError(err error) bool {
+	if err == nil {
+		return false
 	}
-}
-
-func (tb *adaptiveTokenBucket) Retrieve(amount float64) (float64, bool) {
-	tb.mu.Lock()
-	defer tb.mu.Unlock()
-
-	if tb.tokens >= amount {
-		tb.tokens -= amount
-		return amount, true
+	
+	// Check for common Aliyun throttle error codes
+	throttleCodes := []string{
+		"Throttling",
+		"Throttling.User",
+		"Throttling.Api",
+		"Throttling.RateLimit",
+		"Throttling.Quota",
+		"ServiceUnavailable",
+		"RequestLimitExceeded",
+		"RequestThrottled",
+		"TooManyRequests",
 	}
-
-	available := tb.tokens
-	tb.tokens = 0
-	return available, false
-}
-
-func (tb *adaptiveTokenBucket) Refund(amount float64) {
-	tb.mu.Lock()
-	defer tb.mu.Unlock()
-
-	tb.tokens = math.Min(tb.capacity, tb.tokens+amount)
-}
-
-func (tb *adaptiveTokenBucket) Resize(newCapacity float64) {
-	tb.mu.Lock()
-	defer tb.mu.Unlock()
-
-	tb.capacity = newCapacity
-	if tb.tokens > newCapacity {
-		tb.tokens = newCapacity
-	}
-}
-
-// adaptiveRateLimit implements AWS-style adaptive rate limiting
-type adaptiveRateLimit struct {
-	tokenBucketEnabled bool
-
-	smooth        float64
-	beta          float64
-	scaleConstant float64
-	minFillRate   float64
-
-	fillRate         float64
-	calculatedRate   float64
-	lastRefilled     time.Time
-	measuredTxRate   float64
-	lastTxRateBucket float64
-	requestCount     int64
-	lastMaxRate      float64
-	lastThrottleTime time.Time
-	timeWindow       float64
-
-	tokenBucket *adaptiveTokenBucket
-
-	mu sync.Mutex
-}
-
-func newAdaptiveRateLimit() *adaptiveRateLimit {
-	now := time.Now()
-	return &adaptiveRateLimit{
-		smooth:        0.8,
-		beta:          0.7,
-		scaleConstant: 0.4,
-
-		minFillRate: 0.5,
-
-		lastTxRateBucket: math.Floor(timeFloat64Seconds(now)),
-		lastThrottleTime: now,
-
-		tokenBucket: newAdaptiveTokenBucket(0),
-	}
-}
-
-func (a *adaptiveRateLimit) Enable(v bool) {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-
-	a.tokenBucketEnabled = v
-}
-
-func (a *adaptiveRateLimit) AcquireToken(amount uint) (tokenAcquired bool, waitTryAgain time.Duration) {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-
-	if !a.tokenBucketEnabled {
-		return true, 0
-	}
-
-	a.tokenBucketRefill()
-
-	available, ok := a.tokenBucket.Retrieve(float64(amount))
-	if !ok {
-		waitDur := float64Seconds((float64(amount) - available) / a.fillRate)
-		return false, waitDur
-	}
-
-	return true, 0
-}
-
-func (a *adaptiveRateLimit) Update(throttled bool) {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-
-	a.updateMeasuredRate()
-
-	if throttled {
-		rateToUse := a.measuredTxRate
-		if a.tokenBucketEnabled {
-			rateToUse = math.Min(a.measuredTxRate, a.fillRate)
+	
+	errStr := err.Error()
+	for _, code := range throttleCodes {
+		if contains(errStr, code) {
+			return true
 		}
-
-		a.lastMaxRate = rateToUse
-		a.calculateTimeWindow()
-		a.lastThrottleTime = time.Now()
-		a.calculatedRate = a.cubicThrottle(rateToUse)
-		a.tokenBucketEnabled = true
-	} else {
-		a.calculateTimeWindow()
-		a.calculatedRate = a.cubicSuccess(time.Now())
 	}
-
-	newRate := math.Min(a.calculatedRate, 2*a.measuredTxRate)
-	a.tokenBucketUpdateRate(newRate)
+	
+	return false
 }
 
-func (a *adaptiveRateLimit) cubicSuccess(t time.Time) float64 {
-	dt := secondsFloat64(t.Sub(a.lastThrottleTime))
-	return (a.scaleConstant * math.Pow(dt-a.timeWindow, 3)) + a.lastMaxRate
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || 
+		(len(s) > len(substr) && (s[:len(substr)] == substr || 
+		s[len(s)-len(substr):] == substr || 
+		containsSubstring(s, substr))))
 }
 
-func (a *adaptiveRateLimit) cubicThrottle(rateToUse float64) float64 {
-	return rateToUse * a.beta
-}
-
-func (a *adaptiveRateLimit) calculateTimeWindow() {
-	a.timeWindow = math.Pow((a.lastMaxRate*(1.-a.beta))/a.scaleConstant, 1./3.)
-}
-
-func (a *adaptiveRateLimit) tokenBucketUpdateRate(newRPS float64) {
-	a.tokenBucketRefill()
-	a.fillRate = math.Max(newRPS, a.minFillRate)
-	a.tokenBucket.Resize(newRPS)
-}
-
-func (a *adaptiveRateLimit) updateMeasuredRate() {
-	now := time.Now()
-	timeBucket := math.Floor(timeFloat64Seconds(now)*2.) / 2.
-	a.requestCount++
-
-	if timeBucket > a.lastTxRateBucket {
-		currentRate := float64(a.requestCount) / (timeBucket - a.lastTxRateBucket)
-
-		a.measuredTxRate = (currentRate * a.smooth) + (a.measuredTxRate * (1. - a.smooth))
-
-		a.requestCount = 0
-		a.lastTxRateBucket = timeBucket
+func containsSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
 	}
-}
-
-func (a *adaptiveRateLimit) tokenBucketRefill() {
-	now := time.Now()
-	if a.lastRefilled.IsZero() {
-		a.lastRefilled = now
-		return
-	}
-
-	fillAmount := secondsFloat64(now.Sub(a.lastRefilled)) * a.fillRate
-	a.tokenBucket.Refund(fillAmount)
-	a.lastRefilled = now
-}
-
-func float64Seconds(v float64) time.Duration {
-	return time.Duration(v * float64(time.Second))
-}
-
-func secondsFloat64(v time.Duration) float64 {
-	return float64(v) / float64(time.Second)
-}
-
-func timeFloat64Seconds(v time.Time) float64 {
-	return float64(v.UnixNano()) / float64(time.Second)
+	return false
 }
 
 func FromMap(in map[string]int) LimitConfig {
@@ -257,27 +118,33 @@ func FromMap(in map[string]int) LimitConfig {
 }
 
 type RateLimiter struct {
-	store map[string]*adaptiveRateLimit
+	store map[string]*awsAdaptiveRetryer
+}
+
+// awsAdaptiveRetryer wraps AWS AdaptiveMode for per-API rate limiting
+type awsAdaptiveRetryer struct {
+	retryer aws.RetryerV2
 }
 
 func NewRateLimiter(cfg LimitConfig) *RateLimiter {
 	r := &RateLimiter{
-		store: make(map[string]*adaptiveRateLimit),
+		store: make(map[string]*awsAdaptiveRetryer),
 	}
 	
 	// Initialize with default limits
-	for k, v := range defaultLimit {
-		adaptiveLimit := newAdaptiveRateLimit()
-		// Set initial rate based on default limit
-		adaptiveLimit.tokenBucketUpdateRate(float64(v) / 60)
-		r.store[k] = adaptiveLimit
+	for k := range defaultLimit {
+		adaptiveRetryer := &awsAdaptiveRetryer{
+			retryer: retry.NewAdaptiveMode(),
+		}
+		r.store[k] = adaptiveRetryer
 	}
 	
 	// Override with custom config
-	for k, v := range cfg {
-		adaptiveLimit := newAdaptiveRateLimit()
-		adaptiveLimit.tokenBucketUpdateRate(v.QPS)
-		r.store[k] = adaptiveLimit
+	for k := range cfg {
+		adaptiveRetryer := &awsAdaptiveRetryer{
+			retryer: retry.NewAdaptiveMode(),
+		}
+		r.store[k] = adaptiveRetryer
 	}
 
 	return r
@@ -300,21 +167,15 @@ func (r *RateLimiter) Wait(ctx context.Context, name string) error {
 		v = r.store[""]
 	}
 	
-	// Try to acquire token
-	for {
-		acquired, waitTime := v.AcquireToken(1)
-		if acquired {
-			break
-		}
-		
-		// Wait for token to be available
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-time.After(waitTime):
-			// Continue trying
-		}
+	// Use AWS AdaptiveMode to get attempt token
+	releaseToken, err := v.retryer.GetAttemptToken(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get attempt token: %w", err)
 	}
+	
+	// Release the token immediately since we're just using it for rate limiting
+	// The actual API call will be made by the caller
+	releaseToken(nil)
 	
 	return nil
 }
@@ -328,7 +189,7 @@ func (r *RateLimiter) Wait(ctx context.Context, name string) error {
 //       // handle error
 //   }
 //   // After making the API call, update the status based on the response
-//   wasThrottled := isThrottleError(apiResponse)
+//   wasThrottled := IsThrottleError(apiResponse)
 //   r.UpdateThrottleStatus("DescribeInstances", wasThrottled)
 func (r *RateLimiter) UpdateThrottleStatus(name string, wasThrottled bool) {
 	v, ok := r.store[name]
@@ -336,5 +197,25 @@ func (r *RateLimiter) UpdateThrottleStatus(name string, wasThrottled bool) {
 		v = r.store[""]
 	}
 	
-	v.Update(wasThrottled)
+	// Create a throttle error if needed for AWS retryer
+	var err error
+	if wasThrottled {
+		err = &AliyunThrottleError{
+			Code:    "Throttling",
+			Message: "Rate limit exceeded",
+		}
+	}
+	
+	// Use AWS retryer's GetRetryToken to update the adaptive rate limiter
+	ctx := context.Background()
+	releaseToken, retryErr := v.retryer.GetRetryToken(ctx, err)
+	if retryErr != nil {
+		// Log error but don't fail the operation
+		l := logf.FromContext(ctx)
+		l.Error(retryErr, "failed to update throttle status", "api", name)
+		return
+	}
+	
+	// Release the token to complete the update
+	releaseToken(err)
 }

--- a/pkg/aliyun/client/ratelimit.go
+++ b/pkg/aliyun/client/ratelimit.go
@@ -2,9 +2,10 @@ package client
 
 import (
 	"context"
+	"math"
+	"sync"
 	"time"
 
-	"golang.org/x/time/rate"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/AliyunContainerService/terway/pkg/metric"
@@ -49,6 +50,201 @@ const (
 	longThrottleLatency = 5 * time.Second
 )
 
+// adaptiveTokenBucket implements a token bucket for adaptive rate limiting
+type adaptiveTokenBucket struct {
+	capacity float64
+	tokens   float64
+	mu       sync.Mutex
+}
+
+func newAdaptiveTokenBucket(capacity float64) *adaptiveTokenBucket {
+	return &adaptiveTokenBucket{
+		capacity: capacity,
+		tokens:   capacity,
+	}
+}
+
+func (tb *adaptiveTokenBucket) Retrieve(amount float64) (float64, bool) {
+	tb.mu.Lock()
+	defer tb.mu.Unlock()
+
+	if tb.tokens >= amount {
+		tb.tokens -= amount
+		return amount, true
+	}
+
+	available := tb.tokens
+	tb.tokens = 0
+	return available, false
+}
+
+func (tb *adaptiveTokenBucket) Refund(amount float64) {
+	tb.mu.Lock()
+	defer tb.mu.Unlock()
+
+	tb.tokens = math.Min(tb.capacity, tb.tokens+amount)
+}
+
+func (tb *adaptiveTokenBucket) Resize(newCapacity float64) {
+	tb.mu.Lock()
+	defer tb.mu.Unlock()
+
+	tb.capacity = newCapacity
+	if tb.tokens > newCapacity {
+		tb.tokens = newCapacity
+	}
+}
+
+// adaptiveRateLimit implements AWS-style adaptive rate limiting
+type adaptiveRateLimit struct {
+	tokenBucketEnabled bool
+
+	smooth        float64
+	beta          float64
+	scaleConstant float64
+	minFillRate   float64
+
+	fillRate         float64
+	calculatedRate   float64
+	lastRefilled     time.Time
+	measuredTxRate   float64
+	lastTxRateBucket float64
+	requestCount     int64
+	lastMaxRate      float64
+	lastThrottleTime time.Time
+	timeWindow       float64
+
+	tokenBucket *adaptiveTokenBucket
+
+	mu sync.Mutex
+}
+
+func newAdaptiveRateLimit() *adaptiveRateLimit {
+	now := time.Now()
+	return &adaptiveRateLimit{
+		smooth:        0.8,
+		beta:          0.7,
+		scaleConstant: 0.4,
+
+		minFillRate: 0.5,
+
+		lastTxRateBucket: math.Floor(timeFloat64Seconds(now)),
+		lastThrottleTime: now,
+
+		tokenBucket: newAdaptiveTokenBucket(0),
+	}
+}
+
+func (a *adaptiveRateLimit) Enable(v bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	a.tokenBucketEnabled = v
+}
+
+func (a *adaptiveRateLimit) AcquireToken(amount uint) (tokenAcquired bool, waitTryAgain time.Duration) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if !a.tokenBucketEnabled {
+		return true, 0
+	}
+
+	a.tokenBucketRefill()
+
+	available, ok := a.tokenBucket.Retrieve(float64(amount))
+	if !ok {
+		waitDur := float64Seconds((float64(amount) - available) / a.fillRate)
+		return false, waitDur
+	}
+
+	return true, 0
+}
+
+func (a *adaptiveRateLimit) Update(throttled bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	a.updateMeasuredRate()
+
+	if throttled {
+		rateToUse := a.measuredTxRate
+		if a.tokenBucketEnabled {
+			rateToUse = math.Min(a.measuredTxRate, a.fillRate)
+		}
+
+		a.lastMaxRate = rateToUse
+		a.calculateTimeWindow()
+		a.lastThrottleTime = time.Now()
+		a.calculatedRate = a.cubicThrottle(rateToUse)
+		a.tokenBucketEnabled = true
+	} else {
+		a.calculateTimeWindow()
+		a.calculatedRate = a.cubicSuccess(time.Now())
+	}
+
+	newRate := math.Min(a.calculatedRate, 2*a.measuredTxRate)
+	a.tokenBucketUpdateRate(newRate)
+}
+
+func (a *adaptiveRateLimit) cubicSuccess(t time.Time) float64 {
+	dt := secondsFloat64(t.Sub(a.lastThrottleTime))
+	return (a.scaleConstant * math.Pow(dt-a.timeWindow, 3)) + a.lastMaxRate
+}
+
+func (a *adaptiveRateLimit) cubicThrottle(rateToUse float64) float64 {
+	return rateToUse * a.beta
+}
+
+func (a *adaptiveRateLimit) calculateTimeWindow() {
+	a.timeWindow = math.Pow((a.lastMaxRate*(1.-a.beta))/a.scaleConstant, 1./3.)
+}
+
+func (a *adaptiveRateLimit) tokenBucketUpdateRate(newRPS float64) {
+	a.tokenBucketRefill()
+	a.fillRate = math.Max(newRPS, a.minFillRate)
+	a.tokenBucket.Resize(newRPS)
+}
+
+func (a *adaptiveRateLimit) updateMeasuredRate() {
+	now := time.Now()
+	timeBucket := math.Floor(timeFloat64Seconds(now)*2.) / 2.
+	a.requestCount++
+
+	if timeBucket > a.lastTxRateBucket {
+		currentRate := float64(a.requestCount) / (timeBucket - a.lastTxRateBucket)
+
+		a.measuredTxRate = (currentRate * a.smooth) + (a.measuredTxRate * (1. - a.smooth))
+
+		a.requestCount = 0
+		a.lastTxRateBucket = timeBucket
+	}
+}
+
+func (a *adaptiveRateLimit) tokenBucketRefill() {
+	now := time.Now()
+	if a.lastRefilled.IsZero() {
+		a.lastRefilled = now
+		return
+	}
+
+	fillAmount := secondsFloat64(now.Sub(a.lastRefilled)) * a.fillRate
+	a.tokenBucket.Refund(fillAmount)
+	a.lastRefilled = now
+}
+
+func float64Seconds(v float64) time.Duration {
+	return time.Duration(v * float64(time.Second))
+}
+
+func secondsFloat64(v time.Duration) float64 {
+	return float64(v) / float64(time.Second)
+}
+
+func timeFloat64Seconds(v time.Time) float64 {
+	return float64(v.UnixNano()) / float64(time.Second)
+}
+
 func FromMap(in map[string]int) LimitConfig {
 	l := make(LimitConfig)
 	for k, v := range in {
@@ -61,18 +257,27 @@ func FromMap(in map[string]int) LimitConfig {
 }
 
 type RateLimiter struct {
-	store map[string]*rate.Limiter
+	store map[string]*adaptiveRateLimit
 }
 
 func NewRateLimiter(cfg LimitConfig) *RateLimiter {
 	r := &RateLimiter{
-		store: make(map[string]*rate.Limiter),
+		store: make(map[string]*adaptiveRateLimit),
 	}
+	
+	// Initialize with default limits
 	for k, v := range defaultLimit {
-		r.store[k] = rate.NewLimiter(rate.Limit(float64(v)/60), v)
+		adaptiveLimit := newAdaptiveRateLimit()
+		// Set initial rate based on default limit
+		adaptiveLimit.tokenBucketUpdateRate(float64(v) / 60)
+		r.store[k] = adaptiveLimit
 	}
+	
+	// Override with custom config
 	for k, v := range cfg {
-		r.store[k] = rate.NewLimiter(rate.Limit(v.QPS), v.Burst)
+		adaptiveLimit := newAdaptiveRateLimit()
+		adaptiveLimit.tokenBucketUpdateRate(v.QPS)
+		r.store[k] = adaptiveLimit
 	}
 
 	return r
@@ -89,9 +294,47 @@ func (r *RateLimiter) Wait(ctx context.Context, name string) error {
 			l.Info("client rate limit", "api", name, "took", took.Seconds())
 		}
 	}()
+	
 	v, ok := r.store[name]
-	if ok {
-		return v.Wait(ctx)
+	if !ok {
+		v = r.store[""]
 	}
-	return r.store[""].Wait(ctx)
+	
+	// Try to acquire token
+	for {
+		acquired, waitTime := v.AcquireToken(1)
+		if acquired {
+			break
+		}
+		
+		// Wait for token to be available
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(waitTime):
+			// Continue trying
+		}
+	}
+	
+	return nil
+}
+
+// UpdateThrottleStatus should be called after each API call to update the adaptive rate limiter
+// based on whether the call was throttled or not. This is crucial for the adaptive behavior to work.
+// 
+// Example usage:
+//   err := r.Wait(ctx, "DescribeInstances")
+//   if err != nil {
+//       // handle error
+//   }
+//   // After making the API call, update the status based on the response
+//   wasThrottled := isThrottleError(apiResponse)
+//   r.UpdateThrottleStatus("DescribeInstances", wasThrottled)
+func (r *RateLimiter) UpdateThrottleStatus(name string, wasThrottled bool) {
+	v, ok := r.store[name]
+	if !ok {
+		v = r.store[""]
+	}
+	
+	v.Update(wasThrottled)
 }


### PR DESCRIPTION
Replace fixed rate limiting with an AWS-inspired adaptive algorithm to dynamically adjust to OpenAPI rate limits.

The original `golang.org/x/time/rate` based limiter used static QPS and Burst values, which could lead to either underutilization or excessive throttling when API limits fluctuate or are unknown. The new adaptive implementation dynamically adjusts the rate based on feedback (whether an API call was throttled or successful), using a cubic algorithm to smoothly increase or decrease the request rate, thereby improving resilience and efficiency. A new `UpdateThrottleStatus` method is introduced to provide this feedback.

---
<a href="https://cursor.com/background-agent?bcId=bc-3771b31d-53fb-4579-a985-efd231c27dc0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3771b31d-53fb-4579-a985-efd231c27dc0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

