### PR TITLE
feat(policy): update cilium to v1.18.12

### DIFF
--- a/deploy/images/policy/Dockerfile
+++ b/deploy/images/policy/Dockerfile
@@ -21,7 +21,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     ( ! $(readelf -d bin/calico-felix | grep -q NEEDED) || ( echo "Error: bin/calico-felix was not statically linked"; false )) \
     && chmod +x /go/src/github.com/projectcalico/calico/bin/calico-felix
 
-FROM --platform=$TARGETPLATFORM quay.io/cilium/cilium-builder:e372b04eadada3a9931ccd207d2a2733c0592541@sha256:177553f27721c9762475ba3049d99012108adf0b48344dde34bbc3081e31e2fc as cilium-builder
+FROM --platform=$TARGETPLATFORM quay.io/cilium/cilium-builder:8ff4fa93aa6ae31a447562bb8e95d9166ec38493@sha256:a4d151717a7ac362ae1a95c457926a1b42ae208c91a7b13a73943768ea4d8c6a as cilium-builder
 ARG GOPROXY
 ENV GOPROXY=$GOPROXY
 ARG CILIUM_SHA=""
@@ -30,13 +30,14 @@ LABEL cilium-sha=${CILIUM_SHA}
 LABEL maintainer="maintainer@cilium.io"
 WORKDIR /go/src/github.com/cilium
 RUN rm -rf cilium
