### PR TITLE
fix(ipam): exclude LENI primary ENI from pod IP allocation pool

### DIFF
--- a/pkg/aliyun/client/types.go
+++ b/pkg/aliyun/client/types.go
@@ -225,6 +225,22 @@ func LogFields(l logr.Logger, obj any) logr.Logger {
 	return r
 }
 
+// IsLENIPrimary returns true if the ENI has both leni_primary=true and
+// acs:ecs:support_eni=true tags, indicating it's a migrated LENI primary
+// that serves as the node's primary interface.
+func IsLENIPrimary(eni *NetworkInterface) bool {
+	var leniPrimary, supportENI bool
+	for _, tag := range eni.Tags {
+		if tag.TagKey == "leni_primary" && tag.TagValue == "true" {
+			leniPrimary = true
+		}
+		if tag.TagKey == "acs:ecs:support_eni" && tag.TagValue == "true" {
+			supportENI = true
+		}
+	}
+	return leniPrimary && supportENI
+}
+
 // ClassifyENILinkCapability checks whether a list of ENIs indicates ECS link support.
 // hasPrimary is true when a Primary ENI exists (new ENI link instances).
 // hasMigrationTags is true when any non-Primary ENI has both leni_primary=true
@@ -235,17 +251,7 @@ func ClassifyENILinkCapability(enis []*NetworkInterface) (hasPrimary, hasMigrati
 			hasPrimary = true
 			continue
 		}
-
-		var leniPrimary, supportENI bool
-		for _, tag := range eni.Tags {
-			if tag.TagKey == "leni_primary" && tag.TagValue == "true" {
-				leniPrimary = true
-			}
-			if tag.TagKey == "acs:ecs:support_eni" && tag.TagValue == "true" {
-				supportENI = true
-			}
-		}
-		if leniPrimary && supportENI {
+		if IsLENIPrimary(eni) {
 			hasMigrationTags = true
 		}
 	}

--- a/pkg/aliyun/client/types_test.go
+++ b/pkg/aliyun/client/types_test.go
@@ -5,6 +5,7 @@ import (
 
 	ecs20140526 "github.com/alibabacloud-go/ecs-20140526/v7/client"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/ecs"
+	"github.com/stretchr/testify/assert"
 	"k8s.io/utils/ptr"
 )
 
@@ -335,4 +336,117 @@ func TestFromAttributeResp_InstanceIDDirectTakesPrecedence(t *testing.T) {
 	if ni.InstanceID != "i-direct" {
 		t.Errorf("expected direct InstanceID to take precedence, got %s", ni.InstanceID)
 	}
+}
+
+func TestClassifyENILinkCapability(t *testing.T) {
+	t.Run("empty list", func(t *testing.T) {
+		hasPrimary, hasMigration := ClassifyENILinkCapability(nil)
+		assert.False(t, hasPrimary)
+		assert.False(t, hasMigration)
+	})
+
+	t.Run("primary ENI", func(t *testing.T) {
+		enis := []*NetworkInterface{
+			{Type: ENITypePrimary},
+		}
+		hasPrimary, hasMigration := ClassifyENILinkCapability(enis)
+		assert.True(t, hasPrimary)
+		assert.False(t, hasMigration)
+	})
+
+	t.Run("migration tags both set", func(t *testing.T) {
+		enis := []*NetworkInterface{
+			{
+				Type: ENITypeSecondary,
+				Tags: []ecs.Tag{
+					{TagKey: "leni_primary", TagValue: "true"},
+					{TagKey: "acs:ecs:support_eni", TagValue: "true"},
+				},
+			},
+		}
+		hasPrimary, hasMigration := ClassifyENILinkCapability(enis)
+		assert.False(t, hasPrimary)
+		assert.True(t, hasMigration)
+	})
+
+	t.Run("only leni_primary tag", func(t *testing.T) {
+		enis := []*NetworkInterface{
+			{
+				Type: ENITypeSecondary,
+				Tags: []ecs.Tag{
+					{TagKey: "leni_primary", TagValue: "true"},
+				},
+			},
+		}
+		_, hasMigration := ClassifyENILinkCapability(enis)
+		assert.False(t, hasMigration)
+	})
+
+	t.Run("primary and migration mixed", func(t *testing.T) {
+		enis := []*NetworkInterface{
+			{Type: ENITypePrimary},
+			{
+				Type: ENITypeSecondary,
+				Tags: []ecs.Tag{
+					{TagKey: "leni_primary", TagValue: "true"},
+					{TagKey: "acs:ecs:support_eni", TagValue: "true"},
+				},
+			},
+		}
+		hasPrimary, hasMigration := ClassifyENILinkCapability(enis)
+		assert.True(t, hasPrimary)
+		assert.True(t, hasMigration)
+	})
+}
+
+func TestIsLENIPrimary(t *testing.T) {
+	t.Run("both tags present", func(t *testing.T) {
+		eni := &NetworkInterface{
+			Type: ENITypeSecondary,
+			Tags: []ecs.Tag{
+				{TagKey: "leni_primary", TagValue: "true"},
+				{TagKey: "acs:ecs:support_eni", TagValue: "true"},
+			},
+		}
+		assert.True(t, IsLENIPrimary(eni))
+	})
+
+	t.Run("only leni_primary tag", func(t *testing.T) {
+		eni := &NetworkInterface{
+			Type: ENITypeSecondary,
+			Tags: []ecs.Tag{
+				{TagKey: "leni_primary", TagValue: "true"},
+			},
+		}
+		assert.False(t, IsLENIPrimary(eni))
+	})
+
+	t.Run("only support_eni tag", func(t *testing.T) {
+		eni := &NetworkInterface{
+			Type: ENITypeSecondary,
+			Tags: []ecs.Tag{
+				{TagKey: "acs:ecs:support_eni", TagValue: "true"},
+			},
+		}
+		assert.False(t, IsLENIPrimary(eni))
+	})
+
+	t.Run("no tags", func(t *testing.T) {
+		eni := &NetworkInterface{
+			Type: ENITypeSecondary,
+		}
+		assert.False(t, IsLENIPrimary(eni))
+	})
+
+	t.Run("tags with wrong values", func(t *testing.T) {
+		eni := &NetworkInterface{
+			Type: ENITypeSecondary,
+			Tags: []ecs.Tag{
+				{TagKey: "leni_primary", TagValue: "false"},
+				{TagKey: "acs:ecs:support_eni", TagValue: "true"},
+			},
+		}
+		assert.False(t, IsLENIPrimary(eni))
+	})
+
 }

