### PR TITLE
feat(cni): auto MTU detection via auto_mtu config option

### DIFF
--- a/charts/terway/templates/terwayd/configmap.yaml
+++ b/charts/terway/templates/terwayd/configmap.yaml
@@ -36,6 +36,7 @@ data:
       "eniip_virtual_type": "datapathv2",
       "host_stack_cidrs": ["169.254.20.10/32"],
 {{- end}}
+      "auto_mtu": {{ .Values.terway.autoMTU | default false }},
       "type": "terway"
     }
   disable_network_policy: {{ not .Values.terway.enableNetworkPolicy | quote }}

--- a/cmd/terway-cli/cni.go
+++ b/cmd/terway-cli/cni.go
@@ -21,6 +21,12 @@ type switchDataPathV2Func func() bool
 
 var _switchDataPathV2 switchDataPathV2Func
 
+type detectMTUFunc func() int
+
+var _detectMTU detectMTUFunc
+
+const defaultMTU = 1500
+
 const (
 	dataPathDefault = ""
 	dataPathVeth    = "veth"
@@ -69,6 +75,8 @@ func processCNIConfig(cmd *cobra.Command, args []string) error {
 	_checkKernelVersion = checkKernelVersion
 
 	_switchDataPathV2 = switchDataPathV2
+
+	_detectMTU = detectMTU
 
 	err := processInput()
 	if err != nil {
@@ -278,6 +286,15 @@ func mergeConfigList(configs [][]byte, f *feature) (string, error) {
 					return "", err
 				}
 			}
+
+			if autoMTU, ok := plugin.Path("auto_mtu").Data().(bool); ok {
+				_ = plugin.Delete("auto_mtu")
+				if autoMTU && _detectMTU != nil {
+					if err = applyMTU(plugin, _detectMTU()); err != nil {
+						return "", err
+					}
+				}
+			}
 		}
 
 		err = g.ArrayConcat(plugin.Data(), "plugins")
@@ -294,6 +311,48 @@ func mergeConfigList(configs [][]byte, f *feature) (string, error) {
 	}
 
 	return g.StringIndent("", "  "), nil
+}
+
+// applyMTU sets the mtu field on the plugin when it is not already set and
+// the detected mtu is positive.
+func applyMTU(plugin *gabs.Container, mtu int) error {
+	if plugin.Exists("mtu") || mtu <= 0 {
+		return nil
+	}
+	_, err := plugin.Set(mtu, "mtu")
+	return err
+}
+
+// readAutoMTUFromConfig reads the auto_mtu setting from the terway plugin
+// in the CNI config file at the given base path.
+func readAutoMTUFromConfig(basePath string) bool {
+	cfg, err := getAllConfig(basePath)
+	if err != nil {
+		return false
+	}
+	input := cfg.cniConfig
+	if cfg.cniConfigList != nil {
+		input = cfg.cniConfigList
+	}
+	c, err := gabs.ParseJSON(input)
+	if err != nil {
+		return false
+	}
+
+	var plugins []*gabs.Container
+	if c.Exists("plugins") {
+		plugins = c.Path("plugins").Children()
+	} else {
+		plugins = []*gabs.Container{c}
+	}
+	for _, plugin := range plugins {
+		if pluginType, ok := plugin.Path("type").Data().(string); ok && pluginType == pluginTypeTerway {
+			if autoMTU, ok := plugin.Path("auto_mtu").Data().(bool); ok {
+				return autoMTU
+			}
+		}
+	}
+	return false
 }
 
 func isMounted(path string) (bool, error) {

--- a/cmd/terway-cli/cni_linux.go
+++ b/cmd/terway-cli/cni_linux.go
@@ -152,6 +152,19 @@ func parseRelease(rel string) (major, minor, patch int, ok bool) {
 	return
 }
 
+// detectMTU returns the MTU of eth0. If eth0 is not found, returns defaultMTU.
+func detectMTU() int {
+	link, err := netlink.LinkByName("eth0")
+	if err != nil {
+		return defaultMTU
+	}
+	mtu := link.Attrs().MTU
+	if mtu <= 0 {
+		return defaultMTU
+	}
+	return mtu
+}
+
 func mountHostBpf() error {
 	target := "/sys/fs/bpf"
 

--- a/cmd/terway-cli/cni_linux_test.go
+++ b/cmd/terway-cli/cni_linux_test.go
@@ -278,3 +278,11 @@ func Test_isMounted(t *testing.T) {
 func Test_allowEBPFNetworkPolicy(t *testing.T) {
 
 }
+
+func Test_detectMTU(t *testing.T) {
+	mtu := detectMTU()
+	// On a real Linux node, eth0 should exist and have a valid MTU
+	// On CI without eth0, it should fall back to 1500
+	assert.Greater(t, mtu, 0)
+	assert.LessOrEqual(t, mtu, 65535)
+}

--- a/cmd/terway-cli/cni_test.go
+++ b/cmd/terway-cli/cni_test.go
@@ -837,6 +837,176 @@ func TestGetAllConfig_MissingCniConfig(t *testing.T) {
 	assert.Nil(t, cfg)
 }
 
+func Test_mergeConfigList_autoMTU(t *testing.T) {
+	_switchDataPathV2 = func() bool { return false }
+	origDetectMTU := _detectMTU
+	defer func() { _detectMTU = origDetectMTU }()
+	_detectMTU = func() int { return 9000 }
+
+	out, err := mergeConfigList([][]byte{
+		[]byte(`{
+            "type":"terway",
+            "auto_mtu": true
+        }`)}, &feature{EBPF: true, EDT: true})
+	assert.NoError(t, err)
+
+	g, err := gabs.ParseJSON([]byte(out))
+	assert.NoError(t, err)
+
+	assert.Equal(t, float64(9000), g.Path("plugins.0.mtu").Data())
+	assert.False(t, g.ExistsP("plugins.0.auto_mtu"))
+}
+
+func Test_mergeConfigList_autoMTU_disabled(t *testing.T) {
+	_switchDataPathV2 = func() bool { return false }
+
+	out, err := mergeConfigList([][]byte{
+		[]byte(`{
+            "type":"terway",
+            "foo":"bar"
+        }`)}, &feature{EBPF: true, EDT: true})
+	assert.NoError(t, err)
+
+	g, err := gabs.ParseJSON([]byte(out))
+	assert.NoError(t, err)
+
+	assert.False(t, g.ExistsP("plugins.0.mtu"))
+}
+
+func Test_mergeConfigList_autoMTU_userConfigured(t *testing.T) {
+	_switchDataPathV2 = func() bool { return false }
+	origDetectMTU := _detectMTU
+	defer func() { _detectMTU = origDetectMTU }()
+	_detectMTU = func() int { return 9000 }
+
+	out, err := mergeConfigList([][]byte{
+		[]byte(`{
+            "type":"terway",
+            "auto_mtu": true,
+            "mtu": 1400
+        }`)}, &feature{EBPF: true, EDT: true})
+	assert.NoError(t, err)
+
+	g, err := gabs.ParseJSON([]byte(out))
+	assert.NoError(t, err)
+
+	assert.Equal(t, float64(1400), g.Path("plugins.0.mtu").Data())
+}
+
+func Test_mergeConfigList_autoMTU_noEBPF(t *testing.T) {
+	_switchDataPathV2 = func() bool { return false }
+	origDetectMTU := _detectMTU
+	defer func() { _detectMTU = origDetectMTU }()
+	_detectMTU = func() int { return 9000 }
+
+	out, err := mergeConfigList([][]byte{
+		[]byte(`{
+            "type":"terway",
+            "auto_mtu": true
+        }`)}, &feature{EBPF: false, EDT: false})
+	assert.NoError(t, err)
+
+	g, err := gabs.ParseJSON([]byte(out))
+	assert.NoError(t, err)
+
+	// auto_mtu works regardless of eBPF support
+	assert.Equal(t, float64(9000), g.Path("plugins.0.mtu").Data())
+	assert.False(t, g.ExistsP("plugins.0.auto_mtu"))
+}
+
+func Test_processInput_withAutoMTU(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "cni_test")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	originalOutPutPath := outPutPath
+	originalCheckKernelVersion := _checkKernelVersion
+	originalSwitchDataPathV2 := _switchDataPathV2
+	originalDetectMTU := _detectMTU
+	defer func() {
+		outPutPath = originalOutPutPath
+		_checkKernelVersion = originalCheckKernelVersion
+		_switchDataPathV2 = originalSwitchDataPathV2
+		_detectMTU = originalDetectMTU
+	}()
+
+	outPutPath = tempDir + "/output.conflist"
+	_checkKernelVersion = func(major, minor, patch int) bool { return true }
+	_switchDataPathV2 = func() bool { return false }
+	_detectMTU = func() int { return 9000 }
+
+	patchGetAllConfig := gomonkey.ApplyFunc(getAllConfig, func(base string) (*TerwayConfig, error) {
+		return &TerwayConfig{
+			cniConfig:           []byte(`{"type":"terway","auto_mtu":true}`),
+			enableNetworkPolicy: true,
+		}, nil
+	})
+	defer patchGetAllConfig.Reset()
+
+	patchCheckBpfFeature := gomonkey.ApplyFunc(checkBpfFeature, func(key string) (bool, error) {
+		return true, nil
+	})
+	defer patchCheckBpfFeature.Reset()
+
+	err = processInput()
+	assert.NoError(t, err)
+
+	data, err := os.ReadFile(outPutPath)
+	assert.NoError(t, err)
+
+	g, err := gabs.ParseJSON(data)
+	assert.NoError(t, err)
+
+	assert.Equal(t, float64(9000), g.Path("plugins.0.mtu").Data())
+	assert.False(t, g.ExistsP("plugins.0.auto_mtu"))
+}
+
+func Test_processInput_withAutoMTU_disabled(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "cni_test")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	originalOutPutPath := outPutPath
+	originalCheckKernelVersion := _checkKernelVersion
+	originalSwitchDataPathV2 := _switchDataPathV2
+	originalDetectMTU := _detectMTU
+	defer func() {
+		outPutPath = originalOutPutPath
+		_checkKernelVersion = originalCheckKernelVersion
+		_switchDataPathV2 = originalSwitchDataPathV2
+		_detectMTU = originalDetectMTU
+	}()
+
+	outPutPath = tempDir + "/output.conflist"
+	_checkKernelVersion = func(major, minor, patch int) bool { return true }
+	_switchDataPathV2 = func() bool { return false }
+	_detectMTU = func() int { return 9000 }
+
+	patchGetAllConfig := gomonkey.ApplyFunc(getAllConfig, func(base string) (*TerwayConfig, error) {
+		return &TerwayConfig{
+			cniConfig:           []byte(`{"type":"terway"}`),
+			enableNetworkPolicy: true,
+		}, nil
+	})
+	defer patchGetAllConfig.Reset()
+
+	patchCheckBpfFeature := gomonkey.ApplyFunc(checkBpfFeature, func(key string) (bool, error) {
+		return true, nil
+	})
+	defer patchCheckBpfFeature.Reset()
+
+	err = processInput()
+	assert.NoError(t, err)
+
+	data, err := os.ReadFile(outPutPath)
+	assert.NoError(t, err)
+
+	g, err := gabs.ParseJSON(data)
+	assert.NoError(t, err)
+
+	assert.False(t, g.ExistsP("plugins.0.mtu"))
+}
+
 func TestGetAllConfig_MissingEniConf(t *testing.T) {
 	// Create temporary directory
 	tempDir, err := os.MkdirTemp("", "getAllConfig_test")

--- a/cmd/terway-cli/cni_unsupport.go
+++ b/cmd/terway-cli/cni_unsupport.go
@@ -31,3 +31,5 @@ func configureNetworkRulesWithConfig(ipv4, ipv6 bool, config *types.SymmetricRou
 }
 
 func mountHostBpf() error { return nil }
+
+func detectMTU() int { return defaultMTU }

--- a/cmd/terway-cli/node.go
+++ b/cmd/terway-cli/node.go
@@ -164,7 +164,33 @@ func setExclusiveMode(store nodecap.NodeCapabilitiesStore, labels map[string]str
 
 	// write cni config
 	if now == types.ExclusiveENIOnly {
-		err = os.WriteFile(cniPath, []byte(eniOnlyCNI), 0644)
+		cniConfig := eniOnlyCNI
+
+		// nodeconfig path never runs processCNIConfig, so _detectMTU may be
+		// unset here; fall back to the real detector so auto_mtu also works
+		// for exclusive ENI-only nodes.
+		detect := _detectMTU
+		if detect == nil {
+			detect = detectMTU
+		}
+
+		if autoMTU := readAutoMTUFromConfig(eniConfBasePath); autoMTU {
+			g, err := gabs.ParseJSON([]byte(eniOnlyCNI))
+			if err != nil {
+				return err
+			}
+			mtu := detect()
+			for _, plugin := range g.Path("plugins").Children() {
+				if pluginType, ok := plugin.Path("type").Data().(string); ok && pluginType == pluginTypeTerway {
+					if err := applyMTU(plugin, mtu); err != nil {
+						return err
+					}
+				}
+			}
+			cniConfig = g.StringIndent("", "  ")
+		}
+
+		err = os.WriteFile(cniPath, []byte(cniConfig), 0644)
 		if err != nil {
 			return err
 		}

--- a/cmd/terway-cli/node_test.go
+++ b/cmd/terway-cli/node_test.go
@@ -23,6 +23,8 @@ import (
 
 	"github.com/AliyunContainerService/terway/pkg/utils/nodecap"
 	"github.com/AliyunContainerService/terway/types/daemon"
+
+	"github.com/Jeffail/gabs/v2"
 )
 
 func TestExclusiveModeNewNode(t *testing.T) {
@@ -91,6 +93,40 @@ func TestExclusiveModeWritesCNIConfigWhenSet(t *testing.T) {
 	content, err := os.ReadFile(cniPath)
 	assert.NoError(t, err)
 	assert.Contains(t, string(content), `"type": "terway"`)
+}
+
+func TestExclusiveModeWritesCNIConfigWithAutoMTU(t *testing.T) {
+	tempFile, err := os.CreateTemp("", "test_node_capabilities")
+	assert.NoError(t, err)
+	defer os.Remove(tempFile.Name())
+
+	store := nodecap.NewFileNodeCapabilities(tempFile.Name())
+	labels := map[string]string{"k8s.aliyun.com/exclusive-mode-eni-type": "eniOnly"}
+	cniPath := tempFile.Name() + "_cni_config"
+	defer os.Remove(cniPath)
+
+	origDetectMTU := _detectMTU
+	defer func() { _detectMTU = origDetectMTU }()
+	_detectMTU = func() int { return 8500 }
+
+	// Mock readAutoMTUFromConfig via getAllConfig (auto_mtu=true in input config)
+	patchGetAllConfig := gomonkey.ApplyFunc(getAllConfig, func(base string) (*TerwayConfig, error) {
+		return &TerwayConfig{
+			cniConfig:           []byte(`{"type":"terway","auto_mtu":true}`),
+			enableNetworkPolicy: true,
+		}, nil
+	})
+	defer patchGetAllConfig.Reset()
+
+	err = setExclusiveMode(store, labels, cniPath)
+	assert.NoError(t, err)
+
+	content, err := os.ReadFile(cniPath)
+	assert.NoError(t, err)
+
+	g, err := gabs.ParseJSON(content)
+	assert.NoError(t, err)
+	assert.Equal(t, float64(8500), g.Path("plugins.0.mtu").Data())
 }
 
 func TestExclusiveModeDoesNotWriteCNIConfigWhenNotSet(t *testing.T) {


### PR DESCRIPTION
Add auto_mtu option to the terway CNI plugin config. When set to true in 10-terway.conf, terway-cli detects the node primary interface (eth0) MTU at init time and writes it into the generated CNI conflist.

- Config-driven: set "auto_mtu": true in 10-terway.conf
- Detect MTU from eth0 in terway-cli cni init, fallback to 1500
- Works for all datapaths (veth, ipvlan, datapathv2, and non-eBPF)
- Respect user-configured mtu: if already set in config, do not override
- Support exclusive ENI nodes (reads auto_mtu from input config)
- auto_mtu field is stripped from the output conflist
- Enabled by default in chart values (terway.autoMTU: true)