-ENV GIT_TAG=v1.18.10
-ENV GIT_COMMIT=6bf2fe83d2fce50283b702d96c6190f7693dc224
+ENV GIT_TAG=v1.18.12
+ENV GIT_COMMIT=c2cd21cf99352ac16f451c684ba62807b18542e3
 RUN git clone -b $GIT_TAG --depth 1 https://github.com/cilium/cilium.git && \
     cd cilium && git config --global user.email terway && git config --global user.name terway && \
     [ "`git rev-parse HEAD`" = "${GIT_COMMIT}" ]
 COPY ../../../policy/cilium /cilium_patch
 RUN cd cilium && git am --whitespace=fix /cilium_patch/*.patch
+RUN cd cilium && go mod vendor
 ARG NOSTRIP
 ARG LOCKDEBUG
 ARG V

--- a/policy/cilium/0001-terway-cni.patch
+++ b/policy/cilium/0001-terway-cni.patch
@@ -1,7 +1,7 @@
-From 58b71ad433c8b5d5245c86a8d0eef67d4a5337f9 Mon Sep 17 00:00:00 2001
+From d588cc389e8585e80d9eb3645abfeae38d0a4175 Mon Sep 17 00:00:00 2001
 From: l1b0k <libokang.lbk@alibaba-inc.com>
 Date: Tue, 21 Oct 2025 15:26:32 +0800
-Subject: [PATCH] terway: cni
+Subject: [PATCH 1/9] terway: cni
 
 Signed-off-by: l1b0k <libokang.lbk@alibaba-inc.com>
 ---
@@ -558,7 +558,7 @@ index 0000000000..e140cb821f
 +	chainingapi.Register(name, &genericveth.GenericVethChainer{})
 +}
 diff --git a/plugins/cilium-cni/cmd/cmd.go b/plugins/cilium-cni/cmd/cmd.go
-index 885e10017f..933c7472d7 100644
+index 38642d042d..10c96f7bbf 100644
 --- a/plugins/cilium-cni/cmd/cmd.go
 +++ b/plugins/cilium-cni/cmd/cmd.go
 @@ -48,6 +48,7 @@ import (

--- a/policy/cilium/0002-lb-enable-in-cluster-load-balancer.patch
+++ b/policy/cilium/0002-lb-enable-in-cluster-load-balancer.patch
@@ -1,7 +1,7 @@
-From 81cd99b3b46dc04700a9439eaae07af416095763 Mon Sep 17 00:00:00 2001
+From 9ca80bee99abcdbded524153c50f698aec6f067c Mon Sep 17 00:00:00 2001
 From: l1b0k <libokang.lbk@alibaba-inc.com>
 Date: Thu, 13 Nov 2025 15:02:38 +0800
-Subject: [PATCH] lb: enable in cluster load balancer
+Subject: [PATCH 2/9] lb: enable in cluster load balancer
 
 Signed-off-by: l1b0k <libokang.lbk@alibaba-inc.com>
 ---
@@ -109,7 +109,7 @@ index 4ade0dddf0..2b57f45b18 100644
  		EnableSocketLB:                         kprCfg.EnableSocketLB,
  		EnableSocketLBPodConnectionTermination: cfg.EnableSocketLBPodConnectionTermination,
 diff --git a/pkg/loadbalancer/reflectors/conversions.go b/pkg/loadbalancer/reflectors/conversions.go
-index 62734ea932..f4be4696b1 100644
+index 65e3e71c28..03cc2cea3c 100644
 --- a/pkg/loadbalancer/reflectors/conversions.go
 +++ b/pkg/loadbalancer/reflectors/conversions.go
 @@ -277,7 +277,9 @@ func convertService(cfg loadbalancer.Config, extCfg loadbalancer.ExternalConfig,

--- a/policy/cilium/0003-feat-daemon-add-disable-per-packet-LB-policy-flag.patch
+++ b/policy/cilium/0003-feat-daemon-add-disable-per-packet-LB-policy-flag.patch
@@ -1,7 +1,7 @@
-From 8b12242b89082a5777e25218cf54e7b843e44cfc Mon Sep 17 00:00:00 2001
+From bb073efb92f0a9b6621fd80c1269ad274b8e699c Mon Sep 17 00:00:00 2001
 From: l1b0k <libokang.lbk@alibaba-inc.com>
 Date: Thu, 13 Nov 2025 15:08:54 +0800
-Subject: [PATCH] feat(daemon): add disable per-packet LB policy flag
+Subject: [PATCH 3/9] feat(daemon): add disable per-packet LB policy flag
 
 Signed-off-by: l1b0k <libokang.lbk@alibaba-inc.com>
 ---

--- a/policy/cilium/0004-endpoint-fix-sip-config.patch
+++ b/policy/cilium/0004-endpoint-fix-sip-config.patch
@@ -1,7 +1,7 @@
-From 53087f62941c71aafe8c7f557633ae89ba3774a4 Mon Sep 17 00:00:00 2001
+From cf45ff6060cad012caed5bbb511dc3d7870c7e2c Mon Sep 17 00:00:00 2001
 From: l1b0k <libokang.lbk@alibaba-inc.com>
 Date: Thu, 18 Dec 2025 11:00:11 +0800
-Subject: [PATCH] endpoint: fix sip config
+Subject: [PATCH 4/9] endpoint: fix sip config
 
 Signed-off-by: l1b0k <libokang.lbk@alibaba-inc.com>
 ---

--- a/policy/cilium/0005-feat-datapath-add-multi-host-stack-support-for-veth-.patch
+++ b/policy/cilium/0005-feat-datapath-add-multi-host-stack-support-for-veth-.patch
@@ -1,7 +1,7 @@
-From 27b4dae4fd8dcc6fd2878fffd94160d944f76ce6 Mon Sep 17 00:00:00 2001
+From f11fe6c3141ebe950f6cd029f0299c6cd0645bb6 Mon Sep 17 00:00:00 2001
 From: l1b0k <libokang.lbk@alibaba-inc.com>
 Date: Mon, 9 Mar 2026 16:11:17 +0800
-Subject: [PATCH] feat(datapath): add multi-host stack support for veth
+Subject: [PATCH 5/9] feat(datapath): add multi-host stack support for veth
  datapath- Implement host stack CIDR map and related functions - Add support
  for multiple host stack CIDRs in veth datapath mode - Update bpf_lxc to
  handle multiple host stack CIDRs - Modify daemon initialization to set up

--- a/policy/cilium/0006-feat-node-implement-NodeMapGarbageCollect-for-garbag.patch
+++ b/policy/cilium/0006-feat-node-implement-NodeMapGarbageCollect-for-garbag.patch
@@ -1,7 +1,7 @@
-From 4cb08a7d0fde447af895d5344688c63398839be6 Mon Sep 17 00:00:00 2001
+From 34373c4750eeaad258019ff92ff633b5297cef57 Mon Sep 17 00:00:00 2001
 From: l1b0k <libokang.lbk@alibaba-inc.com>
 Date: Mon, 9 Mar 2026 16:27:19 +0800
-Subject: [PATCH] feat(node): implement NodeMapGarbageCollect for garbage
+Subject: [PATCH 6/9] feat(node): implement NodeMapGarbageCollect for garbage
  collection of stale BPF node map entries
 
 Signed-off-by: l1b0k <libokang.lbk@alibaba-inc.com>

--- a/policy/cilium/0007-feat-k8s-skip-CRD-register-wait-for-CPIP-CNC-CL2AP-i.patch
+++ b/policy/cilium/0007-feat-k8s-skip-CRD-register-wait-for-CPIP-CNC-CL2AP-i.patch
@@ -1,7 +1,7 @@
-From 9b52716691ca2b62ca9c6316d644fca3f5e15160 Mon Sep 17 00:00:00 2001
+From 9c0faeeb213564b4877c9da713e4c4cc691143d6 Mon Sep 17 00:00:00 2001
 From: l1b0k <libokang.lbk@alibaba-inc.com>
 Date: Wed, 13 May 2026 14:10:16 +0800
-Subject: [PATCH] feat(k8s): skip CRD register/wait for CPIP, CNC, CL2AP in
+Subject: [PATCH 7/9] feat(k8s): skip CRD register/wait for CPIP, CNC, CL2AP in
  Terway integration
 
 Remove unconditional registration and agent-side wait for three CRDs that
@@ -26,7 +26,7 @@ Signed-off-by: l1b0k <libokang.lbk@alibaba-inc.com>
  2 files changed, 9 insertions(+), 17 deletions(-)
 
 diff --git a/pkg/k8s/apis/cilium.io/client/register.go b/pkg/k8s/apis/cilium.io/client/register.go
-index 216ed4b5b4..149a9c749a 100644
+index 0ec1f49f0f..d7d4385127 100644
 --- a/pkg/k8s/apis/cilium.io/client/register.go
 +++ b/pkg/k8s/apis/cilium.io/client/register.go
 @@ -131,10 +131,8 @@ func CustomResourceDefinitionList() map[string]*CRDList {

--- a/policy/cilium/0008-cep-optimize-cep-watch.patch
+++ b/policy/cilium/0008-cep-optimize-cep-watch.patch
@@ -1,7 +1,7 @@
-From e4f6dc648d5e8ecb47f9e2e805aa65a3144c8bbb Mon Sep 17 00:00:00 2001
+From b955c3885f7128348d2718aa9e217cfd3e89aec6 Mon Sep 17 00:00:00 2001
 From: l1b0k <libokang.lbk@alibaba-inc.com>
 Date: Tue, 26 May 2026 19:47:27 +0800
-Subject: [PATCH] cep: optimize cep watch
+Subject: [PATCH 8/9] cep: optimize cep watch
 
 Reduce agent CEP list/watch load in large clusters by filtering CEPs to
 the local node:

--- a/policy/cilium/0009-lb-skip-pruning-proto-ANY-service-entries-for-upgrad.patch
+++ b/policy/cilium/0009-lb-skip-pruning-proto-ANY-service-entries-for-upgrad.patch
@@ -1,7 +1,7 @@
-From c750c7837375892a804b71c56376f7744b8f5964 Mon Sep 17 00:00:00 2001
+From 44b4c3d75bced8f68ec775cf366559aad02bceff Mon Sep 17 00:00:00 2001
 From: l1b0k <libokang.lbk@alibaba-inc.com>
 Date: Tue, 2 Jun 2026 17:35:02 +0800
-Subject: [PATCH] lb: skip pruning proto=ANY service entries for upgrade
+Subject: [PATCH 9/9] lb: skip pruning proto=ANY service entries for upgrade
  compatibility
 
 During upgrade from cilium 1.16 (proto=ANY) to 1.18 (proto=TCP/UDP),

--- a/policy/cilium/0010-chore-deps-update-golang.org-x-dependencies-to-lates.patch
+++ b/policy/cilium/0010-chore-deps-update-golang.org-x-dependencies-to-lates.patch
@@ -1,0 +1,136 @@
+From f6fec4b71ecb9987049e7295aaee8d8889ee314f Mon Sep 17 00:00:00 2001
+From: l1b0k <libokang.lbk@alibaba-inc.com>
+Date: Mon, 10 Aug 2026 14:01:10 +0800
+Subject: [PATCH] chore(deps): update golang.org/x dependencies to latest
+ versions
+
+Signed-off-by: l1b0k <libokang.lbk@alibaba-inc.com>
+---
+ go.mod | 18 +++++++++---------
+ go.sum | 36 ++++++++++++++++++------------------
+ 2 files changed, 27 insertions(+), 27 deletions(-)
+
+diff --git a/go.mod b/go.mod
+index 121bbef30b..010a78d85b 100644
+--- a/go.mod
++++ b/go.mod
+@@ -104,15 +104,15 @@ require (
+ 	go.uber.org/zap v1.27.0
+ 	go.yaml.in/yaml/v3 v3.0.4
+ 	go4.org/netipx v0.0.0-20231129151722-fdeea329fbba
+-	golang.org/x/crypto v0.52.0
+-	golang.org/x/mod v0.35.0
+-	golang.org/x/net v0.55.0
+-	golang.org/x/sync v0.20.0
+-	golang.org/x/sys v0.45.0
+-	golang.org/x/term v0.43.0
+-	golang.org/x/text v0.37.0
++	golang.org/x/crypto v0.53.0
++	golang.org/x/mod v0.37.0
++	golang.org/x/net v0.56.0
++	golang.org/x/sync v0.21.0
++	golang.org/x/sys v0.46.0
++	golang.org/x/term v0.44.0
++	golang.org/x/text v0.39.0
+ 	golang.org/x/time v0.12.0
+-	golang.org/x/tools v0.44.0
++	golang.org/x/tools v0.47.0
+ 	golang.zx2c4.com/wireguard/wgctrl v0.0.0-20241231184526-a9ab2273dd10
+ 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217
+ 	google.golang.org/grpc v1.79.3
+@@ -256,7 +256,7 @@ require (
+ 	go.yaml.in/yaml/v2 v2.4.2 // indirect
+ 	golang.org/x/exp v0.0.0-20240808152545-0cdaa3abc0fa // indirect
+ 	golang.org/x/oauth2 v0.34.0 // indirect
+-	golang.org/x/telemetry v0.0.0-20260409153401-be6f6cb8b1fa // indirect
++	golang.org/x/telemetry v0.0.0-20260625142307-59b4966ccb57 // indirect
+ 	golang.org/x/tools/go/packages/packagestest v0.1.1-deprecated // indirect
+ 	golang.zx2c4.com/wireguard v0.0.0-20231211153847-12269c276173 // indirect
+ 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
+diff --git a/go.sum b/go.sum
+index c7e209ce8f..0a3a5d619c 100644
+--- a/go.sum
++++ b/go.sum
+@@ -644,8 +644,8 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
+ golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+-golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
+-golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
++golang.org/x/crypto v0.53.0 h1:QZ4Muo8THX6CizN2vPPd5fBGHyogrdK9fG4wLPFUsto=
++golang.org/x/crypto v0.53.0/go.mod h1:DNLU434OwVakk9PzuwV8w62mAJpRJL3vsgcfp4Qnsio=
+ golang.org/x/exp v0.0.0-20180321215751-8460e604b9de/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
+ golang.org/x/exp v0.0.0-20180807140117-3d87b88a115f/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
+ golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
+@@ -664,8 +664,8 @@ golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCc
+ golang.org/x/mod v0.1.0/go.mod h1:0QHyrYULN0/3qlju5TqG8bIK38QM8yzMo5ekMj3DlcY=
+ golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+ golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+-golang.org/x/mod v0.35.0 h1:Ww1D637e6Pg+Zb2KrWfHQUnH2dQRLBQyAtpr/haaJeM=
+-golang.org/x/mod v0.35.0/go.mod h1:+GwiRhIInF8wPm+4AoT6L0FA1QWAad3OMdTRx4tFYlU=
++golang.org/x/mod v0.37.0 h1:vF1DjpVEshcIqoEaauuHebaLk1O1forxjxBaVn884JQ=
++golang.org/x/mod v0.37.0/go.mod h1:m8S8VeM9r4dzDwjrKO0a1sZP3YjeMamRRlD+fmR2Q/0=
+ golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+ golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+ golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+@@ -681,8 +681,8 @@ golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7/go.mod h1:qpuaurCH72eLCgpAm/
+ golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
+ golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+ golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+-golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
+-golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
++golang.org/x/net v0.56.0 h1:Rw8j/hFzGvJUZwNBXnAtf5sVDVt+65SK2C7IxCxZt5o=
++golang.org/x/net v0.56.0/go.mod h1:D3Ku6r+V6JROoZK144D2XfMHFcMq/0zSfLelVTCFKec=
+ golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
+ golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
+ golang.org/x/oauth2 v0.34.0 h1:hqK/t4AKgbqWkdkcAeI8XLmbK+4m4G5YeQRrmiotGlw=
+@@ -694,8 +694,8 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
+ golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+ golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+-golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
+-golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
++golang.org/x/sync v0.21.0 h1:HLII4xRRTtCRkxYp4HNFF0Js/Og6q2i++KXbg0gHCwM=
++golang.org/x/sync v0.21.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
+ golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+ golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+@@ -719,16 +719,16 @@ golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBc
+ golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+ golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+-golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
+-golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+-golang.org/x/telemetry v0.0.0-20260409153401-be6f6cb8b1fa h1:efT73AJZfAAUV7SOip6pWGkwJDzIGiKBZGVzHYa+ve4=
+-golang.org/x/telemetry v0.0.0-20260409153401-be6f6cb8b1fa/go.mod h1:kHjTxDEnAu6/Nl9lDkzjWpR+bmKfxeiRuSDlsMb70gE=
+-golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=
+-golang.org/x/term v0.43.0/go.mod h1:lrhlHNdQJHO+1qVYiHfFKVuVioJIheAc3fBSMFYEIsk=
++golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
++golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
++golang.org/x/telemetry v0.0.0-20260625142307-59b4966ccb57 h1:nwGZBCt+FnXUrGsj5vjzAsEmkcaFvd82BbOjECiFYZc=
++golang.org/x/telemetry v0.0.0-20260625142307-59b4966ccb57/go.mod h1:3AWMyWHS+caVoiEXpiq6+tzKA40J4vQT3MYr80ZtQpc=
++golang.org/x/term v0.44.0 h1:0rLvDRCtNj0gZkyIXhCyOb2OAzEhLVqc4B+hrsBhrmc=
++golang.org/x/term v0.44.0/go.mod h1:7ze4MdzUzLXpSAoFP1H0bOI9aXDqveSvatT5vKcFh2Y=
+ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+ golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+-golang.org/x/text v0.37.0 h1:Cqjiwd9eSg8e0QAkyCaQTNHFIIzWtidPahFWR83rTrc=
+-golang.org/x/text v0.37.0/go.mod h1:a5sjxXGs9hsn/AJVwuElvCAo9v8QYLzvavO5z2PiM38=
++golang.org/x/text v0.39.0 h1:UbZz4pLOvn600D6Oh6GGEI6VAmndrEBLv8/6BEXzyus=
++golang.org/x/text v0.39.0/go.mod h1:3UwRclnC2g0TU9x8PZiyfOajCd1zaUNHF9cvqcQZ+ZM=
+ golang.org/x/time v0.12.0 h1:ScB/8o8olJvc+CQPWrK3fPZNfh7qgwCrY0zJmoEQLSE=
+ golang.org/x/time v0.12.0/go.mod h1:CDIdPxbZBQxdj6cxyCIdrNogrJKMJ7pr37NYpMcMDSg=
+ golang.org/x/tools v0.0.0-20180525024113-a5b4c53f6e8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+@@ -743,8 +743,8 @@ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtn
+ golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
+ golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
+ golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
+-golang.org/x/tools v0.44.0 h1:UP4ajHPIcuMjT1GqzDWRlalUEoY+uzoZKnhOjbIPD2c=
+-golang.org/x/tools v0.44.0/go.mod h1:KA0AfVErSdxRZIsOVipbv3rQhVXTnlU6UhKxHd1seDI=
++golang.org/x/tools v0.47.0 h1:7Kn5x/d1svx/PzryTsqeoZN4TZwqeH5pGWjefhLi/1Q=
++golang.org/x/tools v0.47.0/go.mod h1:dFHnyTvFWY212G+h7ZY4Vsp/K3U4/7W9TyVaAul8uCA=
+ golang.org/x/tools/go/expect v0.1.0-deprecated h1:jY2C5HGYR5lqex3gEniOQL0r7Dq5+VGVgY1nudX5lXY=
+ golang.org/x/tools/go/expect v0.1.0-deprecated/go.mod h1:eihoPOH+FgIqa3FpoTwguz/bVUSGBlGQU67vpBeOrBY=
+ golang.org/x/tools/go/packages/packagestest v0.1.1-deprecated h1:1h2MnaIAIXISqTFKdENegdpAgUXz6NrPEsbIeWaBRvM=
+-- 
+2.50.1 (Apple Git-155)
+


### PR DESCRIPTION
- Regenerate all 9 patches against upstream cilium v1.18.12
- Add patch 0010: update golang.org/x dependencies
- Update GIT_TAG v1.18.10 -> v1.18.12, GIT_COMMIT c2cd21cf99
- Update cilium-builder image to v1.18.12 version