### PR TITLE
feat(policy): update cilium to v1.18.10

### DIFF
--- a/deploy/images/policy/Dockerfile
+++ b/deploy/images/policy/Dockerfile
@@ -21,7 +21,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     ( ! $(readelf -d bin/calico-felix | grep -q NEEDED) || ( echo "Error: bin/calico-felix was not statically linked"; false )) \
     && chmod +x /go/src/github.com/projectcalico/calico/bin/calico-felix
 
-FROM --platform=$TARGETPLATFORM quay.io/cilium/cilium-builder:ec0daa7a92da72d51f3139d4108e222f419f1ed3@sha256:005bbb26dffaecf093f9a1ebd2453c6cefe0a499b2e4714a39e245734b97e909 as cilium-builder
+FROM --platform=$TARGETPLATFORM quay.io/cilium/cilium-builder:e372b04eadada3a9931ccd207d2a2733c0592541@sha256:177553f27721c9762475ba3049d99012108adf0b48344dde34bbc3081e31e2fc as cilium-builder
 ARG GOPROXY
 ENV GOPROXY=$GOPROXY
 ARG CILIUM_SHA=""
@@ -30,8 +30,8 @@ LABEL cilium-sha=${CILIUM_SHA}
 LABEL maintainer="maintainer@cilium.io"
 WORKDIR /go/src/github.com/cilium
 RUN rm -rf cilium
-ENV GIT_TAG=v1.18.7
-ENV GIT_COMMIT=2adae2146ff84963c30bad26d06e1e2a17431559
+ENV GIT_TAG=v1.18.10
+ENV GIT_COMMIT=6bf2fe83d2fce50283b702d96c6190f7693dc224
 RUN git clone -b $GIT_TAG --depth 1 https://github.com/cilium/cilium.git && \
     cd cilium && git config --global user.email terway && git config --global user.name terway && \
     [ "`git rev-parse HEAD`" = "${GIT_COMMIT}" ]

--- a/deploy/images/terway-controlplane/Dockerfile
+++ b/deploy/images/terway-controlplane/Dockerfile
@@ -1,4 +1,4 @@
-ARG TERWAY_POLICY_IMAGE=registry-cn-zhangjiakou.ack.aliyuncs.com/acs/terway:policy-004646df@sha256:7a05e3c654977bb5691279c77a8144905edf3a5112f01b206af2dd2af8ac1527
+ARG TERWAY_POLICY_IMAGE=registry-cn-zhangjiakou.ack.aliyuncs.com/acs/terway:policy-14cd6c0e@sha256:ded6e8a952bd33e76a40c828c091f8ea384b161fae1a99f67d31bdeb8e57a7d9
 
 FROM --platform=$TARGETPLATFORM ${TERWAY_POLICY_IMAGE} AS policy-dist
 

--- a/deploy/images/terway/Dockerfile
+++ b/deploy/images/terway/Dockerfile
@@ -1,4 +1,4 @@
-ARG TERWAY_POLICY_IMAGE=registry-cn-zhangjiakou.ack.aliyuncs.com/acs/terway:policy-004646df@sha256:7a05e3c654977bb5691279c77a8144905edf3a5112f01b206af2dd2af8ac1527
+ARG TERWAY_POLICY_IMAGE=registry-cn-zhangjiakou.ack.aliyuncs.com/acs/terway:policy-14cd6c0e@sha256:ded6e8a952bd33e76a40c828c091f8ea384b161fae1a99f67d31bdeb8e57a7d9
 ARG UBUNTU_IMAGE=registry.cn-hangzhou.aliyuncs.com/acs/ubuntu:24.04-update
 ARG CILIUM_LLVM_IMAGE=quay.io/cilium/cilium-llvm:1763560084-a4eb8f4@sha256:cadc2001d43a1f410280aa82178fdfd5558916e6f9ca0acd52c22ba5b023458a
 ARG CILIUM_BPFTOOL_IMAGE=quay.io/cilium/cilium-bpftool:5a9c4852a21287686009bfe1cdc1fed6e7aabdea@sha256:188e398ee30456373530698d0d29de66dda0c4428068ea430027ceb7e9c15b7c

--- a/policy/cilium/0001-terway-cni.patch
+++ b/policy/cilium/0001-terway-cni.patch
@@ -1,7 +1,7 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From 58b71ad433c8b5d5245c86a8d0eef67d4a5337f9 Mon Sep 17 00:00:00 2001
 From: l1b0k <libokang.lbk@alibaba-inc.com>
 Date: Tue, 21 Oct 2025 15:26:32 +0800
-Subject: terway: cni
+Subject: [PATCH] terway: cni
 
 Signed-off-by: l1b0k <libokang.lbk@alibaba-inc.com>
 ---
@@ -33,10 +33,10 @@ Signed-off-by: l1b0k <libokang.lbk@alibaba-inc.com>
  create mode 100644 plugins/cilium-cni/chaining/terway/terway.go
 
 diff --git a/bpf/bpf_host.c b/bpf/bpf_host.c
-index 65fb86627c..3ac8130dc7 100644
+index 80a49ec748..8d253eb428 100644
 --- a/bpf/bpf_host.c
 +++ b/bpf/bpf_host.c
-@@ -1339,7 +1339,7 @@ int cil_to_netdev(struct __ctx_buff *ctx)
+@@ -1348,7 +1348,7 @@ int cil_to_netdev(struct __ctx_buff *ctx)
  	};
  	__be16 __maybe_unused proto = 0;
  	__u32 vlan_id;
@@ -45,7 +45,7 @@ index 65fb86627c..3ac8130dc7 100644
  	__s8 ext_err = 0;
  
  	bpf_clear_meta(ctx);
-@@ -1642,6 +1642,10 @@ exit:
+@@ -1651,6 +1651,10 @@ exit:
  			  TRACE_EP_ID_UNKNOWN, THIS_INTERFACE_IFINDEX,
  			  trace.reason, trace.monitor, proto);
  
