### PR TITLE
fix(vlan): use ETH_P_IPV6 for IPv6 VLAN push TC filter in EnsureVlanTag

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -527,6 +527,9 @@ func (n *networkService) gcPods(ctx context.Context) error {
 			if pod.PodIPs.IPv4 != nil {
 				existIPs.Insert(pod.PodIPs.IPv4.String())
 			}
+			if pod.PodIPs.IPv6 != nil {
+				existIPs.Insert(pod.PodIPs.IPv6.String())
+			}
 		}
 	}
 
@@ -544,6 +547,9 @@ func (n *networkService) gcPods(ctx context.Context) error {
 			}
 			if podRes.PodInfo.PodIPs.IPv4 != nil {
 				existIPs.Insert(podRes.PodInfo.PodIPs.IPv4.String())
+			}
+			if podRes.PodInfo.PodIPs.IPv6 != nil {
+				existIPs.Insert(podRes.PodInfo.PodIPs.IPv6.String())
 			}
 		}
 

--- a/daemon/daemon_linux.go
+++ b/daemon/daemon_linux.go
@@ -58,42 +58,39 @@ func gcLeakedRules(existIP sets.Set[string]) {
 
 func gcRoutes(links []netlink.Link, existIP sets.Set[string]) {
 	for _, link := range links {
-		routes, err := netlink.RouteList(link, netlink.FAMILY_V4)
-		if err != nil {
-			serviceLog.Error(err, "gc list route", "link", link)
-			return
-		}
-		for _, route := range routes {
-			if route.Dst == nil {
-				continue
-			}
-			// if not found
-			if existIP.Has(route.Dst.IP.String()) {
-				continue
-			}
-
-			serviceLog.Info("gc del route", "route", route)
-			err = netlink.RouteDel(&route)
+		for _, family := range []int{netlink.FAMILY_V4, netlink.FAMILY_V6} {
+			routes, err := netlink.RouteList(link, family)
 			if err != nil {
-				serviceLog.Error(err, "gc del route", "route", route)
-				return
+				serviceLog.Error(err, "gc list route", "link", link, "family", family)
+				continue
+			}
+			for _, route := range routes {
+				if route.Dst == nil {
+					continue
+				}
+				if existIP.Has(route.Dst.IP.String()) {
+					continue
+				}
+
+				serviceLog.Info("gc del route", "route", route)
+				err = netlink.RouteDel(&route)
+				if err != nil {
+					serviceLog.Error(err, "gc del route", "route", route)
+				}
 			}
 		}
 	}
 }
 
 func gcTCFilters(links []netlink.Link, existIP sets.Set[string]) {
-	// map ip to u32
-	toU32List := lo.Map(existIP.UnsortedList(), func(item string, index int) uint32 {
+	u32IPv4Map := make(map[uint32]struct{})
+	for _, item := range existIP.UnsortedList() {
 		ip := net.ParseIP(item)
-		if ip == nil {
-			return 0
+		if ip == nil || ip.To4() == nil {
+			continue
 		}
-		return binary.BigEndian.Uint32(ip.To4())
-	})
-	u32IPMap := lo.SliceToMap(toU32List, func(item uint32) (uint32, struct{}) {
-		return item, struct{}{}
-	})
+		u32IPv4Map[binary.BigEndian.Uint32(ip.To4())] = struct{}{}
+	}
 
 	for _, link := range links {
 		filters, err := netlink.FilterList(link, netlink.HANDLE_MIN_EGRESS)
@@ -106,25 +103,29 @@ func gcTCFilters(links []netlink.Link, existIP sets.Set[string]) {
 			if !ok {
 				continue
 			}
-			if u32.Priority != 50001 {
-				continue
-			}
 
-			if u32.Sel == nil || len(u32.Sel.Keys) != 1 {
-				continue
-			}
-			if len(u32.Actions) != 1 {
+			if u32.Sel == nil || len(u32.Actions) != 1 {
 				continue
 			}
 			_, ok = u32.Actions[0].(*netlink.VlanAction)
 			if !ok {
 				continue
 			}
-			if u32.Sel.Keys[0].Off != 12 {
-				continue
-			}
-			_, ok = u32IPMap[u32.Sel.Keys[0].Val]
-			if ok {
+
+			switch {
+			case u32.Priority == 50001 && len(u32.Sel.Keys) == 1 && u32.Sel.Keys[0].Off == 12:
+				// IPv4 VLAN push filter: single key at offset 12 (src IPv4)
+				if _, alive := u32IPv4Map[u32.Sel.Keys[0].Val]; alive {
+					continue
+				}
+			case len(u32.Sel.Keys) == 4 && (u32.Priority == 50002 || u32.Priority == 50001):
+				// IPv6 VLAN push filter: 4 keys at offsets 8,12,16,20.
+				// New filters use priority 50002; legacy filters used 50001.
+				ip := ipv6FromU32Keys(u32.Sel.Keys)
+				if ip == nil || existIP.Has(ip.String()) {
+					continue
+				}
+			default:
 				continue
 			}
 
@@ -135,4 +136,31 @@ func gcTCFilters(links []netlink.Link, existIP sets.Set[string]) {
 			}
 		}
 	}
+}
+
+// ipv6FromU32Keys reconstructs an IPv6 src address from U32 match keys.
+// The keys must cover exactly offsets 8, 12, 16, 20 (the IPv6 src field) once
+// each; otherwise nil is returned so the caller will not GC unrelated filters.
+func ipv6FromU32Keys(keys []netlink.TcU32Key) net.IP {
+	if len(keys) != 4 {
+		return nil
+	}
+	ip := make(net.IP, 16)
+	var seen uint8
+	for _, key := range keys {
+		byteOff := int(key.Off) - 8
+		if byteOff < 0 || byteOff%4 != 0 || byteOff >= 16 {
+			return nil
+		}
+		bit := uint8(1) << (byteOff / 4)
+		if seen&bit != 0 {
+			return nil
+		}
+		seen |= bit
+		binary.BigEndian.PutUint32(ip[byteOff:byteOff+4], key.Val)
+	}
+	if seen != 0x0f {
+		return nil
+	}
+	return ip
 }

--- a/daemon/daemon_linux_test.go
+++ b/daemon/daemon_linux_test.go
@@ -4,6 +4,7 @@ package daemon
 
 import (
 	"context"
+	"encoding/binary"
 	"net"
 	"runtime"
 	"testing"
@@ -13,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/AliyunContainerService/terway/types"
@@ -570,6 +572,270 @@ func TestGcTCFiltersKeepsExistingIP(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotEmpty(t, filtersAfter, "Filter for existing IP should be kept")
 
+		return nil
+	})
+	require.NoError(t, err)
+}
+
+// ipv6VlanFilter builds the 4-key U32 egress filter that EnsureVlanTag creates for an IPv6 src address.
+// Keys are at offsets 8,12,16,20 in the IPv6 header (source address field).
+func ipv6VlanFilter(linkIndex int, ip net.IP, vid uint16) *netlink.U32 {
+	ip = ip.To16()
+	vlanAct := netlink.NewVlanKeyAction()
+	vlanAct.Attrs().Action = netlink.TC_ACT_PIPE
+	vlanAct.Action = netlink.TCA_VLAN_KEY_PUSH
+	vlanAct.Vid = vid
+
+	keys := make([]netlink.TcU32Key, 4)
+	for i := 0; i < 4; i++ {
+		keys[i] = netlink.TcU32Key{
+			Mask: 0xffffffff,
+			Val:  binary.BigEndian.Uint32(ip[i*4 : i*4+4]),
+			Off:  int32(8 + i*4),
+		}
+	}
+	return &netlink.U32{
+		FilterAttrs: netlink.FilterAttrs{
+			LinkIndex: linkIndex,
+			Parent:    netlink.HANDLE_MIN_EGRESS,
+			Priority:  50002,
+			Protocol:  uint16(unix.ETH_P_IPV6),
+		},
+		Sel: &netlink.TcU32Sel{
+			Nkeys: 4,
+			Flags: netlink.TC_U32_TERMINAL,
+			Keys:  keys,
+		},
+		Actions: []netlink.Action{vlanAct},
+	}
+}
+
+func addClsact(t *testing.T, link netlink.Link) {
+	t.Helper()
+	qdisc := &netlink.GenericQdisc{
+		QdiscAttrs: netlink.QdiscAttrs{
+			LinkIndex: link.Attrs().Index,
+			Handle:    netlink.MakeHandle(0xffff, 0),
+			Parent:    netlink.HANDLE_CLSACT,
+		},
+		QdiscType: "clsact",
+	}
+	require.NoError(t, netlink.QdiscAdd(qdisc))
+}
+
+// TestGcTCFilters_IPv6_GCsStaleFilter verifies that an IPv6 VLAN push filter
+// at priority 50002 is deleted when its src IP is absent from existIP.
+func TestGcTCFilters_IPv6_GCsStaleFilter(t *testing.T) {
+	testNS := setupTestNS(t)
+	defer cleanupTestNS(t, testNS)
+
+	err := testNS.Do(func(ns.NetNS) error {
+		dummy := &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: "gc-v6-stale"}}
+		require.NoError(t, netlink.LinkAdd(dummy))
+		link, err := netlink.LinkByName("gc-v6-stale")
+		require.NoError(t, err)
+		require.NoError(t, netlink.LinkSetUp(link))
+		addClsact(t, link)
+
+		podIP := net.ParseIP("fd00::1")
+		require.NoError(t, netlink.FilterAdd(ipv6VlanFilter(link.Attrs().Index, podIP, 100)))
+
+		filtersBefore, err := netlink.FilterList(link, netlink.HANDLE_MIN_EGRESS)
+		require.NoError(t, err)
+		assert.NotEmpty(t, filtersBefore)
+
+		// fd00::1 NOT in existIP → filter should be GC'd
+		gcTCFilters([]netlink.Link{link}, sets.New[string]("fd00::2"))
+
+		filtersAfter, err := netlink.FilterList(link, netlink.HANDLE_MIN_EGRESS)
+		require.NoError(t, err)
+		assert.Empty(t, filtersAfter, "stale IPv6 VLAN filter should be deleted")
+		return nil
+	})
+	require.NoError(t, err)
+}
+
+// TestGcTCFilters_IPv6_KeepsLiveFilter verifies that an IPv6 VLAN push filter
+// at priority 50002 is retained when its src IP is present in existIP.
+func TestGcTCFilters_IPv6_KeepsLiveFilter(t *testing.T) {
+	testNS := setupTestNS(t)
+	defer cleanupTestNS(t, testNS)
+
+	err := testNS.Do(func(ns.NetNS) error {
+		dummy := &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: "gc-v6-live"}}
+		require.NoError(t, netlink.LinkAdd(dummy))
+		link, err := netlink.LinkByName("gc-v6-live")
+		require.NoError(t, err)
+		require.NoError(t, netlink.LinkSetUp(link))
+		addClsact(t, link)
+
+		podIP := net.ParseIP("fd00::1")
+		require.NoError(t, netlink.FilterAdd(ipv6VlanFilter(link.Attrs().Index, podIP, 100)))
+
+		// fd00::1 IS in existIP → filter should be kept
+		gcTCFilters([]netlink.Link{link}, sets.New[string]("fd00::1"))
+
+		filtersAfter, err := netlink.FilterList(link, netlink.HANDLE_MIN_EGRESS)
+		require.NoError(t, err)
+		assert.NotEmpty(t, filtersAfter, "live IPv6 VLAN filter should be kept")
+		return nil
+	})
+	require.NoError(t, err)
+}
+
+// TestGcTCFilters_DualStack_SelectiveGC verifies that with both an IPv4 filter
+// (priority 50001) and an IPv6 filter (priority 50002), only the stale one is removed.
+func TestGcTCFilters_DualStack_SelectiveGC(t *testing.T) {
+	testNS := setupTestNS(t)
+	defer cleanupTestNS(t, testNS)
+
+	err := testNS.Do(func(ns.NetNS) error {
+		dummy := &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: "gc-dual"}}
+		require.NoError(t, netlink.LinkAdd(dummy))
+		link, err := netlink.LinkByName("gc-dual")
+		require.NoError(t, err)
+		require.NoError(t, netlink.LinkSetUp(link))
+		addClsact(t, link)
+
+		// IPv4 filter for 192.168.1.2 (alive) at priority 50001
+		vlanActV4 := netlink.NewVlanKeyAction()
+		vlanActV4.Attrs().Action = netlink.TC_ACT_PIPE
+		vlanActV4.Action = netlink.TCA_VLAN_KEY_PUSH
+		vlanActV4.Vid = 100
+		v4Filter := &netlink.U32{
+			FilterAttrs: netlink.FilterAttrs{
+				LinkIndex: link.Attrs().Index,
+				Parent:    netlink.HANDLE_MIN_EGRESS,
+				Priority:  50001,
+				Protocol:  uint16(unix.ETH_P_IP),
+			},
+			Sel: &netlink.TcU32Sel{
+				Nkeys: 1,
+				Flags: netlink.TC_U32_TERMINAL,
+				Keys:  []netlink.TcU32Key{{Mask: 0xffffffff, Val: 0xc0a80102, Off: 12}},
+			},
+			Actions: []netlink.Action{vlanActV4},
+		}
+		require.NoError(t, netlink.FilterAdd(v4Filter))
+
+		// IPv6 filter for fd00::1 (stale) at priority 50002
+		require.NoError(t, netlink.FilterAdd(ipv6VlanFilter(link.Attrs().Index, net.ParseIP("fd00::1"), 100)))
+
+		// existIP: IPv4 192.168.1.2 alive, IPv6 fd00::1 absent
+		existIP := sets.New[string]("192.168.1.2")
+		gcTCFilters([]netlink.Link{link}, existIP)
+
+		filters, err := netlink.FilterList(link, netlink.HANDLE_MIN_EGRESS)
+		require.NoError(t, err)
+
+		var v4Alive, v6Alive bool
+		for _, f := range filters {
+			u32, ok := f.(*netlink.U32)
+			if !ok {
+				continue
+			}
+			switch u32.Attrs().Priority {
+			case 50001:
+				v4Alive = true
+			case 50002:
+				v6Alive = true
+			}
+		}
+		assert.True(t, v4Alive, "IPv4 filter for live IP should be kept")
+		assert.False(t, v6Alive, "IPv6 filter for stale IP should be deleted")
+		return nil
+	})
+	require.NoError(t, err)
+}
+
+// legacyIPv6VlanFilter builds an old-style IPv6 VLAN filter that uses
+// ETH_P_IP and priority 50001, as older builds created.
+func legacyIPv6VlanFilter(linkIndex int, ip net.IP, vid uint16) *netlink.U32 {
+	ip = ip.To16()
+	vlanAct := netlink.NewVlanKeyAction()
+	vlanAct.Attrs().Action = netlink.TC_ACT_PIPE
+	vlanAct.Action = netlink.TCA_VLAN_KEY_PUSH
+	vlanAct.Vid = vid
+
+	keys := make([]netlink.TcU32Key, 4)
+	for i := 0; i < 4; i++ {
+		keys[i] = netlink.TcU32Key{
+			Mask: 0xffffffff,
+			Val:  binary.BigEndian.Uint32(ip[i*4 : i*4+4]),
+			Off:  int32(8 + i*4),
+		}
+	}
+	return &netlink.U32{
+		FilterAttrs: netlink.FilterAttrs{
+			LinkIndex: linkIndex,
+			Parent:    netlink.HANDLE_MIN_EGRESS,
+			Priority:  50001,
+			Protocol:  uint16(unix.ETH_P_IP),
+		},
+		Sel: &netlink.TcU32Sel{
+			Nkeys: 4,
+			Flags: netlink.TC_U32_TERMINAL,
+			Keys:  keys,
+		},
+		Actions: []netlink.Action{vlanAct},
+	}
+}
+
+// TestGcTCFilters_LegacyIPv6_GCsStaleFilter verifies that legacy IPv6 VLAN
+// filters (priority 50001, ETH_P_IP, 4 keys) are GC'd when the IP is stale.
+func TestGcTCFilters_LegacyIPv6_GCsStaleFilter(t *testing.T) {
+	testNS := setupTestNS(t)
+	defer cleanupTestNS(t, testNS)
+
+	err := testNS.Do(func(ns.NetNS) error {
+		dummy := &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: "gc-legacy-v6"}}
+		require.NoError(t, netlink.LinkAdd(dummy))
+		link, err := netlink.LinkByName("gc-legacy-v6")
+		require.NoError(t, err)
+		require.NoError(t, netlink.LinkSetUp(link))
+		addClsact(t, link)
+
+		podIP := net.ParseIP("fd00::1")
+		require.NoError(t, netlink.FilterAdd(legacyIPv6VlanFilter(link.Attrs().Index, podIP, 100)))
+
+		filtersBefore, err := netlink.FilterList(link, netlink.HANDLE_MIN_EGRESS)
+		require.NoError(t, err)
+		assert.NotEmpty(t, filtersBefore)
+
+		// fd00::1 NOT in existIP → legacy filter should be GC'd
+		gcTCFilters([]netlink.Link{link}, sets.New[string]("fd00::2"))
+
+		filtersAfter, err := netlink.FilterList(link, netlink.HANDLE_MIN_EGRESS)
+		require.NoError(t, err)
+		assert.Empty(t, filtersAfter, "stale legacy IPv6 VLAN filter should be deleted")
+		return nil
+	})
+	require.NoError(t, err)
+}
+
+// TestGcTCFilters_LegacyIPv6_KeepsLiveFilter verifies that legacy IPv6 VLAN
+// filters are retained when the IP is still alive.
+func TestGcTCFilters_LegacyIPv6_KeepsLiveFilter(t *testing.T) {
+	testNS := setupTestNS(t)
+	defer cleanupTestNS(t, testNS)
+
+	err := testNS.Do(func(ns.NetNS) error {
+		dummy := &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: "gc-legacy-v6-k"}}
+		require.NoError(t, netlink.LinkAdd(dummy))
+		link, err := netlink.LinkByName("gc-legacy-v6-k")
+		require.NoError(t, err)
+		require.NoError(t, netlink.LinkSetUp(link))
+		addClsact(t, link)
+
+		podIP := net.ParseIP("fd00::1")
+		require.NoError(t, netlink.FilterAdd(legacyIPv6VlanFilter(link.Attrs().Index, podIP, 100)))
+
+		// fd00::1 IS in existIP → legacy filter should be kept
+		gcTCFilters([]netlink.Link{link}, sets.New[string]("fd00::1"))
+
+		filtersAfter, err := netlink.FilterList(link, netlink.HANDLE_MIN_EGRESS)
+		require.NoError(t, err)
+		assert.NotEmpty(t, filtersAfter, "live legacy IPv6 VLAN filter should be kept")
 		return nil
 	})
 	require.NoError(t, err)

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -294,8 +294,7 @@ func TestCleanRuntimeNode(t *testing.T) {
 						actualInfo, exists := actualStatus.Status[statusType]
 						if expectedInfo != nil {
 							assert.True(t, exists, "Status %s should exist for pod %s", statusType, uid)
-							assert.Equal(t, expectedInfo.LastUpdateTime.Time.Truncate(time.Second),
-								actualInfo.LastUpdateTime.Time.Truncate(time.Second))
+							assert.WithinDuration(t, expectedInfo.LastUpdateTime.Time, actualInfo.LastUpdateTime.Time, 3*time.Second)
 						}
 					}
 				}

