### PR TITLE
feat(terraform): support byo-dual profile for dual-stack BYO clusters

### DIFF
--- a/hack/terraform/ack/e2e-cluster.sh
+++ b/hack/terraform/ack/e2e-cluster.sh
@@ -15,13 +15,11 @@
 #
 # Profiles:
 #   byo-ipv4      single stack ipv4, no terway addon; deploy terway via helm chart afterwards (BYO CNI)
+#   byo-dual      dual stack, no terway addon; deploy terway via helm chart afterwards (BYO CNI)
 #   ack-ipv4      single stack ipv4 + terway-eniip addon installed by ACK
 #   ack-dual      dual stack + terway-eniip addon installed by ACK
 #                 (terway-controlplane is hosted by Aliyun in managed clusters; only a placeholder
 #                  service/terway-controlplane is visible to the user)
-#
-# The combination dual-stack + BYO is unsupported by the ACK API (rejected with
-# IPv6DependencyNotSatisfied.NetworkPlugin).
 #
 
 set -euo pipefail
@@ -73,13 +71,13 @@ profile_to_vars() {
             SERVICE_CIDR="192.168.0.0/16,fd00:1234::/112"
             ;;
         byo-dual)
-            log_error "Profile 'byo-dual' is not supported: ACK API rejects dual-stack clusters without a CNI plugin."
-            log_error "Use one of: byo-ipv4, ack-ipv4, ack-dual."
-            exit 2
+            IP_STACK="dual"
+            CLUSTER_MODE="byo"
+            SERVICE_CIDR="192.168.0.0/16,fd00:1234::/112"
             ;;
         *)
             log_error "Unknown profile: '$profile'"
-            log_error "Valid profiles: byo-ipv4, ack-ipv4, ack-dual"
+            log_error "Valid profiles: byo-ipv4, byo-dual, ack-ipv4, ack-dual"
             exit 2
             ;;
     esac
@@ -117,7 +115,7 @@ EOF
 cmd_create() {
     if [[ $# -lt 1 ]]; then
         log_error "create requires a profile argument"
-        log_error "Valid profiles: byo-ipv4, ack-ipv4, ack-dual"
+        log_error "Valid profiles: byo-ipv4, byo-dual, ack-ipv4, ack-dual"
         exit 2
     fi
     local profile="$1"; shift

--- a/hack/terraform/ack/terraform_e2e.tf
+++ b/hack/terraform/ack/terraform_e2e.tf
@@ -365,10 +365,6 @@ resource "alicloud_cs_managed_kubernetes" "default" {
 
   lifecycle {
     precondition {
-      condition     = !(var.cluster_mode == "byo" && var.ip_stack == "dual")
-      error_message = "byo + dual is not supported by ACK API (creating a dual-stack cluster without a CNI plugin is rejected with IPv6DependencyNotSatisfied.NetworkPlugin)."
-    }
-    precondition {
       condition     = var.ip_stack != "dual" || length(split(",", var.service_cidr)) >= 2
       error_message = "dual stack requires service_cidr to contain both IPv4 and IPv6 CIDRs (comma-separated, e.g. \"192.168.0.0/16,fd00:1234::/112\")."
     }


### PR DESCRIPTION
## Summary
  - Remove the byo+dual precondition guard in terraform_e2e.tf — ACK API now accepts creating dual-stack clusters without a CNI plugin (previously rejected with IPv6DependencyNotSatisfied.NetworkPlugin)
  - Add byo-dual profile in e2e-cluster.sh (ip_stack=dual, cluster_mode=byo, service_cidr=192.168.0.0/16,fd00:1234::/112)
  - Update help text and error messages to include byo-dual as a valid profile
  
  ## Test plan
  - [x] terraform plan with ip_stack=dual cluster_mode=byo succeeded
  - [x] terraform apply created ACK cluster successfully
  - [x] 6 nodes joined (NotReady expected — BYO mode has no CNI)
  - [x] kube-system has no terway pods (BYO mode confirmed) 
  - [x] terraform destroy cleaned up all resources