@@ -57,7 +57,7 @@ index 65fb86627c..3ac8130dc7 100644
  
  drop_err:
 diff --git a/bpf/bpf_lxc.c b/bpf/bpf_lxc.c
-index 9e92cfa3a3..15d1c15736 100644
+index e677f2e2b2..ace5fd819a 100644
 --- a/bpf/bpf_lxc.c
 +++ b/bpf/bpf_lxc.c
 @@ -751,9 +751,15 @@ ct_recreate6:
@@ -78,7 +78,7 @@ index 9e92cfa3a3..15d1c15736 100644
  		/* Error handling for local routes - just pass the packet to the kernel stack */
  		if (ret == DROP_NO_FIB && *ext_err == BPF_FIB_LKUP_RET_NOT_FWDED)
  			goto pass_to_stack;
-@@ -1310,10 +1316,15 @@ skip_vtep:
+@@ -1314,10 +1320,15 @@ skip_vtep:
  #endif /* TUNNEL_MODE */
  
  	if (is_defined(ENABLE_HOST_ROUTING)) {
@@ -217,7 +217,7 @@ index 0e0dd76bda..2c12bc4252 100644
  		// For netkit we enable also tcx for all non-netkit devices.
  		// The underlying kernel does support it given tcx got merged
 diff --git a/pkg/datapath/config/lxc_config.go b/pkg/datapath/config/lxc_config.go
-index c2ca2f629f..d5fcf8a92f 100644
+index 73b83d5033..789c1d14a8 100644
 --- a/pkg/datapath/config/lxc_config.go
 +++ b/pkg/datapath/config/lxc_config.go
 @@ -28,6 +28,8 @@ type BPFLXC struct {
@@ -228,13 +228,13 @@ index c2ca2f629f..d5fcf8a92f 100644
 +	ParentDevIfindex int32 `config:"parent_dev_ifindex"`
  	// The log level for policy verdicts in workload endpoints.
  	PolicyVerdictLogFilter uint32 `config:"policy_verdict_log_filter"`
- 	// Pull security context from IP cache.
-@@ -44,5 +46,5 @@ func NewBPFLXC(node Node) *BPFLXC {
+ 	// Whether to redirect to the proxy via cilium_net (hairpin) or via stack.
+@@ -46,5 +48,5 @@ func NewBPFLXC(node Node) *BPFLXC {
  		0x0, 0x0, [8]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
  		[4]byte{0x0, 0x0, 0x0, 0x0},
  		[16]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
--		0x0, false, 0x0, node}
-+		0, 0x0, false, 0x0, node}
+-		0x0, false, false, 0x0, node}
++		0, 0x0, false, false, 0x0, node}
  }
 diff --git a/pkg/datapath/linux/bandwidth/ops.go b/pkg/datapath/linux/bandwidth/ops.go
 index e9214303c1..4f8b3774d2 100644
@@ -264,10 +264,10 @@ index 20b46c0864..25e9ce5004 100644
  		if option.Config.EnableHealthDatapath {
  			cDefinesMap["ENABLE_HEALTH_CHECK"] = "1"
 diff --git a/pkg/datapath/loader/loader.go b/pkg/datapath/loader/loader.go
-index 80060b3c2b..79c2c411d8 100644
+index cade9593a6..0182404338 100644
 --- a/pkg/datapath/loader/loader.go
 +++ b/pkg/datapath/loader/loader.go
-@@ -590,6 +590,7 @@ func endpointRewrites(ep datapath.EndpointConfiguration, lnc *datapath.LocalNode
+@@ -599,6 +599,7 @@ func endpointRewrites(ep datapath.EndpointConfiguration, lnc *datapath.LocalNode
  		renames["cilium_calls_custom"] = bpf.LocalMapName(callsmap.CustomCallsMapName, uint16(ep.GetID()))
  	}
  
@@ -360,14 +360,14 @@ index 5c736dce5e..291777e2b8 100644
  
  // GetPolicyNames returns the policy names for this endpoint.
 diff --git a/pkg/endpoint/restore.go b/pkg/endpoint/restore.go
-index 17e1928e0b..464290c31e 100644
+index 17e1928e0b..d1df88ab65 100644
 --- a/pkg/endpoint/restore.go
 +++ b/pkg/endpoint/restore.go
 @@ -456,6 +456,7 @@ func (e *Endpoint) toSerializedEndpoint() *serializableEndpoint {
  		CiliumEndpointUID:        e.ciliumEndpointUID,
  		Properties:               e.properties,
  		NetnsCookie:              e.NetNsCookie,
-+		//EniInterfaceIndex:        e.eniInterfaceIndex,
++		EniInterfaceIndex:        int64(e.parentIfIndex),
  	}
  }
  
@@ -406,10 +406,10 @@ index 0000000000..5fe16f8e7c
 +	return int64(ep.parentIfIndex)
 +}
 diff --git a/pkg/option/config.go b/pkg/option/config.go
-index 8ce57f5611..da4d726438 100644
+index d227234ddc..1a51d90165 100644
 --- a/pkg/option/config.go
 +++ b/pkg/option/config.go