--- a/pkg/tc/u32.go
+++ b/pkg/tc/u32.go
@@ -19,11 +19,16 @@ import (
 
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netlink/nl"
-	"golang.org/x/sys/unix"
 )
 
 // FilterBySrcIP found u32 filter by pod ip
-// used for prio only
+// used for prio only.
+//
+// Note: match keys are family-specific (IPv4 → 1 key at off=12; IPv6 → 4 keys
+// at off=8/12/16/20), so the key set alone disambiguates address family. We
+// intentionally do not compare u32.Protocol here so this lookup tolerates
+// existing filters created with either ETH_P_IP or ETH_P_IPV6 (older builds
+// always used ETH_P_IP for both families).
 func FilterBySrcIP(link netlink.Link, parent uint32, ipNet *net.IPNet) (*netlink.U32, error) {
 	filters, err := netlink.FilterList(link, parent)
 	if err != nil {
@@ -40,9 +45,7 @@ OUT:
 		if !ok {
 			continue
 		}
-		if u32.Attrs().LinkIndex != link.Attrs().Index ||
-			u32.Protocol != unix.ETH_P_IP ||
-			u32.Sel == nil {
+		if u32.Attrs().LinkIndex != link.Attrs().Index || u32.Sel == nil {
 			continue
 		}
 

--- a/pkg/tc/u32_test.go
+++ b/pkg/tc/u32_test.go
@@ -265,7 +265,7 @@ func TestFilterBySrcIP_WithFilters(t *testing.T) {
 		assert.Nil(t, foundFilter)
 	})
 
-	// Test 3: U32 filter with wrong protocol (should skip)
+	// Test 3: U32 filter with mismatched protocol (backward compat: match by keys only)
 	t.Run("u32 filter with wrong protocol", func(t *testing.T) {
 		_, ipNet, _ := net.ParseCIDR("192.168.3.100/32")
 
@@ -286,10 +286,12 @@ func TestFilterBySrcIP_WithFilters(t *testing.T) {
 		})
 		defer patches.Reset()
 
-		// Should not find filter with wrong protocol
+		// Backward compat: FilterBySrcIP matches by keys only, ignoring protocol.
+		// Old builds always used ETH_P_IP even for IPv6, so we must find and clean
+		// those filters regardless of the protocol field.
 		foundFilter, err := FilterBySrcIP(link, netlink.MakeHandle(1, 0), ipNet)
 		require.NoError(t, err)
-		assert.Nil(t, foundFilter)
+		assert.NotNil(t, foundFilter)
 	})
 
 	// Test 4: U32 filter with nil Sel (should skip)

--- a/plugin/driver/utils/utils_linux.go
+++ b/plugin/driver/utils/utils_linux.go
@@ -473,6 +473,15 @@ func EnsureVlanTag(ctx context.Context, link netlink.Link, ipNetSet *terwayTypes
 	}
 
 	exec := func(ipNet *net.IPNet) error {
+		proto := uint16(unix.ETH_P_IP)
+		priority := uint16(50001)
+		if ipNet.IP.To4() == nil {
+			proto = uint16(unix.ETH_P_IPV6)
+			// IPv6 must use a separate priority — Linux TC U32 hash tables at a
+			// given priority are protocol-specific and cannot mix ETH_P_IP and
+			// ETH_P_IPV6 at the same priority slot.
+			priority = 50002
+		}
 		vlanAct := netlink.NewVlanKeyAction()
 		vlanAct.Attrs().Action = netlink.TC_ACT_PIPE
 		vlanAct.Action = netlink.TCA_VLAN_KEY_PUSH
@@ -481,8 +490,8 @@ func EnsureVlanTag(ctx context.Context, link netlink.Link, ipNetSet *terwayTypes
 			FilterAttrs: netlink.FilterAttrs{
 				LinkIndex: link.Attrs().Index,
 				Parent:    netlink.HANDLE_MIN_EGRESS,
-				Priority:  50001,
-				Protocol:  uint16(unix.ETH_P_IP),
+				Priority:  priority,
+				Protocol:  proto,
 			},
 			Actions: []netlink.Action{vlanAct},
 		}
@@ -493,7 +502,7 @@ func EnsureVlanTag(ctx context.Context, link netlink.Link, ipNetSet *terwayTypes
 			if !ok {
 				continue
 			}
-			if u32.Attrs().LinkIndex != link.Attrs().Index || u32.Attrs().Protocol != unix.ETH_P_IP || len(u32.Actions) == 0 || u32.Sel == nil {
+			if u32.Attrs().LinkIndex != link.Attrs().Index || u32.Attrs().Protocol != proto || len(u32.Actions) == 0 || u32.Sel == nil {
 				continue
 			}
 			act, ok := u32.Actions[0].(*netlink.VlanAction)
@@ -527,6 +536,9 @@ func EnsureVlanTag(ctx context.Context, link netlink.Link, ipNetSet *terwayTypes
 	}
 	if ipNetSet.IPv6 != nil {
 		err = exec(NewIPNetWithMaxMask(ipNetSet.IPv6))
+		if err != nil {
+			return err
+		}
 	}
 	return err
 }

--- a/plugin/driver/utils/utils_linux_unit_test.go
+++ b/plugin/driver/utils/utils_linux_unit_test.go
@@ -12,7 +12,9 @@ import (
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/containernetworking/plugins/pkg/testutils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 	k8snet "k8s.io/apimachinery/pkg/util/net"
 
 	terwayTypes "github.com/AliyunContainerService/terway/types"
@@ -987,4 +989,217 @@ func TestDelLinkByName_OtherError(t *testing.T) {
 	// Should return error for non-LinkNotFoundError
 	assert.Error(t, err)
 	_ = linkByNameErr
+}
+
+// TestEnsureVlanTag verifies that EnsureVlanTag creates TC egress VLAN push filters
+// with the correct protocol and priority for each IP family.
+func TestEnsureVlanTag(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("Skipping test that requires root privileges")
+	}
+
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	testNS, err := testutils.NewNS()
+	require.NoError(t, err)
+	defer testNS.Close()
+
+	const vid = uint16(100)
+
+	ipv4Net := &net.IPNet{IP: net.ParseIP("10.0.0.1").To4(), Mask: net.CIDRMask(32, 32)}
+	ipv6Net := &net.IPNet{IP: net.ParseIP("fd00::1"), Mask: net.CIDRMask(128, 128)}
+
+	t.Run("IPv4 only", func(t *testing.T) {
+		require.NoError(t, testNS.Do(func(_ ns.NetNS) error {
+			link, err := createDummy(t, "vlan-v4")
+			if err != nil {
+				return err
+			}
+			defer netlink.LinkDel(link)
+
+			ipNetSet := &terwayTypes.IPNetSet{IPv4: ipv4Net}
+			if err := EnsureVlanTag(context.Background(), link, ipNetSet, vid); err != nil {
+				return err
+			}
+
+			filters, err := netlink.FilterList(link, netlink.HANDLE_MIN_EGRESS)
+			if err != nil {
+				return err
+			}
+			found := findVlanFilter(filters, uint16(unix.ETH_P_IP), 50001, vid)
+			if !found {
+				return fmt.Errorf("expected IPv4 VLAN push filter at priority 50001 with ETH_P_IP")
+			}
+			return nil
+		}))
+	})
+
+	t.Run("IPv6 only", func(t *testing.T) {
+		require.NoError(t, testNS.Do(func(_ ns.NetNS) error {
+			link, err := createDummy(t, "vlan-v6")
+			if err != nil {
+				return err
+			}
+			defer netlink.LinkDel(link)
+
+			ipNetSet := &terwayTypes.IPNetSet{IPv6: ipv6Net}
+			if err := EnsureVlanTag(context.Background(), link, ipNetSet, vid); err != nil {
+				return err
+			}
+
+			filters, err := netlink.FilterList(link, netlink.HANDLE_MIN_EGRESS)
+			if err != nil {
+				return err
+			}
+			found := findVlanFilter(filters, uint16(unix.ETH_P_IPV6), 50002, vid)
+			if !found {
+				return fmt.Errorf("expected IPv6 VLAN push filter at priority 50002 with ETH_P_IPV6")
+			}
+			return nil
+		}))
+	})
+
+	t.Run("Dual stack", func(t *testing.T) {
+		require.NoError(t, testNS.Do(func(_ ns.NetNS) error {
+			link, err := createDummy(t, "vlan-dual")
+			if err != nil {
+				return err
+			}
+			defer netlink.LinkDel(link)
+
+			ipNetSet := &terwayTypes.IPNetSet{IPv4: ipv4Net, IPv6: ipv6Net}
+			if err := EnsureVlanTag(context.Background(), link, ipNetSet, vid); err != nil {
+				return err
+			}
+
+			filters, err := netlink.FilterList(link, netlink.HANDLE_MIN_EGRESS)
+			if err != nil {
+				return err
+			}
+			if !findVlanFilter(filters, uint16(unix.ETH_P_IP), 50001, vid) {
+				return fmt.Errorf("expected IPv4 VLAN push filter at priority 50001")
+			}
+			if !findVlanFilter(filters, uint16(unix.ETH_P_IPV6), 50002, vid) {
+				return fmt.Errorf("expected IPv6 VLAN push filter at priority 50002")
+			}
+			return nil
+		}))
+	})
+
+	t.Run("Idempotent: calling twice does not duplicate filters", func(t *testing.T) {
+		require.NoError(t, testNS.Do(func(_ ns.NetNS) error {
+			link, err := createDummy(t, "vlan-idem")
+			if err != nil {
+				return err
+			}
+			defer netlink.LinkDel(link)
+
+			ipNetSet := &terwayTypes.IPNetSet{IPv4: ipv4Net, IPv6: ipv6Net}
+			for i := 0; i < 2; i++ {
+				if err := EnsureVlanTag(context.Background(), link, ipNetSet, vid); err != nil {
+					return fmt.Errorf("call %d: %w", i+1, err)
+				}
+			}
+
+			filters, err := netlink.FilterList(link, netlink.HANDLE_MIN_EGRESS)
+			if err != nil {
+				return err
+			}
+			v4Count := countVlanFilters(filters, uint16(unix.ETH_P_IP), 50001)
+			v6Count := countVlanFilters(filters, uint16(unix.ETH_P_IPV6), 50002)
+			if v4Count != 1 {
+				return fmt.Errorf("expected exactly 1 IPv4 VLAN filter, got %d", v4Count)
+			}
+			if v6Count != 1 {
+				return fmt.Errorf("expected exactly 1 IPv6 VLAN filter, got %d", v6Count)
+			}
+			return nil
+		}))
+	})
+
+	t.Run("VID change replaces old filter", func(t *testing.T) {
+		require.NoError(t, testNS.Do(func(_ ns.NetNS) error {
+			link, err := createDummy(t, "vlan-vid")
+			if err != nil {
+				return err
+			}
+			defer netlink.LinkDel(link)
+
+			ipNetSet := &terwayTypes.IPNetSet{IPv4: ipv4Net}
+			if err := EnsureVlanTag(context.Background(), link, ipNetSet, vid); err != nil {
+				return err
+			}
+			const newVid = uint16(200)
+			if err := EnsureVlanTag(context.Background(), link, ipNetSet, newVid); err != nil {
+				return err
+			}
+
+			filters, err := netlink.FilterList(link, netlink.HANDLE_MIN_EGRESS)
+			if err != nil {
+				return err
+			}
+			if findVlanFilter(filters, uint16(unix.ETH_P_IP), 50001, vid) {
+				return fmt.Errorf("old VID %d filter should have been removed", vid)
+			}
+			if !findVlanFilter(filters, uint16(unix.ETH_P_IP), 50001, newVid) {
+				return fmt.Errorf("new VID %d filter not found", newVid)
+			}
+			return nil
+		}))
+	})
+}
+
+func createDummy(t *testing.T, name string) (netlink.Link, error) {
+	t.Helper()
+	dummy := &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: name}}
+	if err := netlink.LinkAdd(dummy); err != nil {
+		return nil, fmt.Errorf("add dummy %s: %w", name, err)
+	}
+	link, err := netlink.LinkByName(name)
+	if err != nil {
+		return nil, fmt.Errorf("get dummy %s: %w", name, err)
+	}
+	return link, nil
+}
+
+func findVlanFilter(filters []netlink.Filter, proto uint16, priority uint16, vid uint16) bool {
+	for _, f := range filters {
+		u32, ok := f.(*netlink.U32)
+		if !ok {
+			continue
+		}
+		if u32.Attrs().Protocol != proto || u32.Attrs().Priority != priority {
+			continue
+		}
+		if len(u32.Actions) != 1 {
+			continue
+		}
+		act, ok := u32.Actions[0].(*netlink.VlanAction)
+		if !ok || act.Action != netlink.TCA_VLAN_KEY_PUSH || act.Vid != vid {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+func countVlanFilters(filters []netlink.Filter, proto uint16, priority uint16) int {
+	n := 0
+	for _, f := range filters {
+		u32, ok := f.(*netlink.U32)
+		if !ok {
+			continue
+		}
+		if u32.Attrs().Protocol != proto || u32.Attrs().Priority != priority {
+			continue
+		}
+		if len(u32.Actions) != 1 {
+			continue
+		}
+		if _, ok := u32.Actions[0].(*netlink.VlanAction); ok {
+			n++
+		}
+	}
+	return n
 }


### PR DESCRIPTION
The TC egress U32 filter for VLAN tag push was always using ETH_P_IP (IPv4 protocol), causing the IPv6 filter to never match IPv6 packets. As a result, IPv6 packets from trunk pods exited the ENI without a VLAN tag, preventing the cloud network from routing return traffic back to the source pod, breaking cross-node IPv6 connectivity.