### PR TITLE
feat(terway): add WriteCNIConfFirst feature gate

### DIFF
--- a/cmd/terway/main.go
+++ b/cmd/terway/main.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/klog/v2/textlogger"
 
 	_ "go.uber.org/automaxprocs"
@@ -31,6 +33,7 @@ var (
 	daemonMode     string
 	readonlyListen string
 	configFilePath string
+	featureGates   map[string]bool
 )
 
 func main() {
@@ -41,6 +44,8 @@ func main() {
 	fs.StringVar(&logLevel, "log-level", "info", "terway log level")
 	fs.StringVar(&readonlyListen, "readonly-listen", utils.NormalizePath(debugSocketPath), "terway readonly listen")
 	fs.StringVar(&configFilePath, "config", "/etc/eni/eni.json", "terway config file")
+	fs.Var(cliflag.NewMapStringBool(&featureGates), "feature-gates", "A set of key=value pairs that describe feature gates for alpha/experimental features. "+
+		"Options are:\n"+strings.Join(utilfeature.DefaultFeatureGate.KnownFeatures(), "\n"))
 	ctrl.RegisterFlags(fs)
 
 	err := fs.Parse(os.Args[1:])
@@ -55,6 +60,12 @@ func main() {
 	ctrl.SetLogger(textlogger.NewLogger(textlogger.NewConfig(opts...)))
 
 	log.Info(version.Version)
+
+	err = utilfeature.DefaultMutableFeatureGate.SetFromMap(featureGates)
+	if err != nil {
+		log.Error(err, "unable to set feature gates")
+		os.Exit(1)
+	}
 
 	ctx := ctrl.SetupSignalHandler()
 	ctx = ctrl.LoggerInto(ctx, ctrl.Log)

--- a/daemon/server.go
+++ b/daemon/server.go
@@ -17,9 +17,11 @@ import (
 	"time"
 
 	"github.com/AliyunContainerService/terway/pkg/aliyun/metadata"
+	terwayfeature "github.com/AliyunContainerService/terway/pkg/feature"
 	"github.com/alexflint/go-filemutex"
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/util/wait"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/AliyunContainerService/terway/pkg/metric"
@@ -166,6 +168,11 @@ func newUnixListener(addr string) (net.Listener, error) {
 }
 
 func ensureCNIConfig() error {
+	if utilfeature.DefaultFeatureGate.Enabled(terwayfeature.WriteCNIConfFirst) {
+		serviceLog.Info("WriteCNIConfFirst is enabled, skip write cni conf")
+		return nil
+	}
+
 	src, err := os.Open(filepath.Join(tmpCNIConfigPath, cinConfFile))
 	if err != nil {
 		return err

--- a/hack/init.sh
+++ b/hack/init.sh
@@ -17,6 +17,13 @@ terway-cli cni --output /etc/cni/net.d/10-terway.conflist "$EXTRA_FLAGS"
 terway-cli nodeconfig "$EXTRA_FLAGS"
 cat /etc/cni/net.d/10-terway.conflist
 
+# Check if WriteCNIConfFirst is enabled
+if echo "$EXTRA_FLAGS" | grep "WriteCNIConfFirst=true" >/dev/null; then
+  echo "WriteCNIConfFirst is enabled, copy 10-terway.conflist to host"
+  cp /etc/cni/net.d/10-terway.conflist /host/etc/cni/net.d/10-terway.conflist
+  rm -f /host/etc/cni/net.d/10-terway.conf
+fi
+
 node_capabilities=/var/run/eni/node_capabilities
 if [ ! -f "$node_capabilities" ]; then
   echo "Init node capabilities"

--- a/pkg/feature/feature.go
+++ b/pkg/feature/feature.go
@@ -18,10 +18,13 @@ const (
 	EFLO featuregate.Feature = "EFLO"
 
 	KubeProxyReplacement featuregate.Feature = "KubeProxyReplacement"
+
+	WriteCNIConfFirst featuregate.Feature = "WriteCNIConfFirst"
 )
 
 var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	AutoDataPathV2:       {Default: true, PreRelease: featuregate.Alpha},
 	EFLO:                 {Default: true, PreRelease: featuregate.Alpha},
 	KubeProxyReplacement: {Default: false, PreRelease: featuregate.Alpha},
+	WriteCNIConfFirst:    {Default: false, PreRelease: featuregate.Alpha},
 }


### PR DESCRIPTION
- Introduce new feature gate for writing CNI configuration first
- Implement feature gate parsing and setting in main.go
- Add condition to skip CNI configuration writing in server.go
- Update hack/init.sh script to handle WriteCNIConfFirst flag
- Register WriteCNIConfFirst feature in feature.go