-@@ -2138,6 +2138,7 @@ func (c *DaemonConfig) TunnelingEnabled() bool {
+@@ -2141,6 +2141,7 @@ func (c *DaemonConfig) TunnelingEnabled() bool {
  // AreDevicesRequired returns true if the agent needs to attach to the native
  // devices to implement some features.
  func (c *DaemonConfig) AreDevicesRequired(kprCfg kpr.KPRConfig) bool {

--- a/policy/cilium/0002-lb-enable-in-cluster-load-balancer.patch
+++ b/policy/cilium/0002-lb-enable-in-cluster-load-balancer.patch
@@ -1,17 +1,22 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From 81cd99b3b46dc04700a9439eaae07af416095763 Mon Sep 17 00:00:00 2001
 From: l1b0k <libokang.lbk@alibaba-inc.com>
 Date: Thu, 13 Nov 2025 15:02:38 +0800
-Subject: lb: enable in cluster load balancer
+Subject: [PATCH] lb: enable in cluster load balancer
 
 Signed-off-by: l1b0k <libokang.lbk@alibaba-inc.com>
 ---
- bpf/bpf_lxc.c             | 4 ++--
- daemon/cmd/daemon_main.go | 3 +++
- pkg/option/config.go      | 8 ++++++++
- 3 files changed, 13 insertions(+), 2 deletions(-)
+ bpf/bpf_lxc.c                              | 4 ++--
+ daemon/cmd/daemon_main.go                  | 3 +++
+ daemon/cmd/kube_proxy_replacement.go       | 4 +---
+ pkg/client/client.go                       | 3 +++
+ pkg/loadbalancer/config.go                 | 3 +++
+ pkg/loadbalancer/reflectors/conversions.go | 2 ++
+ pkg/option/config.go                       | 8 ++++++++
+ pkg/status/status_collector.go             | 2 +-
+ 8 files changed, 23 insertions(+), 6 deletions(-)
 
 diff --git a/bpf/bpf_lxc.c b/bpf/bpf_lxc.c
-index 15d1c15736..3c443909dc 100644
+index ace5fd819a..eb6491d891 100644
 --- a/bpf/bpf_lxc.c
 +++ b/bpf/bpf_lxc.c
 @@ -99,7 +99,7 @@ static __always_inline int __per_packet_lb_svc_xlate_4(void *ctx, struct iphdr *
@@ -46,11 +51,82 @@ index 2c12bc4252..9499317cce 100644
  	if err := vp.BindPFlags(flags); err != nil {
  		logging.Fatal(logger, "BindPFlags failed", logfields.Error, err)
  	}
+diff --git a/daemon/cmd/kube_proxy_replacement.go b/daemon/cmd/kube_proxy_replacement.go
+index b1f8ca0b60..e16157f3dc 100644
+--- a/daemon/cmd/kube_proxy_replacement.go
++++ b/daemon/cmd/kube_proxy_replacement.go
+@@ -42,9 +42,6 @@ import (
+ // if this function cannot determine the strictness an error is returned and the boolean
+ // is false. If an error is returned the boolean is of no meaning.
+ func initKubeProxyReplacementOptions(logger *slog.Logger, sysctl sysctl.Sysctl, tunnelConfig tunnel.Config, lbConfig loadbalancer.Config, kprCfg kpr.KPRConfig) error {
+-	if !kprCfg.EnableNodePort {
+-		option.Config.EnableHostLegacyRouting = true
+-	}
+ 	logger.Info("kube-proxy replacement starting with the following config",
+ 		logfields.KPRConfiguration, kprCfg)
+ 
+@@ -260,6 +257,7 @@ func probeKubeProxyReplacementOptions(logger *slog.Logger, lbConfig loadbalancer
+ // finishKubeProxyReplacementInit finishes initialization of kube-proxy
+ // replacement after all devices are known.
+ func finishKubeProxyReplacementInit(logger *slog.Logger, sysctl sysctl.Sysctl, devices []*tables.Device, directRoutingDevice string, lbConfig loadbalancer.Config, kprCfg kpr.KPRConfig) error {
++	return nil
+ 	// For MKE, we only need to change/extend the socket LB behavior in case
+ 	// of kube-proxy replacement. Otherwise, nothing else is needed.
+ 	if option.Config.EnableMKE && kprCfg.EnableSocketLB {
+diff --git a/pkg/client/client.go b/pkg/client/client.go
+index fcaafc7241..86f6655209 100644
+--- a/pkg/client/client.go
++++ b/pkg/client/client.go
+@@ -690,6 +690,9 @@ func FormatStatusResponse(w io.Writer, sr *models.StatusResponse, sd StatusDetai
+ 			nPort = fmt.Sprintf("Enabled (Range: %d-%d)", np.PortMin, np.PortMax)
+ 			lb = "Enabled"
+ 		}
++		if sr.KubeProxyReplacement.Features.ExternalIPs.Enabled {
++			lb = "Enabled"
++		}
+ 
+ 		affinity := "Disabled"
+ 		if sr.KubeProxyReplacement.Features.SessionAffinity.Enabled {
+diff --git a/pkg/loadbalancer/config.go b/pkg/loadbalancer/config.go
+index 4ade0dddf0..2b57f45b18 100644
+--- a/pkg/loadbalancer/config.go
++++ b/pkg/loadbalancer/config.go
+@@ -523,6 +523,8 @@ type ExternalConfig struct {
+ 	EnableSocketLBPodConnectionTermination bool
+ 	EnableHealthCheckLoadBalancerIP        bool
+ 
++	EnableInClusterLoadBalance bool
++
+ 	// The following options will be removed in v1.19
+ 	EnableHostPort              bool
+ 	EnableSessionAffinity       bool
+@@ -537,6 +539,7 @@ func NewExternalConfig(cfg *option.DaemonConfig, kprCfg kpr.KPRConfig) ExternalC
+ 		EnableIPv4:                             cfg.EnableIPv4,
+ 		EnableIPv6:                             cfg.EnableIPv6,
+ 		KubeProxyReplacement:                   kprCfg.KubeProxyReplacement == option.KubeProxyReplacementTrue || kprCfg.EnableNodePort,
++		EnableInClusterLoadBalance:             cfg.EnableInClusterLoadBalance,
+ 		BPFSocketLBHostnsOnly:                  cfg.BPFSocketLBHostnsOnly,
+ 		EnableSocketLB:                         kprCfg.EnableSocketLB,
+ 		EnableSocketLBPodConnectionTermination: cfg.EnableSocketLBPodConnectionTermination,
+diff --git a/pkg/loadbalancer/reflectors/conversions.go b/pkg/loadbalancer/reflectors/conversions.go
+index 62734ea932..f4be4696b1 100644
+--- a/pkg/loadbalancer/reflectors/conversions.go
++++ b/pkg/loadbalancer/reflectors/conversions.go
+@@ -277,7 +277,9 @@ func convertService(cfg loadbalancer.Config, extCfg loadbalancer.ExternalConfig,
+ 				}
+ 			}
+ 		}
++	}
+ 
++	if extCfg.KubeProxyReplacement || extCfg.EnableInClusterLoadBalance {
+ 		// LoadBalancer
+ 		if svc.Spec.Type == slim_corev1.ServiceTypeLoadBalancer && expType.CanExpose(slim_corev1.ServiceTypeLoadBalancer) {
+ 			for _, ip := range svc.Status.LoadBalancer.Ingress {
 diff --git a/pkg/option/config.go b/pkg/option/config.go
-index da4d726438..00739138a0 100644
+index 1a51d90165..ebeb6e5deb 100644
 --- a/pkg/option/config.go
 +++ b/pkg/option/config.go
-@@ -1060,6 +1060,9 @@ const (
+@@ -1063,6 +1063,9 @@ const (
  
  	// ConnectivityProbeFrequencyRatio is the name of the option to specify the connectivity probe frequency
  	ConnectivityProbeFrequencyRatio = "connectivity-probe-frequency-ratio"
@@ -60,7 +136,7 @@ index da4d726438..00739138a0 100644
  )
  
  // Default string arguments
-@@ -2020,6 +2023,9 @@ type DaemonConfig struct {
+@@ -2023,6 +2026,9 @@ type DaemonConfig struct {
  
  	// ConnectivityProbeFrequencyRatio is the ratio of the connectivity probe frequency vs resource consumption
  	ConnectivityProbeFrequencyRatio float64
@@ -70,7 +146,7 @@ index da4d726438..00739138a0 100644
  }
  
  var (
-@@ -2732,6 +2738,8 @@ func (c *DaemonConfig) Populate(logger *slog.Logger, vp *viper.Viper) {
+@@ -2735,6 +2741,8 @@ func (c *DaemonConfig) Populate(logger *slog.Logger, vp *viper.Viper) {
  	c.EnableIPSecEncryptedOverlay = vp.GetBool(EnableIPSecEncryptedOverlay)
  	c.BootIDFile = vp.GetString(BootIDFilename)
  
@@ -79,6 +155,19 @@ index da4d726438..00739138a0 100644
  	c.ServiceNoBackendResponse = vp.GetString(ServiceNoBackendResponse)
  	switch c.ServiceNoBackendResponse {
  	case ServiceNoBackendResponseReject, ServiceNoBackendResponseDrop:
+diff --git a/pkg/status/status_collector.go b/pkg/status/status_collector.go
+index 3c5008e944..2db7821035 100644
+--- a/pkg/status/status_collector.go
++++ b/pkg/status/status_collector.go
+@@ -340,7 +340,7 @@ func (d *statusCollector) getKubeProxyReplacementStatus(ctx context.Context) *mo
+ 	if d.statusParams.KPRConfig.EnableHostPort {
+ 		features.HostPort.Enabled = true
+ 	}
+-	if d.statusParams.KPRConfig.EnableExternalIPs {
++	if d.statusParams.KPRConfig.EnableExternalIPs || d.statusParams.DaemonConfig.EnableInClusterLoadBalance {
+ 		features.ExternalIPs.Enabled = true
+ 	}
+ 	if d.statusParams.KPRConfig.EnableSocketLB {
 -- 
 2.50.1 (Apple Git-155)
 

--- a/policy/cilium/0003-feat-daemon-add-disable-per-packet-LB-policy-flag.patch
+++ b/policy/cilium/0003-feat-daemon-add-disable-per-packet-LB-policy-flag.patch
@@ -1,7 +1,7 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From 8b12242b89082a5777e25218cf54e7b843e44cfc Mon Sep 17 00:00:00 2001
 From: l1b0k <libokang.lbk@alibaba-inc.com>
 Date: Thu, 13 Nov 2025 15:08:54 +0800
-Subject: feat(daemon): add disable per-packet LB policy flag
+Subject: [PATCH] feat(daemon): add disable per-packet LB policy flag
 
 Signed-off-by: l1b0k <libokang.lbk@alibaba-inc.com>
 ---
@@ -12,7 +12,7 @@ Signed-off-by: l1b0k <libokang.lbk@alibaba-inc.com>
  4 files changed, 13 insertions(+), 3 deletions(-)
 
 diff --git a/bpf/bpf_lxc.c b/bpf/bpf_lxc.c
-index 3c443909dc..664799d8ea 100644
+index eb6491d891..a681b05bf5 100644
 --- a/bpf/bpf_lxc.c
 +++ b/bpf/bpf_lxc.c
 @@ -62,11 +62,12 @@
@@ -60,10 +60,10 @@ index 25e9ce5004..e613bceafb 100644
  
  	cDefinesMap["UNKNOWN_ID"] = fmt.Sprintf("%d", identity.GetReservedID(labels.IDNameUnknown))
 diff --git a/pkg/option/config.go b/pkg/option/config.go
-index 00739138a0..208cec7c3e 100644
+index ebeb6e5deb..63e1f8995a 100644
 --- a/pkg/option/config.go
 +++ b/pkg/option/config.go
-@@ -1063,6 +1063,7 @@ const (
+@@ -1066,6 +1066,7 @@ const (
  
  	// EnableInClusterLoadBalance enable short circuit for in cluster traffic to externalIP and loadBalancerIP
  	EnableInClusterLoadBalance = "enable-in-cluster-loadbalance"
@@ -71,7 +71,7 @@ index 00739138a0..208cec7c3e 100644
  )
  
  // Default string arguments
-@@ -2026,6 +2027,8 @@ type DaemonConfig struct {
+@@ -2029,6 +2030,8 @@ type DaemonConfig struct {
  
  	// EnableInClusterLoadBalance enable short circuit for in cluster traffic to externalIP and loadBalancerIP
  	EnableInClusterLoadBalance bool
@@ -80,7 +80,7 @@ index 00739138a0..208cec7c3e 100644
  }
  
  var (
-@@ -2739,6 +2742,7 @@ func (c *DaemonConfig) Populate(logger *slog.Logger, vp *viper.Viper) {
+@@ -2742,6 +2745,7 @@ func (c *DaemonConfig) Populate(logger *slog.Logger, vp *viper.Viper) {
  	c.BootIDFile = vp.GetString(BootIDFilename)
  
  	c.EnableInClusterLoadBalance = vp.GetBool(EnableInClusterLoadBalance)

--- a/policy/cilium/0004-endpoint-fix-sip-config.patch
+++ b/policy/cilium/0004-endpoint-fix-sip-config.patch
@@ -1,7 +1,7 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From 53087f62941c71aafe8c7f557633ae89ba3774a4 Mon Sep 17 00:00:00 2001
 From: l1b0k <libokang.lbk@alibaba-inc.com>
 Date: Thu, 18 Dec 2025 11:00:11 +0800
-Subject: endpoint: fix sip config
+Subject: [PATCH] endpoint: fix sip config
 
 Signed-off-by: l1b0k <libokang.lbk@alibaba-inc.com>
 ---

--- a/policy/cilium/0005-feat-datapath-add-multi-host-stack-support-for-veth-.patch
+++ b/policy/cilium/0005-feat-datapath-add-multi-host-stack-support-for-veth-.patch
@@ -1,15 +1,13 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: l1b0k <libokang.dev@gmail.com>
+From 27b4dae4fd8dcc6fd2878fffd94160d944f76ce6 Mon Sep 17 00:00:00 2001
+From: l1b0k <libokang.lbk@alibaba-inc.com>
 Date: Mon, 9 Mar 2026 16:11:17 +0800
-Subject: =?UTF-8?q?feat(datapath):=20add=20multi-host=20stack=20support=20?=
- =?UTF-8?q?for=20veth=20datapath-=20Implement=20host=20stack=20CIDR=20map?=
- =?UTF-8?q?=20and=20related=20functions=0A-=20Add=20support=20for=20multip?=
- =?UTF-8?q?le=20host=20stack=20CIDRs=20in=20veth=20datapath=20mode=0A-=20U?=
- =?UTF-8?q?pdate=20bpf=5Flxc=20to=20handle=20multiple=20host=20stack=20CID?=
- =?UTF-8?q?Rs=0A-=20Modify=20daemon=20initialization=20to=20set=20up=20hos?=
- =?UTF-8?q?t=20stack=20CIDR=20map?=
+Subject: [PATCH] feat(datapath): add multi-host stack support for veth
+ datapath- Implement host stack CIDR map and related functions - Add support
+ for multiple host stack CIDRs in veth datapath mode - Update bpf_lxc to
+ handle multiple host stack CIDRs - Modify daemon initialization to set up
+ host stack CIDR map
 
-Signed-off-by: l1b0k <libokang.dev@gmail.com>
+Signed-off-by: l1b0k <libokang.lbk@alibaba-inc.com>
 ---
  bpf/bpf_lxc.c                           |   9 ++
  bpf/include/bpf/config/lxc.h            |   3 +
@@ -28,7 +26,7 @@ Signed-off-by: l1b0k <libokang.dev@gmail.com>
  create mode 100644 pkg/maps/hoststackcidr/hoststackcidr.go
 
 diff --git a/bpf/bpf_lxc.c b/bpf/bpf_lxc.c
-index 664799d8ea..6c3e82cd77 100644
+index a681b05bf5..1edbc356f6 100644
 --- a/bpf/bpf_lxc.c
 +++ b/bpf/bpf_lxc.c
 @@ -55,6 +55,7 @@
@@ -39,7 +37,7 @@ index 664799d8ea..6c3e82cd77 100644
  
  /* Per-packet LB is needed if all LB cases can not be handled in bpf_sock.
   * Most services with L7 LB flag can not be redirected to their proxy port
-@@ -1319,6 +1320,14 @@ skip_vtep:
+@@ -1323,6 +1324,14 @@ skip_vtep:
  	if (is_defined(ENABLE_HOST_ROUTING)) {
  		int oif = CONFIG(parent_dev_ifindex);
  
@@ -133,7 +131,7 @@ index 0ba99bdb9b..784facc4ad 100644
  	}
 diff --git a/daemon/cmd/hoststack-cidr.go b/daemon/cmd/hoststack-cidr.go
 new file mode 100644
-index 0000000000..98d0e28dc7
+index 0000000000..9e4cbe8fa5
 --- /dev/null
 +++ b/daemon/cmd/hoststack-cidr.go
 @@ -0,0 +1,48 @@
@@ -159,13 +157,13 @@ index 0000000000..98d0e28dc7
 +	}
 +
 +	for prefix := range exists {
-+		logger.Debug("host stack CIDR entry: %s", prefix)
++		logger.Debug("host stack CIDR entry", "prefix", prefix)
 +	}
 +
 +	for _, cidr := range option.Config.HostStackCIDRs {
 +		expect, err := netip.ParsePrefix(cidr)
 +		if err != nil {
-+			logger.Debug("parse cidr error, ignored : %s", err)
++			logger.Debug("parse cidr error, ignored", "error", err)
 +		} else {
 +			err = hoststackcidr.AddCIDREntry(expect, 0)
 +			if err != nil {
@@ -186,7 +184,7 @@ index 0000000000..98d0e28dc7
 +	return nil
 +}
 diff --git a/pkg/datapath/config/lxc_config.go b/pkg/datapath/config/lxc_config.go
-index d5fcf8a92f..c6874af1ff 100644
+index 789c1d14a8..69b40918dd 100644
 --- a/pkg/datapath/config/lxc_config.go
 +++ b/pkg/datapath/config/lxc_config.go
 @@ -24,6 +24,8 @@ type BPFLXC struct {
@@ -198,14 +196,14 @@ index d5fcf8a92f..c6874af1ff 100644
  	// Masquerade address for IPv4 traffic.
  	NATIPv4Masquerade [4]byte `config:"nat_ipv4_masquerade"`
  	// Masquerade address for IPv6 traffic.
-@@ -44,7 +46,7 @@ func NewBPFLXC(node Node) *BPFLXC {
+@@ -46,7 +48,7 @@ func NewBPFLXC(node Node) *BPFLXC {
  	return &BPFLXC{0x5dc, 0x0, [4]byte{0x0, 0x0, 0x0, 0x0},
  		[16]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
  		0x0, 0x0, [8]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
 -		[4]byte{0x0, 0x0, 0x0, 0x0},
 +		[4]byte{0x0, 0x0, 0x0, 0x0}, [4]byte{0x0, 0x0, 0x0, 0x0},
  		[16]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
- 		0, 0x0, false, 0x0, node}
+ 		0, 0x0, false, false, 0x0, node}
  }
 diff --git a/pkg/datapath/linux/config/config.go b/pkg/datapath/linux/config/config.go
 index e613bceafb..36a5dacd25 100644
@@ -232,10 +230,10 @@ index e613bceafb..36a5dacd25 100644
  		// Only used to differentiate between host endpoint template and other templates.
  		fmt.Fprintf(fw, "#define HOST_ENDPOINT 1\n")
 diff --git a/pkg/datapath/loader/loader.go b/pkg/datapath/loader/loader.go
-index 79c2c411d8..926296e444 100644
+index 0182404338..50d78efee1 100644
 --- a/pkg/datapath/loader/loader.go
 +++ b/pkg/datapath/loader/loader.go
-@@ -591,6 +591,14 @@ func endpointRewrites(ep datapath.EndpointConfiguration, lnc *datapath.LocalNode
+@@ -600,6 +600,14 @@ func endpointRewrites(ep datapath.EndpointConfiguration, lnc *datapath.LocalNode
  	}
  
  	cfg.ParentDevIfindex = int32(ep.GetParentIfIndex())
@@ -408,10 +406,10 @@ index 0000000000..0d4de4e3ae
 +	return result, nil
 +}
 diff --git a/pkg/option/config.go b/pkg/option/config.go
-index 208cec7c3e..5a243fd81b 100644
+index 63e1f8995a..ebea1a56f2 100644
 --- a/pkg/option/config.go
 +++ b/pkg/option/config.go
-@@ -1064,6 +1064,7 @@ const (
+@@ -1067,6 +1067,7 @@ const (
  	// EnableInClusterLoadBalance enable short circuit for in cluster traffic to externalIP and loadBalancerIP
  	EnableInClusterLoadBalance = "enable-in-cluster-loadbalance"
  	DisablePerPacketLB         = "disable-per-package-lb"
@@ -419,7 +417,7 @@ index 208cec7c3e..5a243fd81b 100644
  )
  
  // Default string arguments
-@@ -2029,6 +2030,8 @@ type DaemonConfig struct {
+@@ -2032,6 +2033,8 @@ type DaemonConfig struct {
  	EnableInClusterLoadBalance bool
  
  	DisablePerPacketLB bool
@@ -428,7 +426,7 @@ index 208cec7c3e..5a243fd81b 100644
  }
  
  var (
-@@ -2743,6 +2746,7 @@ func (c *DaemonConfig) Populate(logger *slog.Logger, vp *viper.Viper) {
+@@ -2746,6 +2749,7 @@ func (c *DaemonConfig) Populate(logger *slog.Logger, vp *viper.Viper) {
  
  	c.EnableInClusterLoadBalance = vp.GetBool(EnableInClusterLoadBalance)
  	c.DisablePerPacketLB = vp.GetBool(DisablePerPacketLB)

--- a/policy/cilium/0006-feat-node-implement-NodeMapGarbageCollect-for-garbag.patch
+++ b/policy/cilium/0006-feat-node-implement-NodeMapGarbageCollect-for-garbag.patch
@@ -1,10 +1,10 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: l1b0k <libokang.dev@gmail.com>
+From 4cb08a7d0fde447af895d5344688c63398839be6 Mon Sep 17 00:00:00 2001
+From: l1b0k <libokang.lbk@alibaba-inc.com>
 Date: Mon, 9 Mar 2026 16:27:19 +0800
-Subject: feat(node): implement NodeMapGarbageCollect for garbage collection of
- stale BPF node map entries
+Subject: [PATCH] feat(node): implement NodeMapGarbageCollect for garbage
+ collection of stale BPF node map entries
 
-Signed-off-by: l1b0k <libokang.dev@gmail.com>
+Signed-off-by: l1b0k <libokang.lbk@alibaba-inc.com>
 ---
  pkg/auth/authmap_gc.go                        |  5 ++
  pkg/datapath/fake/types/node_handler.go       |  3 +
@@ -279,7 +279,7 @@ index ed561dc1b5..cbb7f423b1 100644
  	past := time.Now().Add(-clientGCTimeout)
  	for k, v := range h.clients {
 diff --git a/pkg/node/neighbordiscovery/node_neighbor_discovery.go b/pkg/node/neighbordiscovery/node_neighbor_discovery.go
-index 5ea6007279..30bebe9d6d 100644
+index 03f10f3f26..29e60d3305 100644
 --- a/pkg/node/neighbordiscovery/node_neighbor_discovery.go
 +++ b/pkg/node/neighbordiscovery/node_neighbor_discovery.go
 @@ -190,6 +190,11 @@ func (nnh *nodeNeighborHandler) NodeValidateImplementation(node nodeTypes.Node)

--- a/policy/cilium/0007-feat-k8s-skip-CRD-register-wait-for-CPIP-CNC-CL2AP-i.patch
+++ b/policy/cilium/0007-feat-k8s-skip-CRD-register-wait-for-CPIP-CNC-CL2AP-i.patch
@@ -1,5 +1,5 @@
-From 9dca17303093945238f5aecf9f11518e23d1849b Mon Sep 17 00:00:00 2001
-From: l1b0k <libokang.dev@gmail.com>
+From 9b52716691ca2b62ca9c6316d644fca3f5e15160 Mon Sep 17 00:00:00 2001
+From: l1b0k <libokang.lbk@alibaba-inc.com>
 Date: Wed, 13 May 2026 14:10:16 +0800
 Subject: [PATCH] feat(k8s): skip CRD register/wait for CPIP, CNC, CL2AP in
  Terway integration
@@ -18,6 +18,8 @@ agent-side waiter (agentCRDResourceNames / AllCiliumCRDResourceNames)
 must stay in sync, otherwise SyncCRDs fatals on missing CRDs.
 
 CiliumCIDRGroup is kept (still gated by EnableCiliumNetworkPolicy).
+
+Signed-off-by: l1b0k <libokang.lbk@alibaba-inc.com>
 ---
  pkg/k8s/apis/cilium.io/client/register.go | 17 +++++------------
  pkg/k8s/synced/crd.go                     |  9 ++++-----

--- a/policy/cilium/0008-cep-optimize-cep-watch.patch
+++ b/policy/cilium/0008-cep-optimize-cep-watch.patch
@@ -1,0 +1,139 @@
+From e4f6dc648d5e8ecb47f9e2e805aa65a3144c8bbb Mon Sep 17 00:00:00 2001
+From: l1b0k <libokang.lbk@alibaba-inc.com>
+Date: Tue, 26 May 2026 19:47:27 +0800
+Subject: [PATCH] cep: optimize cep watch
+
+Reduce agent CEP list/watch load in large clusters by filtering CEPs to
+the local node:
+
+- Watch CEPs with LabelSelector k8s-node-name=<this node> when policy
+  enforcement is "never" (per-node scope is safe since no cross-node
+  label selection is needed).
+- Stamp CEPs at create time with {k8s-node-ip, k8s-node-name} labels
+  instead of mirroring pod labels.
+- Backfill k8s-node-name on existing CEPs after upgrade so the new
+  selector still matches them.
+- Stop mirroring pod label updates to CEP (no longer used for
+  selection).
+
+Signed-off-by: l1b0k <libokang.lbk@alibaba-inc.com>
+---
+ pkg/endpointmanager/endpointsynchronizer.go | 34 +++++++++++++++++++--
+ pkg/k8s/resource_ctors.go                   | 15 ++++++++-
+ pkg/k8s/watchers/pod.go                     |  6 ++--
+ 3 files changed, 47 insertions(+), 8 deletions(-)
+
+diff --git a/pkg/endpointmanager/endpointsynchronizer.go b/pkg/endpointmanager/endpointsynchronizer.go
+index e34df27323..2153a1e0a4 100644
+--- a/pkg/endpointmanager/endpointsynchronizer.go
++++ b/pkg/endpointmanager/endpointsynchronizer.go
+@@ -256,6 +256,33 @@ func (epSync *EndpointSynchronizer) RunK8sCiliumEndpointSync(e *endpoint.Endpoin
+ 							scopedLog.Warn("could not take ownership of existing ciliumendpoint", logfields.Error, err)
+ 							return err
+ 						}
++						// Backfill node-name label on existing CEPs that pre-date the
++						// per-node CEP watch optimization (upgrade path).
++						if localCEP.Labels["k8s-node-name"] != types.GetName() {
++							replaceLabels := []k8s.JSONPatch{
++								{
++									OP:   "replace",
++									Path: "/metadata/labels",
++									Value: map[string]string{
++										"k8s-node-name": types.GetName(),
++									},
++								},
++							}
++							labelsPatch, err := json.Marshal(replaceLabels)
++							if err != nil {
++								scopedLog.Debug("Error marshalling CEP labels", logfields.Error, err)
++								return err
++							}
++							_, err = ciliumClient.CiliumEndpoints(cepOwner.GetNamespace()).Patch(
++								ctx, cepName,
++								k8stypes.JSONPatchType,
++								labelsPatch,
++								meta_v1.PatchOptions{})
++							if err != nil {
++								scopedLog.Debug("Error while updating CiliumEndpoint object with new labels", logfields.Error, err)
++								return err
++							}
++						}
+ 					case k8serrors.IsNotFound(err):
+ 						// We can't create localCEP directly, it must come from the k8s
+ 						// server via an API call.
+@@ -270,9 +297,10 @@ func (epSync *EndpointSynchronizer) RunK8sCiliumEndpointSync(e *endpoint.Endpoin
+ 										UID:        cepOwner.GetUID(),
+ 									},
+ 								},
+-								// Mirror the labels of parent pod in CiliumEndpoint object to enable
+-								// label based selection for CiliumEndpoints.
+-								Labels: cepOwner.GetLabels(),
++								Labels: map[string]string{
++									"k8s-node-ip":   node.GetCiliumEndpointNodeIP(scopedLog),
++									"k8s-node-name": types.GetName(),
++								},
+ 							},
+ 							Status: *mdl,
+ 						}
+diff --git a/pkg/k8s/resource_ctors.go b/pkg/k8s/resource_ctors.go
+index 23558a761e..121b612ab8 100644
+--- a/pkg/k8s/resource_ctors.go
++++ b/pkg/k8s/resource_ctors.go
+@@ -12,6 +12,7 @@ import (
+ 	"github.com/cilium/hive/cell"
+ 	"github.com/spf13/pflag"
+ 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
++	"k8s.io/apimachinery/pkg/labels"
+ 	k8sRuntime "k8s.io/apimachinery/pkg/runtime"
+ 	"k8s.io/apimachinery/pkg/watch"
+ 	"k8s.io/client-go/tools/cache"
+@@ -32,6 +33,9 @@ import (
+ 	"github.com/cilium/cilium/pkg/k8s/version"
+ 	"github.com/cilium/cilium/pkg/logging/logfields"
+ 	"github.com/cilium/cilium/pkg/node"
++	nodeTypes "github.com/cilium/cilium/pkg/node/types"
++	"github.com/cilium/cilium/pkg/option"
++	"github.com/cilium/cilium/pkg/policy"
+ 	"github.com/cilium/cilium/pkg/promise"
+ )
+ 
+@@ -441,9 +445,18 @@ func CiliumSlimEndpointResource(params CiliumResourceParams, _ *node.LocalNodeSt
+ 	if !params.ClientSet.IsEnabled() {
+ 		return nil, nil
+ 	}
++
++	lb := labels.Set{}
++	if policy.GetPolicyEnabled() == option.NeverEnforce {
++		lb["k8s-node-name"] = nodeTypes.GetName()
++	}
++	params.Logger.Info("watch cep with selector", logfields.Selector, lb.String())
++
+ 	lw := utils.ListerWatcherWithModifiers(
+ 		utils.ListerWatcherFromTyped[*cilium_api_v2.CiliumEndpointList](params.ClientSet.CiliumV2().CiliumEndpoints(slim_corev1.NamespaceAll)),
+-		opts...,
++		func(options *metav1.ListOptions) {
++			options.LabelSelector = lb.String()
++		},
+ 	)
+ 	indexers := cache.Indexers{
+ 		"localNode": func(obj any) ([]string, error) {
+diff --git a/pkg/k8s/watchers/pod.go b/pkg/k8s/watchers/pod.go
+index fcbd6bcbfd..d89b42cd08 100644
+--- a/pkg/k8s/watchers/pod.go
++++ b/pkg/k8s/watchers/pod.go
+@@ -355,10 +355,8 @@ func (k *K8sPodWatcher) updateK8sPodV1(oldK8sPod, newK8sPod *slim_corev1.Pod) er
+ 				return err
+ 			}
+ 
+-			// Synchronize Pod labels with CiliumEndpoint labels if there is a change.
+-			if !option.Config.DisableCiliumEndpointCRD {
+-				updateCiliumEndpointLabels(k.logger, k.clientset, podEP, newK8sPod.Labels)
+-			}
++			// Pod labels are no longer mirrored to CiliumEndpoint; CEP carries
++			// k8s-node-name/k8s-node-ip labels instead to enable per-node CEP watch.
+ 		}
+ 
+ 		if annotationsChanged {
+-- 
+2.50.1 (Apple Git-155)
+

--- a/policy/cilium/0009-lb-skip-pruning-proto-ANY-service-entries-for-upgrad.patch
+++ b/policy/cilium/0009-lb-skip-pruning-proto-ANY-service-entries-for-upgrad.patch
@@ -1,0 +1,43 @@
+From c750c7837375892a804b71c56376f7744b8f5964 Mon Sep 17 00:00:00 2001
+From: l1b0k <libokang.lbk@alibaba-inc.com>
+Date: Tue, 2 Jun 2026 17:35:02 +0800
+Subject: [PATCH] lb: skip pruning proto=ANY service entries for upgrade
+ compatibility
+
+During upgrade from cilium 1.16 (proto=ANY) to 1.18 (proto=TCP/UDP),
+old BPF programs still query service map with proto=0 key. Pruning
+these entries before BPF reload causes lb4_lookup_service to return
+NULL, generating RST on existing connections.
+
+Keep proto=ANY entries in the service map. The new BPF programs with
+ENABLE_SERVICE_PROTOCOL_DIFFERENTIATION try specific proto first and
+fall back to ANY, so coexistence is safe.
+
+Signed-off-by: l1b0k <libokang.lbk@alibaba-inc.com>
+---
+ pkg/loadbalancer/reconciler/bpf_reconciler.go | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/pkg/loadbalancer/reconciler/bpf_reconciler.go b/pkg/loadbalancer/reconciler/bpf_reconciler.go
+index bfcbde80ad..c2da435fca 100644
+--- a/pkg/loadbalancer/reconciler/bpf_reconciler.go
++++ b/pkg/loadbalancer/reconciler/bpf_reconciler.go
+@@ -504,6 +504,15 @@ func (ops *BPFOps) pruneServiceMaps() error {
+ 	svcCB := func(svcKey maps.ServiceKey, svcValue maps.ServiceValue) {
+ 		svcKey = svcKey.ToHost()
+ 		svcValue = svcValue.ToHost()
++
++		// Keep proto=ANY (legacy) entries for backward compatibility during
++		// upgrade from cilium versions without protocol differentiation.
++		// Old BPF programs only query with proto=0, removing these entries
++		// before BPF reload causes connection RST.
++		if svcKey.GetProtocol() == 0 {
++			return
++		}
++
+ 		ac, ok := cmtypes.AddrClusterFromIP(svcKey.GetAddress())
+ 		if !ok {
+ 			ops.log.Warn("Prune: bad address in service key", logfields.Key, svcKey)
+-- 
+2.50.1 (Apple Git-155)
+


### PR DESCRIPTION
## Summary
- Update cilium patches from `terway/1.18.10` branch (9 patches including new cep-optimize and lb-skip-pruning-proto-ANY)
- Bump policy image to `policy-14cd6c0e` built on cilium v1.18.10
- Update TERWAY_POLICY_IMAGE in terway and terway-controlplane Dockerfiles

## Test plan
- [x] Patches verified: `git am` applies cleanly on top of cilium `v1.18.10` tag
- [x] Multi-arch policy image built and pushed (`linux/amd64` + `linux/arm64`)