### PR TITLE
test(prefix): set explicit ipv4_prefix_count in dual-stack 1:1 ratio test

### DIFF
--- a/tests/prefix_dualstack_test.go
+++ b/tests/prefix_dualstack_test.go
@@ -157,11 +157,11 @@ func assessDualStack1to1Ratio(ctx context.Context, t *testing.T, config *envconf
 		t.Logf("Warning: resetNodePrefixState failed (node may have no prefixes yet): %v", resetErr)
 	}
 
-	// Setup Dynamic Config with enable_ip_prefix=true
-	// Dual stack mode does not support ipv4_prefix_count; count is determined by system capacity
-	t.Log("Configure enable_ip_prefix=true via Dynamic Config")
+	// Setup Dynamic Config with enable_ip_prefix=true and an explicit ipv4_prefix_count.
+	// ipv4_prefix_count is required in dual-stack mode; only the per-ENI IPv6 prefix is auto-assigned.
+	t.Log("Configure enable_ip_prefix=true and ipv4_prefix_count=3 via Dynamic Config")
 	var err error
-	ctx, err = setupNodeDynamicConfig(ctx, config, t, `{"enable_ip_prefix":true}`)
+	ctx, err = setupNodeDynamicConfig(ctx, config, t, `{"enable_ip_prefix":true,"ipv4_prefix_count":3}`)
 	if err != nil {
 		t.Fatalf("failed to setup node dynamic config: %v", err)
 	}


### PR DESCRIPTION
## Summary

- `TestPrefix_DualStack_1to1Ratio` was timing out because `assessDualStack1to1Ratio` only sent `enable_ip_prefix=true` to the dynamic config, based on an incorrect assumption that dual-stack mode auto-fills `ipv4_prefix_count` from node capacity.
- The daemon does not auto-fill: `pkg/eni/node_reconcile.go` copies `eniConfig.IPv4PrefixCount` (Go zero value `0`) directly into the Node CR, so the controller allocates 0 prefixes and the 4-minute wait loop times out.
- Per the field doc on `types/daemon/config.go`, `ipv4_prefix_count` is effective in both IPv4 single-stack and dual-stack modes; only the per-ENI IPv6 prefix is auto-assigned in dual-stack. `TestPrefix_DualStack_CapacityConstraint` already passes because it sets the count explicitly — this PR mirrors that pattern in the 1:1 ratio test and drops the misleading comment.

## Test plan

- [x] `go vet -tags e2e ./tests/...` passes
- [x] `go test -tags e2e -run '^TestPrefix_DualStack_1to1Ratio$' ./tests/...` PASS on a dual-stack ACK cluster (170s; 3 IPv4 prefixes, 1/1 ENI with IPv6 prefix)
- [x] No daemon / controller code changes — fix is scoped to the test only