--- a/pkg/controller/multi-ip/node/pool.go
+++ b/pkg/controller/multi-ip/node/pool.go
@@ -462,9 +462,12 @@ func (n *ReconcileNode) syncWithAPI(ctx context.Context, node *networkv1beta1.No
 		return err
 	}
 
-	// ignore primary eni
+	// ignore primary eni (including migration-tagged LENI primary on lingjun nodes)
 	enis = lo.Filter(enis, func(item *aliyunClient.NetworkInterface, index int) bool {
-		return item.Type != aliyunClient.ENITypePrimary
+		if item.Type == aliyunClient.ENITypePrimary {
+			return false
+		}
+		return !aliyunClient.IsLENIPrimary(item)
 	})
 
 	eniIDMap := map[string]struct{}{}

--- a/pkg/controller/multi-ip/node/pool_test.go
+++ b/pkg/controller/multi-ip/node/pool_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/AliyunContainerService/terway/pkg/internal/testutil"
 	vswpool "github.com/AliyunContainerService/terway/pkg/vswitch"
 	"github.com/AliyunContainerService/terway/types"
+	"github.com/aliyun/alibaba-cloud-sdk-go/services/ecs"
 	"github.com/aliyun/alibaba-cloud-sdk-go/services/vpc"
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
@@ -3167,6 +3168,61 @@ var _ = Describe("Test ReconcileNode", func() {
 			By("Syncing network interfaces with API")
 			err := reconciler.syncWithAPI(ctx, node)
 			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("Should filter out LENI primary ENI with migration tags", func() {
+			ctx := context.TODO()
+			ctx = MetaIntoCtx(ctx)
+			MetaCtx(ctx).NeedSyncOpenAPI.Store(true)
+
+			// Setup mock API
+			mockHelper := NewMockAPIHelperWithT(GinkgoT())
+			openAPI, vpcClient, ecsClient = mockHelper.GetMocks()
+
+			// Setup vSwitch
+			mockHelper.SetupVSwitch("vsw-1", &vpc.VSwitch{
+				VSwitchId:               "vsw-1",
+				ZoneId:                  "zone-1",
+				AvailableIpAddressCount: 10,
+				CidrBlock:               "192.168.0.0/16",
+				Ipv6CidrBlock:           "fd00::/64",
+			})
+
+			// Build a LENI primary ENI (migration-tagged, serves as node's primary interface)
+			leniPrimaryENI := BuildMockENI("eni-leni", "Secondary", "InUse", "vsw-1", "zone-1",
+				[]string{"172.16.0.153", "172.16.0.215"}, nil)
+			leniPrimaryENI.Tags = []ecs.Tag{
+				{TagKey: "leni_primary", TagValue: "true"},
+				{TagKey: "acs:ecs:support_eni", TagValue: "true"},
+			}
+
+			// Setup API to return: LENI primary (should be filtered), normal secondary (should be kept)
+			openAPI.On("DescribeNetworkInterfaceV2", mock.Anything, mock.Anything).Return([]*aliyunClient.NetworkInterface{
+				leniPrimaryENI,
+				BuildMockENI("eni-normal", "Secondary", "InUse", "vsw-1", "zone-1",
+					[]string{"192.168.0.10", "192.168.0.11"}, nil),
+			}, nil).Maybe()
+
+			node := NewNodeFactory("lingjun-node").
+				WithECS().
+				WithInstanceID("test-lingjun-instance").
+				Build()
+
+			reconciler := NewReconcilerBuilder().
+				WithAliyun(openAPI).
+				WithVSwitchPool(switchPool).
+				WithSyncPeriod(time.Hour).
+				WithDefaults().
+				Build()
+
+			By("Syncing network interfaces with API")
+			err := reconciler.syncWithAPI(ctx, node)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying LENI primary ENI was filtered out")
+			Expect(node.Status.NetworkInterfaces).To(HaveLen(1))
+			Expect(node.Status.NetworkInterfaces).To(HaveKey("eni-normal"))
+			Expect(node.Status.NetworkInterfaces).NotTo(HaveKey("eni-leni"))
 		})
 	})
 


### PR DESCRIPTION
On migrated lingjun nodes, the ENI with tags leni_primary=true and acs:ecs:support_eni=true serves as the node's primary interface (eth0) but has type=Secondary in ECS API responses. The syncWithAPI filter only excluded type=Primary ENIs, causing this LENI primary to be added to the pod IP pool. This led to cilium-cni failures with "unable to determine eni index of veth pair on the host side" because datapathv2 expects pod ENIs to be separate auxiliary interfaces.

Add IsLENIPrimary() helper and use it in the syncWithAPI filter to exclude migration-tagged LENI primary ENIs from the pod IP pool.