### PR TITLE
test(hostport): delete pods before restoring eni-config in teardown

### DIFF
--- a/tests/connective_test.go
+++ b/tests/connective_test.go
@@ -781,6 +781,11 @@ func createHostPortNodeIPTest(nodeType NodeType) features.Feature {
 		}).
 		Teardown(func(ctx context.Context, t *testing.T, config *envconf.Config) context.Context {
 			if state.configured && state.backup != nil {
+				// Delete pods first so CNI DEL runs while portmap is still in the chain;
+				// otherwise portmap DNAT rules leak on the node and break IPv6 hostPort
+				// on subsequent rounds (nftables rejects duplicate rules).
+				deleteHostPortPods(ctx, t, config, serverName, clientName)
+
 				err := RestoreENIConfig(ctx, config, state.backup)
 				if err != nil {
 					t.Logf("Warning: failed to restore eni-config: %v", err)
@@ -956,6 +961,11 @@ func createHostPortExternalIPTest(nodeType NodeType) features.Feature {
 		}).
 		Teardown(func(ctx context.Context, t *testing.T, config *envconf.Config) context.Context {
 			if state.configured && state.backup != nil {
+				// Delete pods first so CNI DEL runs while portmap is still in the chain;
+				// otherwise portmap DNAT rules leak on the node and break IPv6 hostPort
+				// on subsequent rounds (nftables rejects duplicate rules).
+				deleteHostPortPods(ctx, t, config, serverName, clientName)
+
 				err := RestoreENIConfig(ctx, config, state.backup)
 				if err != nil {
 					t.Logf("Warning: failed to restore eni-config: %v", err)
@@ -968,6 +978,21 @@ func createHostPortExternalIPTest(nodeType NodeType) features.Feature {
 			return ctx
 		}).
 		Feature()
+}
+
+func deleteHostPortPods(ctx context.Context, t *testing.T, config *envconf.Config, names ...string) {
+	for _, name := range names {
+		pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: config.Namespace()}}
+		if err := config.Client().Resources().Delete(ctx, pod); err != nil {
+			t.Logf("Warning: failed to delete pod %s: %v", name, err)
+			continue
+		}
+		err := wait.For(conditions.New(config.Client().Resources()).ResourceDeleted(pod),
+			wait.WithInterval(1*time.Second), wait.WithImmediate(), wait.WithTimeout(1*time.Minute))
+		if err != nil {
+			t.Logf("Warning: waiting for pod %s deletion: %v", name, err)
+		}
+	}
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

- HostPort feature Teardown restored `eni-config` (removing the portmap plugin from the CNI chain) and restarted Terway **before** the framework deleted server/client pods. CNI DEL then ran without portmap in the chain, so portmap DNAT rules leaked on the node.
- On subsequent rounds, IPv6 nftables rejected the duplicate rules, causing `TestSharedENI_HostPort_NodeIP` to time out on IPv6 (round 1 passes on a clean cluster; rounds 2–5 consistently fail).
- Fix: delete the server/client pods explicitly first in the Teardown so CNI DEL fires while portmap is still in the chain, then restore eni-config and restart Terway. Applied to both `createHostPortNodeIPTest` and `createHostPortExternalIPTest`.

## Test plan

- [x] `go vet -tags=e2e ./tests/...` passes
- [ ] Run `TestSharedENI_HostPort_NodeIP` for 5 consecutive rounds — expect all rounds to pass on both IPv4 and IPv6 (previously failed rounds 2–5 on IPv6)
- [ ] Run `TestSharedENI_HostPort_ExternalIP` for 5 consecutive rounds on a cluster with external-IP nodes