### PR TITLE
fix(ipam): preserve PodID bindings in syncTaskQueueStatus

### DIFF
--- a/pkg/controller/multi-ip/node/pool.go
+++ b/pkg/controller/multi-ip/node/pool.go
@@ -968,9 +968,20 @@ func (n *ReconcileNode) syncTaskQueueStatus(ctx context.Context, node *networkv1
 				nic.PrimaryIPAddress = task.ENIInfo.PrivateIPAddress
 				nic.NetworkInterfaceTrafficMode = networkv1beta1.NetworkInterfaceTrafficMode(task.ENIInfo.NetworkInterfaceTrafficMode)
 
-				// Convert IP sets using existing helper function
-				nic.IPv4 = convertIPSet(task.ENIInfo.PrivateIPSets)
-				nic.IPv6 = convertIPSet(task.ENIInfo.IPv6Set)
+				// Merge IP sets from the task result, preserving existing PodID bindings.
+				// A recovery task may complete after IPs have already been assigned to pods
+				// (the task was submitted when the ENI was Attaching, but by the time it
+				// completes the ENI is InUse with active pod bindings).
+				if nic.IPv4 == nil {
+					nic.IPv4 = convertIPSet(task.ENIInfo.PrivateIPSets)
+				} else {
+					mergeIPMap(l, convertIPSet(task.ENIInfo.PrivateIPSets), nic.IPv4)
+				}
+				if nic.IPv6 == nil {
+					nic.IPv6 = convertIPSet(task.ENIInfo.IPv6Set)
+				} else {
+					mergeIPMap(l, convertIPSet(task.ENIInfo.IPv6Set), nic.IPv6)
+				}
 
 				// IMPORTANT: Update prefixes from DescribeNetworkInterface response.
 				// This ensures prefixes are correctly recorded even if the CreateNetworkInterface

--- a/pkg/controller/multi-ip/node/pool_test.go
+++ b/pkg/controller/multi-ip/node/pool_test.go
@@ -2632,6 +2632,104 @@ var _ = Describe("Test ReconcileNode", func() {
 		})
 	})
 
+	Context("Test syncTaskQueueStatus preserves PodID", func() {
+		It("Should preserve existing PodID bindings when syncing completed task", func() {
+			ctx := context.TODO()
+			ctx = MetaIntoCtx(ctx)
+
+			// Setup mock API
+			mockHelper := NewMockAPIHelperWithT(GinkgoT())
+			openAPI, _, _ = mockHelper.GetMocks()
+			openAPI.On("AttachNetworkInterfaceV2", mock.Anything, mock.Anything).Return(nil).Maybe()
+			openAPI.On("DescribeNetworkInterfaceV2", mock.Anything, mock.Anything).Return([]*aliyunClient.NetworkInterface{}, nil).Maybe()
+
+			// Create reconciler with task queue
+			reconciler := NewReconcilerBuilder().
+				WithAliyun(openAPI).
+				WithVSwitchPool(switchPool).
+				WithDefaults().
+				Build()
+
+			By("Setting up node with InUse ENI that has an IP already assigned to a Pod")
+			ipv4s := map[string]*networkv1beta1.IP{
+				"10.149.35.182": {
+					IP:      "10.149.35.182",
+					Status:  networkv1beta1.IPStatusValid,
+					Primary: true,
+					PodID:   "kube-system/loongcollector",
+					PodUID:  "uid-loongcollector",
+				},
+				"10.149.38.38": {
+					IP:      "10.149.38.38",
+					Status:  networkv1beta1.IPStatusValid,
+					Primary: false,
+					PodID:   "",
+				},
+			}
+			eniInUse := BuildENIWithCustomIPs("eni-trunk-1", aliyunClient.ENIStatusInUse, ipv4s, nil)
+			eniInUse.NetworkInterfaceType = networkv1beta1.ENITypeTrunk
+
+			node := NewNodeFactory("test-node").
+				WithECS().
+				WithInstanceID("i-test").
+				WithExistingENIs(eniInUse).
+				Build()
+
+			By("Creating completed task with same IPs but without PodID (simulating OpenAPI response)")
+			now := time.Now()
+			eniInfo := &aliyunClient.NetworkInterface{
+				NetworkInterfaceID: "eni-trunk-1",
+				Type:               string(networkv1beta1.ENITypeTrunk),
+				Status:             aliyunClient.ENIStatusInUse,
+				MacAddress:         "aa:bb:cc:dd:ee:01",
+				SecurityGroupIDs:   []string{"sg-1"},
+				PrivateIPAddress:   "10.149.35.182",
+				NetworkInterfaceTrafficMode: "Standard",
+				PrivateIPSets: []aliyunClient.IPSet{
+					{IPAddress: "10.149.35.182", Primary: true},
+					{IPAddress: "10.149.38.38", Primary: false},
+				},
+				IPv6Set: nil,
+			}
+
+			reconciler.eniTaskQueue.tasks["eni-trunk-1"] = &ENITaskRecord{
+				ENIID:              "eni-trunk-1",
+				Operation:          OpAttach,
+				InstanceID:         "i-test",
+				NodeName:           "test-node",
+				Status:             TaskStatusCompleted,
+				CreatedAt:          now.Add(-1 * time.Minute),
+				CompletedAt:        &now,
+				RequestedIPv4Count: 2,
+				RequestedIPv6Count: 0,
+				ENIInfo:            eniInfo,
+				Error:              nil,
+			}
+
+			By("Calling syncTaskQueueStatus to process completed task")
+			reconciler.syncTaskQueueStatus(ctx, node)
+
+			By("Verifying ENI status is updated")
+			Expect(node.Status.NetworkInterfaces).To(HaveKey("eni-trunk-1"))
+			nic := node.Status.NetworkInterfaces["eni-trunk-1"]
+			Expect(nic.Status).To(Equal(aliyunClient.ENIStatusInUse))
+
+			By("Verifying IPv4 addresses are present")
+			Expect(nic.IPv4).To(HaveLen(2))
+			Expect(nic.IPv4).To(HaveKey("10.149.35.182"))
+			Expect(nic.IPv4).To(HaveKey("10.149.38.38"))
+
+			By("Verifying PodID is preserved on the primary IP that was already assigned")
+			Expect(nic.IPv4["10.149.35.182"].PodID).To(Equal("kube-system/loongcollector"),
+				"syncTaskQueueStatus should preserve existing PodID bindings")
+			Expect(nic.IPv4["10.149.35.182"].PodUID).To(Equal("uid-loongcollector"),
+				"syncTaskQueueStatus should preserve existing PodUID bindings")
+
+			By("Verifying the free IP remains unassigned")
+			Expect(nic.IPv4["10.149.38.38"].PodID).To(Equal(""))
+		})
+	})
+
 	Context("Test assign err", func() {
 		It("Test assign err", func() {
 


### PR DESCRIPTION
syncTaskQueueStatus unconditionally overwrites nic.IPv4/IPv6 with convertIPSet() when processing a completed attach task. This clears all existing PodID bindings, causing pods to be reassigned to different IPs in the subsequent assignIPFromLocalPool call.

This race occurs when a recovery task (submitted for an Attaching ENI) completes after the ENI has transitioned to InUse and already has pods bound to its IPs. The task's lifecycle crosses the reconcile boundary: submitted when no pods are using the ENI, but consumed when they are.

Use mergeIPMap instead of direct assignment to preserve existing PodID bindings while still incorporating IP changes from the task result.