### PR TITLE
[terway] add upgrade compatibility e2e test framework

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,10 @@ e2e-test-phased: e2e-test-connectivity e2e-test-mutating e2e-test-prefix ## Run 
 e2e-upgrade-test: ## Run e2e upgrade tests only.
 	go test -v -count=1 -timeout 60m -tags e2e ./tests -run 'TestUpgrade' $(TESTARGS)
 
+.PHONY: e2e-upgrade-compat-test
+e2e-upgrade-compat-test: ## Run terway upgrade compatibility tests (requires cluster + templates).
+	./tests/upgrade/run-upgrade-test.sh $(UPGRADE_ARGS)
+
 .PHONY: e2e-migrate-test
 e2e-migrate-test: ## Run e2e migration tests only.
 	go test -v -count=1 -timeout 120m -tags e2e ./tests -run 'TestMigrate' $(TESTARGS)

--- a/hack/terraform/ack/e2e-cluster.sh
+++ b/hack/terraform/ack/e2e-cluster.sh
@@ -178,7 +178,11 @@ cmd_create() {
 
     if [[ "${CLUSTER_MODE}" == "byo" ]]; then
         log_info "BYO profile; invoking deploy-terway.sh --ip-stack ${IP_STACK} ${extra_args[*]:-}"
-        ./deploy-terway.sh --ip-stack "${IP_STACK}" "${extra_args[@]}"
+        if [[ ${#extra_args[@]} -gt 0 ]]; then
+            ./deploy-terway.sh --ip-stack "${IP_STACK}" "${extra_args[@]}"
+        else
+            ./deploy-terway.sh --ip-stack "${IP_STACK}"
+        fi
     else
         log_info "ACK profile; terway-eniip is installed by ACK addon. Skipping helm deployment."
         if [[ ${#extra_args[@]} -gt 0 ]]; then

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -119,21 +119,33 @@ func TestMain(m *testing.M) {
 		panic(fmt.Sprintf("error create klient: %v", err))
 	}
 
-	envCfg := envconf.New().WithClient(client).
-		WithRandomNamespace().WithParallelTestEnabled()
+	envCfg := envconf.New().WithClient(client)
 
-	testenv = env.NewWithConfig(envCfg)
-	testenv.Setup(
-		cleanupNamespaces,
-		envfuncs.CreateNamespace(envCfg.Namespace()),
-		patchNamespace,
-		checkENIConfig,
-		configureKubeClientQPS,
-		printClusterEnvironment,
-		labelExternalIPNodes,
-		labelIPPrefixNodes,
-		resetNodeConfigToDefault,
-	)
+	if upgradePhase != "" {
+		// Upgrade test mode: fixed namespace, sequential, minimal setup
+		envCfg = envCfg.WithNamespace(upgradeTestNamespace)
+		testenv = env.NewWithConfig(envCfg)
+		testenv.Setup(
+			ensureUpgradeNamespace,
+			checkENIConfig,
+			printClusterEnvironment,
+		)
+	} else {
+		// Normal test mode: random namespace, parallel, full setup
+		envCfg = envCfg.WithRandomNamespace().WithParallelTestEnabled()
+		testenv = env.NewWithConfig(envCfg)
+		testenv.Setup(
+			cleanupNamespaces,
+			envfuncs.CreateNamespace(envCfg.Namespace()),
+			patchNamespace,
+			checkENIConfig,
+			configureKubeClientQPS,
+			printClusterEnvironment,
+			labelExternalIPNodes,
+			labelIPPrefixNodes,
+			resetNodeConfigToDefault,
+		)
+	}
 	testenv.AfterEachFeature(func(ctx context.Context, config *envconf.Config, t *testing.T, feature features.Feature) (context.Context, error) {
 		if t.Skipped() {
 			return ctx, nil
@@ -298,6 +310,11 @@ func cleanupNamespaces(ctx context.Context, config *envconf.Config) (context.Con
 			continue
 		}
 
+		// Skip upgrade test namespace — it persists across PreUpgrade/PostUpgrade runs
+		if ns.Name == upgradeTestNamespace {
+			continue
+		}
+
 		// Use fmt.Printf for logging during setup (before test starts)
 		fmt.Printf("Cleaning up namespace: %s\n", ns.Name)
 		err = config.Client().Resources().Delete(ctx, &ns)
@@ -335,6 +352,34 @@ func patchNamespace(ctx context.Context, config *envconf.Config) (context.Contex
 	})
 	err = config.Client().Resources().Patch(ctx, ns, k8s.Patch{PatchType: types.StrategicMergePatchType, Data: mergePatch})
 	return ctx, err
+}
+
+// ensureUpgradeNamespace creates the fixed upgrade test namespace if it doesn't exist.
+// Unlike the normal namespace setup, it does NOT add the k8s.aliyun.com/terway-e2e
+// label (which would cause cleanupNamespaces to delete it between PreUpgrade/PostUpgrade runs).
+func ensureUpgradeNamespace(ctx context.Context, config *envconf.Config) (context.Context, error) {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: upgradeTestNamespace,
+		},
+	}
+	err := config.Client().Resources().Create(ctx, ns)
+	if err != nil && !errors.IsAlreadyExists(err) {
+		return ctx, fmt.Errorf("failed to create namespace %s: %w", upgradeTestNamespace, err)
+	}
+
+	// Add node-local-dns-injection label only (NOT terway-e2e label, to prevent cleanup)
+	mergePatch, _ := json.Marshal(map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"labels": map[string]interface{}{
+				"node-local-dns-injection": "enabled",
+			},
+		},
+	})
+	_ = config.Client().Resources().Patch(ctx, ns, k8s.Patch{PatchType: types.StrategicMergePatchType, Data: mergePatch})
+
+	fmt.Printf("Upgrade test namespace ready: %s\n", upgradeTestNamespace)
+	return ctx, nil
 }
 
 type Config struct {

--- a/tests/upgrade/render-configmap.go
+++ b/tests/upgrade/render-configmap.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"text/template"
+)
+
+// ConfigMapParams holds the parameters for rendering the eni-config ConfigMap template.
+// Only Datapath and DisableNetworkPolicy vary by test config mode (A/B/C).
+// The rest are cluster-specific values extracted from Terraform state.
+type ConfigMapParams struct {
+	Datapath             bool   // true: enable eniip_virtual_type (IPVlan/datapathv2); false: veth mode
+	DisableNetworkPolicy string // "true" to disable NP, "false" to enable
+	PodVswitchId         string // JSON map string, e.g. {"cn-hangzhou-j":["vsw-xxx"]}
+	ClusterID            string // ACK cluster ID
+	ServiceCIDR          string // Kubernetes service CIDR
+	SecurityGroupId      string // Security group ID
+	IPStack              string // "ipv4" or "dual"
+	RegionID             string // ACK region ID, e.g. cn-hangzhou
+	VPCID                string // VPC ID, e.g. vpc-xxx
+}
+
+func main() {
+	var (
+		templateFile    string
+		datapath        bool
+		disableNP       string
+		podVswitchId    string
+		clusterID       string
+		serviceCIDR     string
+		securityGroupID string
+		ipStack         string
+		regionID        string
+		vpcID           string
+	)
+
+	flag.StringVar(&templateFile, "template", "", "path to configmap.yaml.tmpl (required)")
+	flag.BoolVar(&datapath, "datapath", false, "enable datapath mode (IPVlan/datapathv2)")
+	flag.StringVar(&disableNP, "disable-np", "true", "disable_network_policy value (true=disable, false=enable)")
+	flag.StringVar(&podVswitchId, "pod-vswitch-id", "", `vswitch IDs as JSON map, e.g. '{"cn-hangzhou-j":["vsw-xxx"]}'`)
+	flag.StringVar(&clusterID, "cluster-id", "", "ACK cluster ID")
+	flag.StringVar(&serviceCIDR, "service-cidr", "", "Kubernetes service CIDR")
+	flag.StringVar(&securityGroupID, "security-group-id", "", "security group ID")
+	flag.StringVar(&ipStack, "ip-stack", "ipv4", "IP stack: ipv4 or dual")
+	flag.StringVar(&regionID, "region-id", "cn-hangzhou", "ACK region ID")
+	flag.StringVar(&vpcID, "vpc-id", "", "VPC ID")
+	flag.Parse()
+
+	if templateFile == "" {
+		fmt.Fprintln(os.Stderr, "error: --template is required")
+		os.Exit(1)
+	}
+
+	tmpl, err := template.ParseFiles(templateFile)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error parsing template %s: %v\n", templateFile, err)
+		os.Exit(1)
+	}
+
+	params := ConfigMapParams{
+		Datapath:             datapath,
+		DisableNetworkPolicy: disableNP,
+		PodVswitchId:         podVswitchId,
+		ClusterID:            clusterID,
+		ServiceCIDR:          serviceCIDR,
+		SecurityGroupId:      securityGroupID,
+		IPStack:              ipStack,
+		RegionID:             regionID,
+		VPCID:                vpcID,
+	}
+
+	if err := tmpl.Execute(os.Stdout, params); err != nil {
+		fmt.Fprintf(os.Stderr, "error executing template: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/tests/upgrade/run-upgrade-test.sh
+++ b/tests/upgrade/run-upgrade-test.sh
@@ -1,0 +1,635 @@
+#!/bin/bash
+#
+# Terway 升级兼容性测试编排脚本
+#
+# 用法:
+#   ./run-upgrade-test.sh --path 1.9.18 1.17.6 --config B
+#   ./run-upgrade-test.sh --path 1.7.4 1.9.18 1.17.6 --config A
+#   ./run-upgrade-test.sh --all
+#
+# 前提: 已创建 ACK BYO 集群 (make ack-cluster-byo-ipv4) 且 KUBECONFIG 已设置
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+TEMPLATE_DIR="${SCRIPT_DIR}/templates"
+ACK_DIR="${PROJECT_ROOT}/hack/terraform/ack"
+
+# 颜色
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log_info()  { echo -e "${GREEN}[INFO]${NC}  $*"; }
+log_warn()  { echo -e "${YELLOW}[WARN]${NC}  $*"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+log_step()  { echo -e "${BLUE}[STEP]${NC}  $*"; }
+
+# Extract minor version (e.g. "1.7.4" -> "1.7") so template folders use the
+# minor-version convention (v1.7, v1.9, v1.17) while templates inside still
+# carry the full patch version.
+minor_version() {
+    local v="$1"
+    echo "${v%.*}"
+}
+
+# 默认值
+REGION="cn-hangzhou"
+DRY_RUN=false
+WORKDIR=""
+
+# 集群参数 (从 terraform state 提取或通过 flag 指定)
+POD_VSWITCH_ID=""
+CLUSTER_ID=""
+SERVICE_CIDR=""
+SECURITY_GROUP_ID=""
+VPC_ID=""
+
+# 解析参数
+PATH_VERSIONS=()
+CONFIG=""
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --path)
+            shift
+            while [[ $# -gt 0 && ! "$1" =~ ^-- ]]; do
+                PATH_VERSIONS+=("$1")
+                shift
+            done
+            ;;
+        --config)
+            CONFIG="$2"; shift 2 ;;
+        --all)
+            ALL=true; shift ;;
+        --region)
+            REGION="$2"; shift 2 ;;
+        --workdir)
+            WORKDIR="$2"; shift 2 ;;
+        --pod-vswitch-id)
+            POD_VSWITCH_ID="$2"; shift 2 ;;
+        --cluster-id)
+            CLUSTER_ID="$2"; shift 2 ;;
+        --service-cidr)
+            SERVICE_CIDR="$2"; shift 2 ;;
+        --security-group-id)
+            SECURITY_GROUP_ID="$2"; shift 2 ;;
+        --vpc-id)
+            VPC_ID="$2"; shift 2 ;;
+        --dry-run)
+            DRY_RUN=true; shift ;;
+        -h|--help)
+            sed -n '2,15p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *)
+            log_error "Unknown option: $1"; exit 1 ;;
+    esac
+done
+
+# 配置模式映射
+get_config_flags() {
+    local cfg="$1"
+    case "$cfg" in
+        A) echo "--datapath --disable-np false" ;;
+        B) echo "--disable-np false" ;;
+        C) echo "--disable-np true" ;;
+        *) log_error "Invalid config: $cfg (use A, B, or C)"; exit 1 ;;
+    esac
+}
+
+# 从 terraform state 提取集群参数
+extract_cluster_params() {
+    # Resolve KUBECONFIG to absolute path (script may cd to different directories)
+    if [[ -n "${KUBECONFIG}" && ! "${KUBECONFIG}" = /* ]]; then
+        export KUBECONFIG="${PWD}/${KUBECONFIG}"
+    fi
+
+    log_step "Extracting cluster params..."
+
+    if [[ -z "${WORKDIR}" ]]; then
+        WORKDIR=$(ls -dt "${ACK_DIR}"/runs/*/ 2>/dev/null | head -1 || true)
+        if [[ -z "${WORKDIR}" ]]; then
+            # 尝试主目录
+            WORKDIR="${ACK_DIR}"
+        fi
+    fi
+
+    local tfstate="${WORKDIR}/terraform.tfstate"
+
+    if [[ -f "${tfstate}" ]]; then
+        log_info "Reading from terraform state: ${tfstate}"
+
+        if [[ -z "${CLUSTER_ID}" ]]; then
+            CLUSTER_ID=$(jq -r '.resources[] | select(.type=="alicloud_cs_managed_kubernetes" and .name=="default") | .instances[0].attributes.id' "${tfstate}" 2>/dev/null || echo "")
+        fi
+        if [[ -z "${SECURITY_GROUP_ID}" ]]; then
+            SECURITY_GROUP_ID=$(jq -r '.resources[] | select(.type=="alicloud_cs_managed_kubernetes" and .name=="default") | .instances[0].attributes.security_group_id' "${tfstate}" 2>/dev/null || echo "")
+        fi
+        if [[ -z "${VPC_ID}" ]]; then
+            VPC_ID=$(jq -r '.resources[] | select(.type=="alicloud_vpc" and .name=="default") | .instances[0].attributes.id' "${tfstate}" 2>/dev/null || echo "")
+        fi
+        if [[ -z "${SERVICE_CIDR}" ]]; then
+            SERVICE_CIDR=$(terraform -chdir="${WORKDIR}" output -raw service_cidr 2>/dev/null || echo "192.168.0.0/16")
+        fi
+        if [[ -z "${POD_VSWITCH_ID}" ]]; then
+            # vswitches must be a map of zone→[vswitchIDs], not a flat array
+            POD_VSWITCH_ID=$(jq -c -r -s 'add' < <(jq -c '.resources[] | select(.type=="alicloud_vswitch" and .name=="terway_vswitches") | .instances[] | {(.attributes.zone_id // .attributes.availability_zone): [.attributes.id]}' "${tfstate}" 2>/dev/null) 2>/dev/null || echo "")
+        fi
+    fi
+
+    # 检查必要参数
+    local missing=()
+    [[ -z "${CLUSTER_ID}" ]] && missing+=("--cluster-id")
+    [[ -z "${SECURITY_GROUP_ID}" ]] && missing+=("--security-group-id")
+    [[ -z "${POD_VSWITCH_ID}" ]] && missing+=("--pod-vswitch-id")
+    [[ -z "${VPC_ID}" ]] && missing+=("--vpc-id")
+
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        log_error "Missing required params: ${missing[*]}"
+        log_error "Provide via flags or ensure terraform state exists at: ${tfstate}"
+        exit 1
+    fi
+
+    [[ -z "${SERVICE_CIDR}" ]] && SERVICE_CIDR="192.168.0.0/16"
+
+    log_info "Cluster ID: ${CLUSTER_ID}"
+    log_info "Security Group: ${SECURITY_GROUP_ID}"
+    log_info "VPC ID: ${VPC_ID}"
+    log_info "Service CIDR: ${SERVICE_CIDR}"
+    log_info "Region: ${REGION}"
+    log_info "Pod VSwitch IDs: ${POD_VSWITCH_ID}"
+}
+
+# 清理 terway 资源
+cleanup_terway() {
+    log_step "Cleaning up previous terway deployment..."
+
+    if [[ "${DRY_RUN}" == "true" ]]; then
+        log_info "[DRY-RUN] Would remove the previous Terway Kubernetes resources"
+        return
+    fi
+
+    # Delete test workloads first while Terway can still release their ENIs.
+    if kubectl get namespace terway-upgrade-test >/dev/null 2>&1; then
+        kubectl delete pod,service --all -n terway-upgrade-test --ignore-not-found=true --timeout=3m || return 1
+        kubectl wait --for=delete pod --all -n terway-upgrade-test --timeout=3m || return 1
+        kubectl delete namespace terway-upgrade-test --wait=false || return 1
+    fi
+
+    # Uninstall helm release if one was left by cluster provisioning.
+    if helm status terway -n kube-system >/dev/null 2>&1; then
+        helm uninstall terway -n kube-system
+    fi
+
+    kubectl delete daemonset terway-eniip -n kube-system --ignore-not-found=true --timeout=3m || return 1
+    kubectl delete deployment terway-controlplane -n kube-system --ignore-not-found=true --timeout=3m || return 1
+    kubectl delete configmap eni-config -n kube-system --ignore-not-found=true || return 1
+    kubectl delete configmap terway-controlplane -n kube-system --ignore-not-found=true || return 1
+    kubectl delete job terway-preflight -n kube-system --ignore-not-found=true || return 1
+    kubectl delete serviceaccount terway -n kube-system --ignore-not-found=true || return 1
+    kubectl delete clusterrolebinding terway-binding --ignore-not-found=true || return 1
+    kubectl delete clusterrole terway-pod-reader --ignore-not-found=true || return 1
+    kubectl delete rolebinding terway-binding -n kube-system --ignore-not-found=true || return 1
+    kubectl delete role terway -n kube-system --ignore-not-found=true || return 1
+
+    # 删除 Calico CRDs
+    local crds=(
+        felixconfigurations.crd.projectcalico.org
+        bgpconfigurations.crd.projectcalico.org
+        ippools.crd.projectcalico.org
+        hostendpoints.crd.projectcalico.org
+        clusterinformations.crd.projectcalico.org
+        globalnetworkpolicies.crd.projectcalico.org
+        globalnetworksets.crd.projectcalico.org
+        networkpolicies.crd.projectcalico.org
+    )
+    for crd in "${crds[@]}"; do
+        kubectl delete crd "${crd}" --ignore-not-found=true || return 1
+    done
+
+    # 删除 Cilium CRDs
+    local cilium_crds=(
+        ciliumclusterwidenetworkpolicies.cilium.io
+        ciliumendpoints.cilium.io
+        ciliumendpointslices.cilium.io
+        ciliumexternalworkloads.cilium.io
+        ciliumidentities.cilium.io
+        ciliumnetworkpolicies.cilium.io
+        ciliumnodes.cilium.io
+        ciliumpodippools.cilium.io
+        ciliumloadbalancerippools.cilium.io
+        ciliuml2announcementpolicies.cilium.io
+        ciliumcidrgroups.cilium.io
+    )
+    for crd in "${cilium_crds[@]}"; do
+        kubectl delete crd "${crd}" --ignore-not-found=true || return 1
+    done
+
+    # 删除 controlplane credential secret
+    kubectl delete secret terway-controlplane-credential -n kube-system --ignore-not-found=true || return 1
+
+    # Once the controller has stopped, it can no longer re-add PodENI
+    # finalizers. Remove only finalizers left in the deleting test namespace.
+    if kubectl get namespace terway-upgrade-test >/dev/null 2>&1; then
+        local podeni
+        while IFS= read -r podeni; do
+            [[ -z "${podeni}" ]] && continue
+            kubectl patch "${podeni}" -n terway-upgrade-test --type=merge \
+                -p '{"metadata":{"finalizers":[]}}' || return 1
+        done < <(kubectl get podeni.network.alibabacloud.com -n terway-upgrade-test -o name 2>/dev/null || true)
+        kubectl wait --for=delete namespace/terway-upgrade-test --timeout=3m || return 1
+    fi
+
+    # 等待 terway pods 消失
+    kubectl wait --for=delete pod -l app=terway-eniip -n kube-system --timeout=3m 2>/dev/null || \
+        [[ -z "$(kubectl get pod -n kube-system -l app=terway-eniip -o name)" ]]
+
+    log_info "Cleanup complete"
+}
+
+# 重启 worker 节点
+reboot_nodes() {
+    log_step "Rebooting worker nodes..."
+
+    # 获取 worker 节点列表 (排除 master)
+    local nodes
+    nodes=$(kubectl get nodes -l node-role.kubernetes.io/control-plane!=true -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || echo "")
+
+    if [[ -z "${nodes}" ]]; then
+        # 如果没有 control-plane label, 尝试获取所有节点
+        nodes=$(kubectl get nodes -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || echo "")
+    fi
+
+    if [[ -z "${nodes}" ]]; then
+        log_warn "No nodes found, skipping reboot"
+        return
+    fi
+
+    log_info "Nodes to reboot: ${nodes}"
+
+    if [[ "${DRY_RUN}" == "true" ]]; then
+        log_info "[DRY-RUN] Would reboot: ${nodes}"
+        return
+    fi
+
+    command -v aliyun >/dev/null 2>&1 || {
+        log_error "aliyun CLI is required for a real node reboot"
+        return 1
+    }
+
+    # Reboot sequentially and require both a changed boot ID and Ready=True.
+    for node in ${nodes}; do
+        local provider_id instance_id old_boot_id deadline new_boot_id ready
+        provider_id=$(kubectl get node "${node}" -o jsonpath='{.spec.providerID}')
+        instance_id=$(echo "${provider_id}" | grep -oE 'i-[a-z0-9]+')
+        old_boot_id=$(kubectl get node "${node}" -o jsonpath='{.status.nodeInfo.bootID}')
+        if [[ -z "${instance_id}" || -z "${old_boot_id}" ]]; then
+            log_error "Cannot resolve instance or boot ID for ${node}"
+            return 1
+        fi
+
+        log_info "Rebooting ${node} (instance: ${instance_id}, bootID: ${old_boot_id})"
+        aliyun ecs RebootInstance --InstanceId "${instance_id}" --region "${REGION}" >/dev/null
+        deadline=$((SECONDS + 600))
+        while (( SECONDS < deadline )); do
+            new_boot_id=$(kubectl get node "${node}" -o jsonpath='{.status.nodeInfo.bootID}' 2>/dev/null || true)
+            ready=$(kubectl get node "${node}" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || true)
+            if [[ -n "${new_boot_id}" && "${new_boot_id}" != "${old_boot_id}" && "${ready}" == "True" ]]; then
+                log_info "Node ${node} reboot verified (bootID: ${new_boot_id})"
+                break
+            fi
+            sleep 5
+        done
+        if [[ "${new_boot_id:-}" == "${old_boot_id}" || "${ready:-}" != "True" ]]; then
+            log_error "Node ${node} did not complete a verified reboot within 10m"
+            return 1
+        fi
+    done
+
+    log_info "All nodes ready"
+}
+
+validate_version_template() {
+    local version="$1"
+    local version_dir="$2"
+    local manifest="${version_dir}/terway-eniip.yaml"
+
+    [[ -f "${manifest}" ]] || {
+        log_error "Missing version manifest: ${manifest}"
+        return 1
+    }
+    local unexpected
+    unexpected=$(grep -E 'image: .*/(terway|terway-controlplane):' "${manifest}" | grep -v ":v${version}$" || true)
+    if [[ -n "${unexpected}" ]]; then
+        log_error "Version manifest contains a mismatched Terway image tag:"
+        echo "${unexpected}" >&2
+        return 1
+    fi
+}
+
+# 部署初始版本
+deploy_version() {
+    local version="$1"
+    local config="$2"
+
+    log_step "Deploying terway v${version} (config: ${config})..."
+
+    local config_flags
+    config_flags=$(get_config_flags "${config}")
+    local version_dir
+    version_dir="${TEMPLATE_DIR}/v$(minor_version "${version}")"
+    validate_version_template "${version}" "${version_dir}"
+
+    if [[ "${DRY_RUN}" == "true" ]]; then
+        log_info "[DRY-RUN] Would render and apply configmap + terway-eniip.yaml for v${version}"
+        return
+    fi
+
+    # 1. 渲染并 apply ConfigMap
+    log_info "Rendering ConfigMap..."
+    go run "${SCRIPT_DIR}/render-configmap.go" \
+        --template "${version_dir}/configmap.yaml.tmpl" \
+        ${config_flags} \
+        --pod-vswitch-id "${POD_VSWITCH_ID}" \
+        --cluster-id "${CLUSTER_ID}" \
+        --service-cidr "${SERVICE_CIDR}" \
+        --security-group-id "${SECURITY_GROUP_ID}" \
+        --ip-stack ipv4 \
+        --region-id "${REGION}" \
+        --vpc-id "${VPC_ID}" | kubectl apply -f -
+
+    # 2. Apply 静态 YAML (SA, RBAC, DS, Job, CRDs)
+    log_info "Applying terway-eniip.yaml..."
+    kubectl apply -f "${version_dir}/terway-eniip.yaml"
+
+    # 3. 等待 terway pods ready
+    log_info "Waiting for terway pods to be ready..."
+    kubectl wait pod -l app=terway-eniip --for=condition=ready -n kube-system --timeout=5m 2>/dev/null || {
+        log_error "Terway pods not ready after 5m"
+        kubectl get pods -n kube-system -l app=terway-eniip -o wide
+        return 1
+    }
+
+    kubectl rollout status deployment/terway-controlplane -n kube-system --timeout=5m || {
+        log_error "Terway controlplane rollout failed"
+        kubectl get pods -n kube-system -l k8s-app=terway-controlplane -o wide
+        return 1
+    }
+    kubectl wait pod -l k8s-app=terway-controlplane --for=condition=ready -n kube-system --timeout=3m || {
+        log_error "Terway controlplane pods not ready after 3m"
+        kubectl get pods -n kube-system -l k8s-app=terway-controlplane -o wide
+        return 1
+    }
+
+    log_info "Terway v${version} deployed successfully"
+}
+
+# 升级版本 (仅 apply terway-eniip.yaml, 不碰 ConfigMap)
+upgrade_version() {
+    local version="$1"
+    local version_dir
+    version_dir="${TEMPLATE_DIR}/v$(minor_version "${version}")"
+    validate_version_template "${version}" "${version_dir}"
+
+    log_step "Upgrading to terway v${version} (ConfigMap unchanged)..."
+
+    if [[ "${DRY_RUN}" == "true" ]]; then
+        log_info "[DRY-RUN] Would apply terway-eniip.yaml for v${version}"
+        return
+    fi
+
+    # 只 apply 目标版本的 terway-eniip.yaml (不碰 ConfigMap!)
+    kubectl apply -f "${version_dir}/terway-eniip.yaml"
+
+    # 等待滚动更新完成
+    log_info "Waiting for DaemonSet rollout..."
+    kubectl rollout status daemonset/terway-eniip -n kube-system --timeout=10m || {
+        log_error "DaemonSet rollout failed"
+        kubectl get pods -n kube-system -l app=terway-eniip -o wide
+        return 1
+    }
+
+    # 等待 pods ready
+    kubectl wait pod -l app=terway-eniip --for=condition=ready -n kube-system --timeout=5m
+
+    # 等待 controlplane Deployment 就绪 (必须等 controlplane ready 才能跑 PostUpgrade)
+    log_info "Waiting for controlplane Deployment rollout..."
+    kubectl rollout status deployment/terway-controlplane -n kube-system --timeout=5m
+
+    # 等待 controlplane pods ready
+    kubectl wait pod -l k8s-app=terway-controlplane --for=condition=ready -n kube-system --timeout=3m
+
+    log_info "Upgrade to v${version} complete"
+}
+
+# 运行 e2e 测试
+run_e2e() {
+    local phase="$1"
+
+    log_step "Running e2e test (phase: ${phase})..."
+
+    local test_name
+    if [[ "${phase}" == "pre" ]]; then
+        test_name="TestUpgrade_PreUpgrade"
+    else
+        test_name="TestUpgrade_PostUpgrade"
+    fi
+
+    # Config B/C intentionally leave eniip_virtual_type unset (legacy veth).
+    # Config A differs by release (IPVlan vs datapathv2), so its live value is
+    # protected by the pre/post ConfigMap snapshot instead of hard-coding one.
+    if [[ "${DRY_RUN}" == "true" ]]; then
+        log_info "[DRY-RUN] Would run: go test -tags e2e -run ${test_name} -upgrade-phase ${phase}"
+        return
+    fi
+
+    cd "${PROJECT_ROOT}"
+    if [[ "${CONFIG}" == "B" || "${CONFIG}" == "C" ]]; then
+        go test -v -count=1 -timeout 30m -tags e2e ./tests \
+            -run "${test_name}" \
+            -upgrade-phase "${phase}" \
+            -upgrade-expected-datapath unset \
+            -region-id "${REGION}"
+    else
+        go test -v -count=1 -timeout 30m -tags e2e ./tests \
+            -run "${test_name}" \
+            -upgrade-phase "${phase}" \
+            -region-id "${REGION}"
+    fi
+
+    return $?
+}
+
+# 运行单个场景
+run_scenario() {
+    local -a versions=("${@:1:$(($#-1))}")
+    local config="${!#}"
+    local scenario_name
+
+    # 构建场景名称
+    local path_str
+    path_str=$(IFS='→'; echo "${versions[*]}")
+    scenario_name="${path_str} | ${config}"
+
+    local start_time
+    start_time=$(date +%s)
+
+    echo ""
+    echo "════════════════════════════════════════════════════════════════"
+    log_info "Scenario: ${scenario_name}"
+    echo "════════════════════════════════════════════════════════════════"
+
+    local result="PASS"
+    if [[ "${DRY_RUN}" == "true" ]]; then
+        result="DRY-RUN"
+    fi
+
+    # Step 1: 清理 (非第一个场景时)
+    if ! cleanup_terway; then
+        log_error "Cleanup failed; refusing to continue with a partial environment"
+        return 1
+    fi
+    log_info "Cleanup OK"
+
+    # Step 2: 部署初始版本
+    if ! deploy_version "${versions[0]}" "${config}"; then
+        log_error "Deploy failed"
+        result="FAIL"
+        echo ""
+        echo "${scenario_name} | ${result} | $(($(date +%s) - start_time))s"
+        return 1
+    fi
+
+    # Step 3: 部署旧版本后重启节点，确保节点 CNI 和数据面完整切换。
+    if ! reboot_nodes; then
+        log_error "Node reboot failed"
+        result="FAIL"
+        echo ""
+        echo "${scenario_name} | ${result} | $(($(date +%s) - start_time))s"
+        return 1
+    fi
+
+    # Step 4: 预升级 e2e
+    if ! run_e2e "pre"; then
+        log_error "PreUpgrade e2e failed"
+        result="FAIL"
+        echo ""
+        echo "${scenario_name} | ${result} | $(($(date +%s) - start_time))s"
+        return 1
+    fi
+
+    # Step 5+: 升级 (每个后续版本)
+    for ((i=1; i<${#versions[@]}; i++)); do
+        local hop_num=$i
+        local total_hops=$((${#versions[@]} - 1))
+
+        log_info "Upgrade hop ${hop_num}/${total_hops}: v${versions[$((i-1))]} → v${versions[i]}"
+
+        if ! upgrade_version "${versions[i]}"; then
+            log_error "Upgrade to v${versions[i]} failed"
+            result="FAIL"
+            break
+        fi
+
+        # 每跳后运行 PostUpgrade e2e
+        if ! run_e2e "post"; then
+            log_error "PostUpgrade e2e failed after hop ${hop_num}"
+            result="FAIL"
+            break
+        fi
+
+        log_info "Hop ${hop_num}/${total_hops} completed successfully"
+    done
+
+    local duration=$(($(date +%s) - start_time))
+
+    echo ""
+    echo "────────────────────────────────────────────────────────────────"
+    echo "Scenario: ${scenario_name}"
+    echo "Result:   ${result}"
+    echo "Duration: ${duration}s"
+    echo "────────────────────────────────────────────────────────────────"
+
+    [[ "${result}" != "FAIL" ]]
+}
+
+# 主函数
+main() {
+    echo "╔══════════════════════════════════════════════════════════════════╗"
+    echo "║        Terway 升级兼容性测试                                       ║"
+    echo "╚══════════════════════════════════════════════════════════════════╝"
+
+    # 提取集群参数
+    extract_cluster_params
+
+    # 结果汇总
+    declare -a RESULTS=()
+    local overall_status=0
+
+    if [[ "${ALL:-false}" == "true" ]]; then
+        # 运行全部 6 个场景
+        SCENARIOS=(
+            "1.9.18 1.17.6 A"
+            "1.9.18 1.17.6 B"
+            "1.9.18 1.17.6 C"
+            "1.7.4 1.9.18 1.17.6 A"
+            "1.7.4 1.9.18 1.17.6 B"
+            "1.7.4 1.9.18 1.17.6 C"
+        )
+
+        for scenario in "${SCENARIOS[@]}"; do
+            read -ra parts <<< "${scenario}"
+            local last_idx=$((${#parts[@]}-1))
+            local scenario_status=0
+            run_scenario "${parts[@]:0:${last_idx}}" "${parts[${last_idx}]}" || scenario_status=$?
+            if [[ "${DRY_RUN}" == "true" ]]; then
+                RESULTS+=("${scenario} | DRY-RUN")
+            elif [[ ${scenario_status} -eq 0 ]]; then
+                RESULTS+=("${scenario} | PASS")
+            else
+                RESULTS+=("${scenario} | FAIL")
+                overall_status=1
+            fi
+        done
+    else
+        # 运行指定场景
+        if [[ ${#PATH_VERSIONS[@]} -lt 2 ]]; then
+            log_error "--path requires at least 2 versions (from and to)"
+            exit 1
+        fi
+        if [[ -z "${CONFIG}" ]]; then
+            log_error "--config is required (A, B, or C)"
+            exit 1
+        fi
+
+        local scenario_status=0
+        run_scenario "${PATH_VERSIONS[@]}" "${CONFIG}" || scenario_status=$?
+        if [[ "${DRY_RUN}" == "true" ]]; then
+            RESULTS+=("${PATH_VERSIONS[*]} | ${CONFIG} | DRY-RUN")
+        elif [[ ${scenario_status} -eq 0 ]]; then
+            RESULTS+=("${PATH_VERSIONS[*]} | ${CONFIG} | PASS")
+        else
+            RESULTS+=("${PATH_VERSIONS[*]} | ${CONFIG} | FAIL")
+            overall_status=1
+        fi
+    fi
+
+    # 打印汇总
+    echo ""
+    echo "╔══════════════════════════════════════════════════════════════════╗"
+    echo "║                        测试结果汇总                                ║"
+    echo "╠══════════════════════════════════════════════════════════════════╣"
+    for r in "${RESULTS[@]}"; do
+        echo "  ${r}"
+    done
+    echo "╚══════════════════════════════════════════════════════════════════╝"
+
+    return "${overall_status}"
+}
+
+main "$@"

--- a/tests/upgrade/templates/v1.17/configmap.yaml.tmpl
+++ b/tests/upgrade/templates/v1.17/configmap.yaml.tmpl
@@ -1,0 +1,80 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: eni-config
+  namespace: kube-system
+data:
+  eni_conf: |
+    {
+      "version": "1",
+      "max_pool_size": 5,
+      "min_pool_size": 0,
+      "credential_path": "/var/addon/token-config",
+      "vswitches": {{.PodVswitchId}},
+      "eni_tags": {"ack.aliyun.com":"{{.ClusterID}}"},
+      "service_cidr": "{{.ServiceCIDR}}",
+      "security_group": "{{.SecurityGroupId}}",
+      "ip_stack": "{{.IPStack}}",
+      "vswitch_selection_policy": "ordered"
+    }
+  10-terway.conf: |
+    {
+      "cniVersion": "0.4.0",
+      "name": "terway",
+      "capabilities": {"bandwidth": true},
+      "network_policy_provider": "ebpf",
+{{if .Datapath}}
+      "eniip_virtual_type": "datapathv2",
+      "host_stack_cidrs": ["169.254.20.10/32"],
+{{end}}
+      "type": "terway"
+    }
+  disable_network_policy: "{{.DisableNetworkPolicy}}"
+  in_cluster_loadbalance: "true"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: terway-controlplane
+  namespace: kube-system
+data:
+  ctrl-config.yaml: |
+    leaseLockName: "terway-controller-lock"
+    leaseLockNamespace: "kube-system"
+    controllerNamespace: "kube-system"
+    controllerName: "terway-controlplane"
+    healthzBindAddress: "0.0.0.0:8080"
+    clusterDomain: "cluster.local"
+    leaderElection: true
+    webhookPort: 0
+    disableWebhook: true
+    certDir: "/var/run/webhook-cert"
+    regionID: "{{ .RegionID }}"
+    clusterID: "{{ .ClusterID }}"
+    vpcID: "{{ .VPCID }}"
+    ipStack: "{{ .IPStack }}"
+    enableTrunk: false
+    enableTrace: false
+    metricsBindAddress: "0"
+    centralizedIPAM: true
+    controllers:
+    - pod-eni
+    - pod
+    - pod-networking
+    - node
+    - multi-ip-node
+    - multi-ip-pod
+  cilium-config.yaml: |
+    k8s-namespace: kube-system
+    identity-gc-interval: 10m
+    identity-heartbeat-timeout: 20m
+    enable-gops: false
+    ipam: delegated-plugin
+    enable-cilium-endpoint-slice: true
+    set-cilium-node-taints: false
+    set-cilium-is-up-condition: false
+    remove-cilium-node-taints: false
+    k8s-client-qps: 20
+    k8s-client-burst: 30
+    operator-api-serve-addr: 127.0.0.1:9234
+    unmanaged-pod-watcher-interval: 0

--- a/tests/upgrade/templates/v1.17/terway-eniip.yaml
+++ b/tests/upgrade/templates/v1.17/terway-eniip.yaml
@@ -1,0 +1,2624 @@
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: terway
+  namespace: kube-system
+
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: terway-pod-reader
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - pods
+      - nodes
+      - namespaces
+
+      - serviceaccounts
+
+      - endpoints
+      - services
+    verbs:
+      - get
+      - watch
+      - list
+  - apiGroups:
+      - ''
+    resources:
+      - pods
+      - nodes
+      - nodes/status
+    verbs:
+      - patch
+  - apiGroups:
+      - ''
+      - events.k8s.io
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - networkpolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - crd.projectcalico.org
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - cilium.io
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  - apiGroups:
+      - network.alibabacloud.com
+    resources:
+      - podenis
+      - nodes
+      - noderuntimes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - network.alibabacloud.com
+    resources:
+      - nodes
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - network.alibabacloud.com
+    resources:
+      - noderuntimes
+      - noderuntimes/status
+    verbs:
+      - create
+      - patch
+      - update
+  - apiGroups:
+      - ''
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - watch
+      - update
+      - create
+  - apiGroups:
+      - ''
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+  - apiGroups:
+      - ''
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+      - patch
+  - apiGroups:
+      - network.alibabacloud.com
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  - apiGroups:
+      - alibabacloud.com
+    resources:
+      - '*'
+    verbs:
+      - '*'
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: terway-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: terway-pod-reader
+subjects:
+- kind: ServiceAccount
+  name: terway
+  namespace: kube-system
+---
+
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: terway
+  namespace: kube-system
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - watch
+      - list
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: terway-binding
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: terway
+subjects:
+- kind: ServiceAccount
+  name: terway
+  namespace: kube-system
+
+---
+
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: terway-eniip
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app: terway-eniip
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 3%
+    type: RollingUpdate
+  template:
+    metadata:
+
+      labels:
+        app: terway-eniip
+    spec:
+      priorityClassName: system-node-critical
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: type
+                operator: NotIn
+                values:
+                - virtual-kubelet
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+                - arm64
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+              - key: alibabacloud.com/nodepool-type
+                operator: NotIn
+                values:
+                - hybridcloud
+                - edge
+              - key: k8s.aliyun.com/ignore-by-terway
+                operator: NotIn
+                values:
+                - "true"
+      tolerations:
+      - operator: "Exists"
+      terminationGracePeriodSeconds: 10
+      serviceAccountName: terway
+      enableServiceLinks: false
+      hostNetwork: true
+      initContainers:
+      - name: terway-init
+        image: registry-cn-hangzhou.ack.aliyuncs.com/acs/terway:v1.17.6
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          privileged: true
+        command:
+        - /bin/init.sh
+        env:
+        - name: TERWAY_DAEMON_MODE
+          value: ENIMultiIP
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: DISABLE_POLICY
+          valueFrom:
+            configMapKeyRef:
+              name: eni-config
+              key: disable_network_policy
+              optional: true
+        volumeMounts:
+        - name: sys-fs
+          mountPath: /tmp/fs
+        - name: bpf-maps
+          mountPath: /sys/fs/bpf
+          mountPropagation: Bidirectional
+        - name: eni-config
+          mountPath: /etc/eni
+        - mountPath: /var-run-eni
+          name: var-run-eni
+        - name: cni-bin
+          mountPath: /opt/cni/bin/
+        - name: cni
+          mountPath: /etc/cni/net.d/
+        - mountPath: /lib/modules
+          name: lib-modules
+        - mountPath: /host
+          name: host-root
+        - mountPath: /var/run/
+          name: eni-run
+      containers:
+      - name: terway
+        image: registry-cn-hangzhou.ack.aliyuncs.com/acs/terway:v1.17.6
+        imagePullPolicy: IfNotPresent
+        command:
+        - /usr/bin/terwayd
+        - "-log-level"
+        - info
+        - "-daemon-mode"
+        - ENIMultiIP
+        - "-config"
+        - "/etc/eni/eni_conf"
+        startupProbe:
+          exec:
+            command:
+              - sh
+              - -c
+              - curl --fail --silent --unix-socket /var/run/eni/eni_debug.socket --connect-timeout 5 --max-time 10 http://localhost/metrics > /dev/null 2>&1
+          failureThreshold: 180
+          periodSeconds: 1
+          initialDelaySeconds: 25
+        livenessProbe:
+          exec:
+            command:
+              - sh
+              - -c
+              - curl --fail --silent --unix-socket /var/run/eni/eni_debug.socket --connect-timeout 5 --max-time 10 http://localhost/metrics > /dev/null 2>&1
+          periodSeconds: 10
+          timeoutSeconds: 15
+          failureThreshold: 3
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+            - DAC_OVERRIDE
+            drop:
+            - ALL
+
+        env:
+
+        - name: TERWAY_GC_RULES
+          value: "true"
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: POD_NAMESPACE
+          valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+
+        volumeMounts:
+        - name: eni-config
+          mountPath: /etc/eni
+          readOnly: true
+
+        - mountPath: /var/run/
+          name: eni-run
+        - mountPath: /lib/modules
+          name: lib-modules
+        - mountPath: /var/lib/cni/terway
+          name: cni-terway
+        - mountPath: /etc/cni/net.d
+          name: cni
+          readOnly: true
+        - mountPath: /host-etc-net.d
+          name: host-cni
+        - mountPath: /var/lib/kubelet/device-plugins
+          name: device-plugin-path
+
+        - name: addon-token
+          mountPath: "/var/addon"
+          readOnly: true
+
+      - name: policy
+        image: registry-cn-hangzhou.ack.aliyuncs.com/acs/terway:v1.17.6
+        imagePullPolicy: IfNotPresent
+        command: ["/bin/policyinit.sh"]
+        env:
+
+        - name: NODENAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: DISABLE_POLICY
+          valueFrom:
+            configMapKeyRef:
+              name: eni-config
+              key: disable_network_policy
+              optional: true
+        - name: FELIX_TYPHAK8SSERVICENAME
+          valueFrom:
+            configMapKeyRef:
+              name: eni-config
+              key: felix_relay_service
+              optional: true
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: CILIUM_K8S_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: CILIUM_CNI_CHAINING_MODE
+          value: terway-chainer
+        - name: IN_CLUSTER_LOADBALANCE
+          valueFrom:
+            configMapKeyRef:
+              name: eni-config
+              key: in_cluster_loadbalance
+              optional: true
+        securityContext:
+          privileged: false
+          capabilities:
+            add:
+            - NET_ADMIN
+            - DAC_OVERRIDE
+            - SYS_ADMIN
+            - NET_RAW
+            - SYS_MODULE
+            - CHOWN
+            - IPC_LOCK
+            - SYS_RESOURCE
+            drop:
+            - ALL
+
+        livenessProbe:
+          httpGet: null
+          tcpSocket:
+            port: 9099
+            host: 127.0.0.1
+          periodSeconds: 10
+          initialDelaySeconds: 10
+          failureThreshold: 6
+        readinessProbe:
+          httpGet: null
+          tcpSocket:
+            port: 9099
+            host: 127.0.0.1
+          periodSeconds: 10
+        volumeMounts:
+
+        - name: sys-fs
+          mountPath: /tmp/fs
+        - name: eni-config
+          mountPath: /etc/eni
+          readOnly: true
+        - mountPath: /var-run-eni
+          name: var-run-eni
+          readOnly: true
+        - mountPath: /lib/modules
+          name: lib-modules
+        - mountPath: /etc/cni/net.d
+          name: cni
+          readOnly: true
+        # volumes use by cilium
+        - name: bpf-maps
+          mountPath: /sys/fs/bpf
+          # Unprivileged containers can't set mount propagation to bidirectional
+          # in this case we will mount the bpf fs from an init container that
+          # is privileged and set the mount propagation from host to container
+          # in Cilium.
+          mountPropagation: HostToContainer
+        - mountPath: /var/run/cilium
+          name: cilium-run
+          # Needed to be able to load kernel modules
+        - mountPath: /run/xtables.lock
+          name: xtables-lock
+      volumes:
+
+      - name: var-run-eni
+        emptyDir: {}
+      - name: eni-config
+        configMap:
+          name: eni-config
+          items: null
+      - name: cni-bin
+        hostPath:
+          path: /opt/cni/bin
+          type: "Directory"
+      - name: host-cni
+        hostPath:
+          path: /etc/cni/net.d
+      - name: cni
+        emptyDir: {}
+      - name: eni-run
+        hostPath:
+          path: /var/run/
+          type: "Directory"
+      - name: lib-modules
+        hostPath:
+          path: /lib/modules
+      - name: cni-terway
+        hostPath:
+          path: /var/lib/cni/terway
+      - name: device-plugin-path
+        hostPath:
+          path: /var/lib/kubelet/device-plugins
+          type: "Directory"
+      - name: host-root
+        hostPath:
+          path: /
+          type: "Directory"
+
+      - name: addon-token
+        secret:
+          secretName: addon.network.token
+          items:
+            - key: addon.token.config
+              path: token-config
+          optional: true
+
+      # used by cilium
+      # To keep state between restarts / upgrades
+      - hostPath:
+          path: /var/run/cilium
+          type: DirectoryOrCreate
+        name: cilium-run
+      # To keep state between restarts / upgrades for bpf maps
+      - name: bpf-maps
+        hostPath:
+          path: /sys/fs/bpf
+          type: DirectoryOrCreate
+        # To access iptables concurrently with other processes (e.g. kube-proxy)
+      - hostPath:
+          path: /run/xtables.lock
+          type: FileOrCreate
+        name: xtables-lock
+      - emptyDir: {}
+        name: sys-fs
+
+---
+
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: felixconfigurations.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            x-kubernetes-preserve-unknown-fields: true
+          apiVersion:
+            type: string
+  names:
+    kind: FelixConfiguration
+    plural: felixconfigurations
+    singular: felixconfiguration
+
+---
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: bgpconfigurations.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            x-kubernetes-preserve-unknown-fields: true
+          apiVersion:
+            type: string
+  names:
+    kind: BGPConfiguration
+    plural: bgpconfigurations
+    singular: bgpconfiguration
+
+---
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: ippools.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            x-kubernetes-preserve-unknown-fields: true
+          apiVersion:
+            type: string
+  names:
+    kind: IPPool
+    plural: ippools
+    singular: ippool
+
+---
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: hostendpoints.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            x-kubernetes-preserve-unknown-fields: true
+          apiVersion:
+            type: string
+  names:
+    kind: HostEndpoint
+    plural: hostendpoints
+    singular: hostendpoint
+
+---
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterinformations.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            x-kubernetes-preserve-unknown-fields: true
+          apiVersion:
+            type: string
+  names:
+    kind: ClusterInformation
+    plural: clusterinformations
+    singular: clusterinformation
+
+---
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: globalnetworkpolicies.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: GlobalNetworkPolicy
+    listKind: GlobalNetworkPolicyList
+    plural: globalnetworkpolicies
+    singular: globalnetworkpolicy
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            x-kubernetes-preserve-unknown-fields: true
+            properties:
+              applyOnForward:
+                description: ApplyOnForward indicates to apply the rules in this policy
+                  on forward traffic.
+                type: boolean
+              doNotTrack:
+                description: DoNotTrack indicates whether packets matched by the rules
+                  in this policy should go through the data plane's connection tracking,
+                  such as Linux conntrack.  If True, the rules in this policy are
+                  applied before any data plane connection tracking, and packets allowed
+                  by this policy are marked as not to be tracked.
+                type: boolean
+              egress:
+                description: The ordered set of egress rules.  Each rule contains
+                  a set of packet match criteria and a corresponding action to apply.
+                items:
+                  description: "A Rule encapsulates a set of match criteria and an
+                    action.  Both selector-based security Policy and security Profiles
+                    reference rules - separated out as a list of rules for both ingress
+                    and egress packet matching. \n Each positive match criteria has
+                    a negated version, prefixed with \"Not\". All the match criteria
+                    within a rule must be satisfied for a packet to match. A single
+                    rule can contain the positive and negative version of a match
+                    and both must be satisfied for the rule to match."
+                  properties:
+                    action:
+                      type: string
+                    destination:
+                      description: Destination contains the match criteria that apply
+                        to destination entity.
+                      properties:
+                        namespaceSelector:
+                          description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and another selector are defined on the same rule, then
+                            only workload endpoints that are matched by both selectors
+                            will be selected by the rule. \n For NetworkPolicy, an
+                            empty NamespaceSelector implies that the Selector is limited
+                            to selecting only workload endpoints in the same namespace
+                            as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                            NamespaceSelector implies that the Selector is limited
+                            to selecting only GlobalNetworkSet or HostEndpoint. \n
+                            For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                            the Selector applies to workload endpoints across all
+                            namespaces."
+                          type: string
+                        nets:
+                          description: Nets is an optional field that restricts the
+                            rule to only apply to traffic that originates from (or
+                            terminates at) IP addresses in any of the given subnets.
+                          items:
+                            type: string
+                          type: array
+                        notNets:
+                          description: NotNets is the negated version of the Nets
+                            field.
+                          items:
+                            type: string
+                          type: array
+                        notPorts:
+                          description: NotPorts is the negated version of the Ports
+                            field. Since only some protocols have ports, if any ports
+                            are specified it requires the Protocol match in the Rule
+                            to be set to "TCP" or "UDP".
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        notSelector:
+                          description: NotSelector is the negated version of the Selector
+                            field.  See Selector field for subtleties with negated
+                            selectors.
+                          type: string
+                        ports:
+                          description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        selector:
+                          description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label \"my_label\". \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label \"my_label\".
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                          type: string
+                        serviceAccounts:
+                          description: ServiceAccounts is an optional field that restricts
+                            the rule to only apply to traffic that originates from
+                            (or terminates at) a pod running as a matching service
+                            account.
+                          properties:
+                            names:
+                              description: Names is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account whose name is in the list.
+                              items:
+                                type: string
+                              type: array
+                            selector:
+                              description: Selector is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account that matches the given label selector. If
+                                both Names and Selector are specified then they are
+                                AND'ed.
+                              type: string
+                          type: object
+                        services:
+                          description: "Services is an optional field that contains
+                            options for matching Kubernetes Services. If specified,
+                            only traffic that originates from or terminates at endpoints
+                            within the selected service(s) will be matched, and only
+                            to/from each endpoint's port. \n Services cannot be specified
+                            on the same rule as Selector, NotSelector, NamespaceSelector,
+                            Nets, NotNets or ServiceAccounts. \n Ports and NotPorts
+                            can only be specified with Services on ingress rules."
+                          properties:
+                            name:
+                              description: Name specifies the name of a Kubernetes
+                                Service to match.
+                              type: string
+                            namespace:
+                              description: Namespace specifies the namespace of the
+                                given Service. If left empty, the rule will match
+                                within this policy's namespace.
+                              type: string
+                          type: object
+                      type: object
+                    http:
+                      description: HTTP contains match criteria that apply to HTTP
+                        requests.
+                      properties:
+                        methods:
+                          description: Methods is an optional field that restricts
+                            the rule to apply only to HTTP requests that use one of
+                            the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                            methods are OR'd together.
+                          items:
+                            type: string
+                          type: array
+                        paths:
+                          description: 'Paths is an optional field that restricts
+                            the rule to apply to HTTP requests that use one of the
+                            listed HTTP Paths. Multiple paths are OR''d together.
+                            e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                            ONLY specify either a `exact` or a `prefix` match. The
+                            validator will check for it.'
+                          items:
+                            description: 'HTTPPath specifies an HTTP path to match.
+                              It may be either of the form: exact: <path>: which matches
+                              the path exactly or prefix: <path-prefix>: which matches
+                              the path prefix'
+                            properties:
+                              exact:
+                                type: string
+                              prefix:
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    icmp:
+                      description: ICMP is an optional field that restricts the rule
+                        to apply to a specific type and code of ICMP traffic.  This
+                        should only be specified if the Protocol field is set to "ICMP"
+                        or "ICMPv6".
+                      properties:
+                        code:
+                          description: Match on a specific ICMP code.  If specified,
+                            the Type value must also be specified. This is a technical
+                            limitation imposed by the kernel's iptables firewall,
+                            which Calico uses to enforce the rule.
+                          type: integer
+                        type:
+                          description: Match on a specific ICMP type.  For example
+                            a value of 8 refers to ICMP Echo Request (i.e. pings).
+                          type: integer
+                      type: object
+                    ipVersion:
+                      description: IPVersion is an optional field that restricts the
+                        rule to only match a specific IP version.
+                      type: integer
+                    metadata:
+                      description: Metadata contains additional information for this
+                        rule
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Annotations is a set of key value pairs that
+                            give extra information about the rule
+                          type: object
+                      type: object
+                    notICMP:
+                      description: NotICMP is the negated version of the ICMP field.
+                      properties:
+                        code:
+                          description: Match on a specific ICMP code.  If specified,
+                            the Type value must also be specified. This is a technical
+                            limitation imposed by the kernel's iptables firewall,
+                            which Calico uses to enforce the rule.
+                          type: integer
+                        type:
+                          description: Match on a specific ICMP type.  For example
+                            a value of 8 refers to ICMP Echo Request (i.e. pings).
+                          type: integer
+                      type: object
+                    notProtocol:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: NotProtocol is the negated version of the Protocol
+                        field.
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    protocol:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: "Protocol is an optional field that restricts the
+                        rule to only apply to traffic of a specific IP protocol. Required
+                        if any of the EntityRules contain Ports (because ports only
+                        apply to certain protocols). \n Must be one of these string
+                        values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                        \"UDPLite\" or an integer in the range 1-255."
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    source:
+                      description: Source contains the match criteria that apply to
+                        source entity.
+                      properties:
+                        namespaceSelector:
+                          description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and another selector are defined on the same rule, then
+                            only workload endpoints that are matched by both selectors
+                            will be selected by the rule. \n For NetworkPolicy, an
+                            empty NamespaceSelector implies that the Selector is limited
+                            to selecting only workload endpoints in the same namespace
+                            as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                            NamespaceSelector implies that the Selector is limited
+                            to selecting only GlobalNetworkSet or HostEndpoint. \n
+                            For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                            the Selector applies to workload endpoints across all
+                            namespaces."
+                          type: string
+                        nets:
+                          description: Nets is an optional field that restricts the
+                            rule to only apply to traffic that originates from (or
+                            terminates at) IP addresses in any of the given subnets.
+                          items:
+                            type: string
+                          type: array
+                        notNets:
+                          description: NotNets is the negated version of the Nets
+                            field.
+                          items:
+                            type: string
+                          type: array
+                        notPorts:
+                          description: NotPorts is the negated version of the Ports
+                            field. Since only some protocols have ports, if any ports
+                            are specified it requires the Protocol match in the Rule
+                            to be set to "TCP" or "UDP".
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        notSelector:
+                          description: NotSelector is the negated version of the Selector
+                            field.  See Selector field for subtleties with negated
+                            selectors.
+                          type: string
+                        ports:
+                          description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        selector:
+                          description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label \"my_label\". \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label \"my_label\".
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                          type: string
+                        serviceAccounts:
+                          description: ServiceAccounts is an optional field that restricts
+                            the rule to only apply to traffic that originates from
+                            (or terminates at) a pod running as a matching service
+                            account.
+                          properties:
+                            names:
+                              description: Names is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account whose name is in the list.
+                              items:
+                                type: string
+                              type: array
+                            selector:
+                              description: Selector is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account that matches the given label selector. If
+                                both Names and Selector are specified then they are
+                                AND'ed.
+                              type: string
+                          type: object
+                        services:
+                          description: "Services is an optional field that contains
+                            options for matching Kubernetes Services. If specified,
+                            only traffic that originates from or terminates at endpoints
+                            within the selected service(s) will be matched, and only
+                            to/from each endpoint's port. \n Services cannot be specified
+                            on the same rule as Selector, NotSelector, NamespaceSelector,
+                            Nets, NotNets or ServiceAccounts. \n Ports and NotPorts
+                            can only be specified with Services on ingress rules."
+                          properties:
+                            name:
+                              description: Name specifies the name of a Kubernetes
+                                Service to match.
+                              type: string
+                            namespace:
+                              description: Namespace specifies the namespace of the
+                                given Service. If left empty, the rule will match
+                                within this policy's namespace.
+                              type: string
+                          type: object
+                      type: object
+                  required:
+                  - action
+                  type: object
+                type: array
+              ingress:
+                description: The ordered set of ingress rules.  Each rule contains
+                  a set of packet match criteria and a corresponding action to apply.
+                items:
+                  description: "A Rule encapsulates a set of match criteria and an
+                    action.  Both selector-based security Policy and security Profiles
+                    reference rules - separated out as a list of rules for both ingress
+                    and egress packet matching. \n Each positive match criteria has
+                    a negated version, prefixed with \"Not\". All the match criteria
+                    within a rule must be satisfied for a packet to match. A single
+                    rule can contain the positive and negative version of a match
+                    and both must be satisfied for the rule to match."
+                  properties:
+                    action:
+                      type: string
+                    destination:
+                      description: Destination contains the match criteria that apply
+                        to destination entity.
+                      properties:
+                        namespaceSelector:
+                          description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and another selector are defined on the same rule, then
+                            only workload endpoints that are matched by both selectors
+                            will be selected by the rule. \n For NetworkPolicy, an
+                            empty NamespaceSelector implies that the Selector is limited
+                            to selecting only workload endpoints in the same namespace
+                            as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                            NamespaceSelector implies that the Selector is limited
+                            to selecting only GlobalNetworkSet or HostEndpoint. \n
+                            For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                            the Selector applies to workload endpoints across all
+                            namespaces."
+                          type: string
+                        nets:
+                          description: Nets is an optional field that restricts the
+                            rule to only apply to traffic that originates from (or
+                            terminates at) IP addresses in any of the given subnets.
+                          items:
+                            type: string
+                          type: array
+                        notNets:
+                          description: NotNets is the negated version of the Nets
+                            field.
+                          items:
+                            type: string
+                          type: array
+                        notPorts:
+                          description: NotPorts is the negated version of the Ports
+                            field. Since only some protocols have ports, if any ports
+                            are specified it requires the Protocol match in the Rule
+                            to be set to "TCP" or "UDP".
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        notSelector:
+                          description: NotSelector is the negated version of the Selector
+                            field.  See Selector field for subtleties with negated
+                            selectors.
+                          type: string
+                        ports:
+                          description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        selector:
+                          description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label \"my_label\". \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label \"my_label\".
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                          type: string
+                        serviceAccounts:
+                          description: ServiceAccounts is an optional field that restricts
+                            the rule to only apply to traffic that originates from
+                            (or terminates at) a pod running as a matching service
+                            account.
+                          properties:
+                            names:
+                              description: Names is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account whose name is in the list.
+                              items:
+                                type: string
+                              type: array
+                            selector:
+                              description: Selector is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account that matches the given label selector. If
+                                both Names and Selector are specified then they are
+                                AND'ed.
+                              type: string
+                          type: object
+                        services:
+                          description: "Services is an optional field that contains
+                            options for matching Kubernetes Services. If specified,
+                            only traffic that originates from or terminates at endpoints
+                            within the selected service(s) will be matched, and only
+                            to/from each endpoint's port. \n Services cannot be specified
+                            on the same rule as Selector, NotSelector, NamespaceSelector,
+                            Nets, NotNets or ServiceAccounts. \n Ports and NotPorts
+                            can only be specified with Services on ingress rules."
+                          properties:
+                            name:
+                              description: Name specifies the name of a Kubernetes
+                                Service to match.
+                              type: string
+                            namespace:
+                              description: Namespace specifies the namespace of the
+                                given Service. If left empty, the rule will match
+                                within this policy's namespace.
+                              type: string
+                          type: object
+                      type: object
+                    http:
+                      description: HTTP contains match criteria that apply to HTTP
+                        requests.
+                      properties:
+                        methods:
+                          description: Methods is an optional field that restricts
+                            the rule to apply only to HTTP requests that use one of
+                            the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                            methods are OR'd together.
+                          items:
+                            type: string
+                          type: array
+                        paths:
+                          description: 'Paths is an optional field that restricts
+                            the rule to apply to HTTP requests that use one of the
+                            listed HTTP Paths. Multiple paths are OR''d together.
+                            e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                            ONLY specify either a `exact` or a `prefix` match. The
+                            validator will check for it.'
+                          items:
+                            description: 'HTTPPath specifies an HTTP path to match.
+                              It may be either of the form: exact: <path>: which matches
+                              the path exactly or prefix: <path-prefix>: which matches
+                              the path prefix'
+                            properties:
+                              exact:
+                                type: string
+                              prefix:
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    icmp:
+                      description: ICMP is an optional field that restricts the rule
+                        to apply to a specific type and code of ICMP traffic.  This
+                        should only be specified if the Protocol field is set to "ICMP"
+                        or "ICMPv6".
+                      properties:
+                        code:
+                          description: Match on a specific ICMP code.  If specified,
+                            the Type value must also be specified. This is a technical
+                            limitation imposed by the kernel's iptables firewall,
+                            which Calico uses to enforce the rule.
+                          type: integer
+                        type:
+                          description: Match on a specific ICMP type.  For example
+                            a value of 8 refers to ICMP Echo Request (i.e. pings).
+                          type: integer
+                      type: object
+                    ipVersion:
+                      description: IPVersion is an optional field that restricts the
+                        rule to only match a specific IP version.
+                      type: integer
+                    metadata:
+                      description: Metadata contains additional information for this
+                        rule
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Annotations is a set of key value pairs that
+                            give extra information about the rule
+                          type: object
+                      type: object
+                    notICMP:
+                      description: NotICMP is the negated version of the ICMP field.
+                      properties:
+                        code:
+                          description: Match on a specific ICMP code.  If specified,
+                            the Type value must also be specified. This is a technical
+                            limitation imposed by the kernel's iptables firewall,
+                            which Calico uses to enforce the rule.
+                          type: integer
+                        type:
+                          description: Match on a specific ICMP type.  For example
+                            a value of 8 refers to ICMP Echo Request (i.e. pings).
+                          type: integer
+                      type: object
+                    notProtocol:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: NotProtocol is the negated version of the Protocol
+                        field.
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    protocol:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: "Protocol is an optional field that restricts the
+                        rule to only apply to traffic of a specific IP protocol. Required
+                        if any of the EntityRules contain Ports (because ports only
+                        apply to certain protocols). \n Must be one of these string
+                        values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                        \"UDPLite\" or an integer in the range 1-255."
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    source:
+                      description: Source contains the match criteria that apply to
+                        source entity.
+                      properties:
+                        namespaceSelector:
+                          description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and another selector are defined on the same rule, then
+                            only workload endpoints that are matched by both selectors
+                            will be selected by the rule. \n For NetworkPolicy, an
+                            empty NamespaceSelector implies that the Selector is limited
+                            to selecting only workload endpoints in the same namespace
+                            as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                            NamespaceSelector implies that the Selector is limited
+                            to selecting only GlobalNetworkSet or HostEndpoint. \n
+                            For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                            the Selector applies to workload endpoints across all
+                            namespaces."
+                          type: string
+                        nets:
+                          description: Nets is an optional field that restricts the
+                            rule to only apply to traffic that originates from (or
+                            terminates at) IP addresses in any of the given subnets.
+                          items:
+                            type: string
+                          type: array
+                        notNets:
+                          description: NotNets is the negated version of the Nets
+                            field.
+                          items:
+                            type: string
+                          type: array
+                        notPorts:
+                          description: NotPorts is the negated version of the Ports
+                            field. Since only some protocols have ports, if any ports
+                            are specified it requires the Protocol match in the Rule
+                            to be set to "TCP" or "UDP".
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        notSelector:
+                          description: NotSelector is the negated version of the Selector
+                            field.  See Selector field for subtleties with negated
+                            selectors.
+                          type: string
+                        ports:
+                          description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        selector:
+                          description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label \"my_label\". \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label \"my_label\".
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                          type: string
+                        serviceAccounts:
+                          description: ServiceAccounts is an optional field that restricts
+                            the rule to only apply to traffic that originates from
+                            (or terminates at) a pod running as a matching service
+                            account.
+                          properties:
+                            names:
+                              description: Names is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account whose name is in the list.
+                              items:
+                                type: string
+                              type: array
+                            selector:
+                              description: Selector is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account that matches the given label selector. If
+                                both Names and Selector are specified then they are
+                                AND'ed.
+                              type: string
+                          type: object
+                        services:
+                          description: "Services is an optional field that contains
+                            options for matching Kubernetes Services. If specified,
+                            only traffic that originates from or terminates at endpoints
+                            within the selected service(s) will be matched, and only
+                            to/from each endpoint's port. \n Services cannot be specified
+                            on the same rule as Selector, NotSelector, NamespaceSelector,
+                            Nets, NotNets or ServiceAccounts. \n Ports and NotPorts
+                            can only be specified with Services on ingress rules."
+                          properties:
+                            name:
+                              description: Name specifies the name of a Kubernetes
+                                Service to match.
+                              type: string
+                            namespace:
+                              description: Namespace specifies the namespace of the
+                                given Service. If left empty, the rule will match
+                                within this policy's namespace.
+                              type: string
+                          type: object
+                      type: object
+                  required:
+                  - action
+                  type: object
+                type: array
+              namespaceSelector:
+                description: NamespaceSelector is an optional field for an expression
+                  used to select a pod based on namespaces.
+                type: string
+              order:
+                description: Order is an optional field that specifies the order in
+                  which the policy is applied. Policies with higher "order" are applied
+                  after those with lower order.  If the order is omitted, it may be
+                  considered to be "infinite" - i.e. the policy will be applied last.  Policies
+                  with identical order will be applied in alphanumerical order based
+                  on the Policy "Name".
+                type: number
+              preDNAT:
+                description: PreDNAT indicates to apply the rules in this policy before
+                  any DNAT.
+                type: boolean
+              selector:
+                description: "The selector is an expression used to pick pick out
+                  the endpoints that the policy should be applied to. \n Selector
+                  expressions follow this syntax: \n \tlabel == \"string_literal\"
+                  \ ->  comparison, e.g. my_label == \"foo bar\" \tlabel != \"string_literal\"
+                  \  ->  not equal; also matches if label is not present \tlabel in
+                  { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is
+                  one of \"a\", \"b\", \"c\" \tlabel not in { \"a\", \"b\", \"c\",
+                  ... }  ->  true if the value of label X is not one of \"a\", \"b\",
+                  \"c\" \thas(label_name)  -> True if that label is present \t! expr
+                  -> negation of expr \texpr && expr  -> Short-circuit and \texpr
+                  || expr  -> Short-circuit or \t( expr ) -> parens for grouping \tall()
+                  or the empty selector -> matches all endpoints. \n Label names are
+                  allowed to contain alphanumerics, -, _ and /. String literals are
+                  more permissive but they do not support escape characters. \n Examples
+                  (with made-up labels): \n \ttype == \"webserver\" && deployment
+                  == \"prod\" \ttype in {\"frontend\", \"backend\"} \tdeployment !=
+                  \"dev\" \t! has(label_name)"
+                type: string
+              serviceAccountSelector:
+                description: ServiceAccountSelector is an optional field for an expression
+                  used to select a pod based on service accounts.
+                type: string
+              types:
+                description: "Types indicates whether this policy applies to ingress,
+                  or to egress, or to both.  When not explicitly specified (and so
+                  the value on creation is empty or nil), Calico defaults Types according
+                  to what Ingress and Egress rules are present in the policy.  The
+                  default is: \n - [ PolicyTypeIngress ], if there are no Egress rules
+                  (including the case where there are   also no Ingress rules) \n
+                  - [ PolicyTypeEgress ], if there are Egress rules but no Ingress
+                  rules \n - [ PolicyTypeIngress, PolicyTypeEgress ], if there are
+                  both Ingress and Egress rules. \n When the policy is read back again,
+                  Types will always be one of these values, never empty or nil."
+                items:
+                  description: PolicyType enumerates the possible values of the PolicySpec
+                    Types field.
+                  type: string
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+---
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: globalnetworksets.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            x-kubernetes-preserve-unknown-fields: true
+          apiVersion:
+            type: string
+  names:
+    kind: GlobalNetworkSet
+    plural: globalnetworksets
+    singular: globalnetworkset
+
+---
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: networkpolicies.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: NetworkPolicy
+    listKind: NetworkPolicyList
+    plural: networkpolicies
+    singular: networkpolicy
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            x-kubernetes-preserve-unknown-fields: true
+            properties:
+              egress:
+                description: The ordered set of egress rules.  Each rule contains
+                  a set of packet match criteria and a corresponding action to apply.
+                items:
+                  description: "A Rule encapsulates a set of match criteria and an
+                    action.  Both selector-based security Policy and security Profiles
+                    reference rules - separated out as a list of rules for both ingress
+                    and egress packet matching. \n Each positive match criteria has
+                    a negated version, prefixed with \"Not\". All the match criteria
+                    within a rule must be satisfied for a packet to match. A single
+                    rule can contain the positive and negative version of a match
+                    and both must be satisfied for the rule to match."
+                  properties:
+                    action:
+                      type: string
+                    destination:
+                      description: Destination contains the match criteria that apply
+                        to destination entity.
+                      properties:
+                        namespaceSelector:
+                          description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and another selector are defined on the same rule, then
+                            only workload endpoints that are matched by both selectors
+                            will be selected by the rule. \n For NetworkPolicy, an
+                            empty NamespaceSelector implies that the Selector is limited
+                            to selecting only workload endpoints in the same namespace
+                            as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                            NamespaceSelector implies that the Selector is limited
+                            to selecting only GlobalNetworkSet or HostEndpoint. \n
+                            For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                            the Selector applies to workload endpoints across all
+                            namespaces."
+                          type: string
+                        nets:
+                          description: Nets is an optional field that restricts the
+                            rule to only apply to traffic that originates from (or
+                            terminates at) IP addresses in any of the given subnets.
+                          items:
+                            type: string
+                          type: array
+                        notNets:
+                          description: NotNets is the negated version of the Nets
+                            field.
+                          items:
+                            type: string
+                          type: array
+                        notPorts:
+                          description: NotPorts is the negated version of the Ports
+                            field. Since only some protocols have ports, if any ports
+                            are specified it requires the Protocol match in the Rule
+                            to be set to "TCP" or "UDP".
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        notSelector:
+                          description: NotSelector is the negated version of the Selector
+                            field.  See Selector field for subtleties with negated
+                            selectors.
+                          type: string
+                        ports:
+                          description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        selector:
+                          description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label \"my_label\". \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label \"my_label\".
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                          type: string
+                        serviceAccounts:
+                          description: ServiceAccounts is an optional field that restricts
+                            the rule to only apply to traffic that originates from
+                            (or terminates at) a pod running as a matching service
+                            account.
+                          properties:
+                            names:
+                              description: Names is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account whose name is in the list.
+                              items:
+                                type: string
+                              type: array
+                            selector:
+                              description: Selector is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account that matches the given label selector. If
+                                both Names and Selector are specified then they are
+                                AND'ed.
+                              type: string
+                          type: object
+                        services:
+                          description: "Services is an optional field that contains
+                            options for matching Kubernetes Services. If specified,
+                            only traffic that originates from or terminates at endpoints
+                            within the selected service(s) will be matched, and only
+                            to/from each endpoint's port. \n Services cannot be specified
+                            on the same rule as Selector, NotSelector, NamespaceSelector,
+                            Nets, NotNets or ServiceAccounts. \n Ports and NotPorts
+                            can only be specified with Services on ingress rules."
+                          properties:
+                            name:
+                              description: Name specifies the name of a Kubernetes
+                                Service to match.
+                              type: string
+                            namespace:
+                              description: Namespace specifies the namespace of the
+                                given Service. If left empty, the rule will match
+                                within this policy's namespace.
+                              type: string
+                          type: object
+                      type: object
+                    http:
+                      description: HTTP contains match criteria that apply to HTTP
+                        requests.
+                      properties:
+                        methods:
+                          description: Methods is an optional field that restricts
+                            the rule to apply only to HTTP requests that use one of
+                            the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                            methods are OR'd together.
+                          items:
+                            type: string
+                          type: array
+                        paths:
+                          description: 'Paths is an optional field that restricts
+                            the rule to apply to HTTP requests that use one of the
+                            listed HTTP Paths. Multiple paths are OR''d together.
+                            e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                            ONLY specify either a `exact` or a `prefix` match. The
+                            validator will check for it.'
+                          items:
+                            description: 'HTTPPath specifies an HTTP path to match.
+                              It may be either of the form: exact: <path>: which matches
+                              the path exactly or prefix: <path-prefix>: which matches
+                              the path prefix'
+                            properties:
+                              exact:
+                                type: string
+                              prefix:
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    icmp:
+                      description: ICMP is an optional field that restricts the rule
+                        to apply to a specific type and code of ICMP traffic.  This
+                        should only be specified if the Protocol field is set to "ICMP"
+                        or "ICMPv6".
+                      properties:
+                        code:
+                          description: Match on a specific ICMP code.  If specified,
+                            the Type value must also be specified. This is a technical
+                            limitation imposed by the kernel's iptables firewall,
+                            which Calico uses to enforce the rule.
+                          type: integer
+                        type:
+                          description: Match on a specific ICMP type.  For example
+                            a value of 8 refers to ICMP Echo Request (i.e. pings).
+                          type: integer
+                      type: object
+                    ipVersion:
+                      description: IPVersion is an optional field that restricts the
+                        rule to only match a specific IP version.
+                      type: integer
+                    metadata:
+                      description: Metadata contains additional information for this
+                        rule
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Annotations is a set of key value pairs that
+                            give extra information about the rule
+                          type: object
+                      type: object
+                    notICMP:
+                      description: NotICMP is the negated version of the ICMP field.
+                      properties:
+                        code:
+                          description: Match on a specific ICMP code.  If specified,
+                            the Type value must also be specified. This is a technical
+                            limitation imposed by the kernel's iptables firewall,
+                            which Calico uses to enforce the rule.
+                          type: integer
+                        type:
+                          description: Match on a specific ICMP type.  For example
+                            a value of 8 refers to ICMP Echo Request (i.e. pings).
+                          type: integer
+                      type: object
+                    notProtocol:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: NotProtocol is the negated version of the Protocol
+                        field.
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    protocol:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: "Protocol is an optional field that restricts the
+                        rule to only apply to traffic of a specific IP protocol. Required
+                        if any of the EntityRules contain Ports (because ports only
+                        apply to certain protocols). \n Must be one of these string
+                        values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                        \"UDPLite\" or an integer in the range 1-255."
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    source:
+                      description: Source contains the match criteria that apply to
+                        source entity.
+                      properties:
+                        namespaceSelector:
+                          description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and another selector are defined on the same rule, then
+                            only workload endpoints that are matched by both selectors
+                            will be selected by the rule. \n For NetworkPolicy, an
+                            empty NamespaceSelector implies that the Selector is limited
+                            to selecting only workload endpoints in the same namespace
+                            as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                            NamespaceSelector implies that the Selector is limited
+                            to selecting only GlobalNetworkSet or HostEndpoint. \n
+                            For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                            the Selector applies to workload endpoints across all
+                            namespaces."
+                          type: string
+                        nets:
+                          description: Nets is an optional field that restricts the
+                            rule to only apply to traffic that originates from (or
+                            terminates at) IP addresses in any of the given subnets.
+                          items:
+                            type: string
+                          type: array
+                        notNets:
+                          description: NotNets is the negated version of the Nets
+                            field.
+                          items:
+                            type: string
+                          type: array
+                        notPorts:
+                          description: NotPorts is the negated version of the Ports
+                            field. Since only some protocols have ports, if any ports
+                            are specified it requires the Protocol match in the Rule
+                            to be set to "TCP" or "UDP".
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        notSelector:
+                          description: NotSelector is the negated version of the Selector
+                            field.  See Selector field for subtleties with negated
+                            selectors.
+                          type: string
+                        ports:
+                          description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        selector:
+                          description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label \"my_label\". \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label \"my_label\".
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                          type: string
+                        serviceAccounts:
+                          description: ServiceAccounts is an optional field that restricts
+                            the rule to only apply to traffic that originates from
+                            (or terminates at) a pod running as a matching service
+                            account.
+                          properties:
+                            names:
+                              description: Names is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account whose name is in the list.
+                              items:
+                                type: string
+                              type: array
+                            selector:
+                              description: Selector is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account that matches the given label selector. If
+                                both Names and Selector are specified then they are
+                                AND'ed.
+                              type: string
+                          type: object
+                        services:
+                          description: "Services is an optional field that contains
+                            options for matching Kubernetes Services. If specified,
+                            only traffic that originates from or terminates at endpoints
+                            within the selected service(s) will be matched, and only
+                            to/from each endpoint's port. \n Services cannot be specified
+                            on the same rule as Selector, NotSelector, NamespaceSelector,
+                            Nets, NotNets or ServiceAccounts. \n Ports and NotPorts
+                            can only be specified with Services on ingress rules."
+                          properties:
+                            name:
+                              description: Name specifies the name of a Kubernetes
+                                Service to match.
+                              type: string
+                            namespace:
+                              description: Namespace specifies the namespace of the
+                                given Service. If left empty, the rule will match
+                                within this policy's namespace.
+                              type: string
+                          type: object
+                      type: object
+                  required:
+                  - action
+                  type: object
+                type: array
+              ingress:
+                description: The ordered set of ingress rules.  Each rule contains
+                  a set of packet match criteria and a corresponding action to apply.
+                items:
+                  description: "A Rule encapsulates a set of match criteria and an
+                    action.  Both selector-based security Policy and security Profiles
+                    reference rules - separated out as a list of rules for both ingress
+                    and egress packet matching. \n Each positive match criteria has
+                    a negated version, prefixed with \"Not\". All the match criteria
+                    within a rule must be satisfied for a packet to match. A single
+                    rule can contain the positive and negative version of a match
+                    and both must be satisfied for the rule to match."
+                  properties:
+                    action:
+                      type: string
+                    destination:
+                      description: Destination contains the match criteria that apply
+                        to destination entity.
+                      properties:
+                        namespaceSelector:
+                          description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and another selector are defined on the same rule, then
+                            only workload endpoints that are matched by both selectors
+                            will be selected by the rule. \n For NetworkPolicy, an
+                            empty NamespaceSelector implies that the Selector is limited
+                            to selecting only workload endpoints in the same namespace
+                            as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                            NamespaceSelector implies that the Selector is limited
+                            to selecting only GlobalNetworkSet or HostEndpoint. \n
+                            For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                            the Selector applies to workload endpoints across all
+                            namespaces."
+                          type: string
+                        nets:
+                          description: Nets is an optional field that restricts the
+                            rule to only apply to traffic that originates from (or
+                            terminates at) IP addresses in any of the given subnets.
+                          items:
+                            type: string
+                          type: array
+                        notNets:
+                          description: NotNets is the negated version of the Nets
+                            field.
+                          items:
+                            type: string
+                          type: array
+                        notPorts:
+                          description: NotPorts is the negated version of the Ports
+                            field. Since only some protocols have ports, if any ports
+                            are specified it requires the Protocol match in the Rule
+                            to be set to "TCP" or "UDP".
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        notSelector:
+                          description: NotSelector is the negated version of the Selector
+                            field.  See Selector field for subtleties with negated
+                            selectors.
+                          type: string
+                        ports:
+                          description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        selector:
+                          description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label \"my_label\". \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label \"my_label\".
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                          type: string
+                        serviceAccounts:
+                          description: ServiceAccounts is an optional field that restricts
+                            the rule to only apply to traffic that originates from
+                            (or terminates at) a pod running as a matching service
+                            account.
+                          properties:
+                            names:
+                              description: Names is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account whose name is in the list.
+                              items:
+                                type: string
+                              type: array
+                            selector:
+                              description: Selector is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account that matches the given label selector. If
+                                both Names and Selector are specified then they are
+                                AND'ed.
+                              type: string
+                          type: object
+                        services:
+                          description: "Services is an optional field that contains
+                            options for matching Kubernetes Services. If specified,
+                            only traffic that originates from or terminates at endpoints
+                            within the selected service(s) will be matched, and only
+                            to/from each endpoint's port. \n Services cannot be specified
+                            on the same rule as Selector, NotSelector, NamespaceSelector,
+                            Nets, NotNets or ServiceAccounts. \n Ports and NotPorts
+                            can only be specified with Services on ingress rules."
+                          properties:
+                            name:
+                              description: Name specifies the name of a Kubernetes
+                                Service to match.
+                              type: string
+                            namespace:
+                              description: Namespace specifies the namespace of the
+                                given Service. If left empty, the rule will match
+                                within this policy's namespace.
+                              type: string
+                          type: object
+                      type: object
+                    http:
+                      description: HTTP contains match criteria that apply to HTTP
+                        requests.
+                      properties:
+                        methods:
+                          description: Methods is an optional field that restricts
+                            the rule to apply only to HTTP requests that use one of
+                            the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                            methods are OR'd together.
+                          items:
+                            type: string
+                          type: array
+                        paths:
+                          description: 'Paths is an optional field that restricts
+                            the rule to apply to HTTP requests that use one of the
+                            listed HTTP Paths. Multiple paths are OR''d together.
+                            e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                            ONLY specify either a `exact` or a `prefix` match. The
+                            validator will check for it.'
+                          items:
+                            description: 'HTTPPath specifies an HTTP path to match.
+                              It may be either of the form: exact: <path>: which matches
+                              the path exactly or prefix: <path-prefix>: which matches
+                              the path prefix'
+                            properties:
+                              exact:
+                                type: string
+                              prefix:
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    icmp:
+                      description: ICMP is an optional field that restricts the rule
+                        to apply to a specific type and code of ICMP traffic.  This
+                        should only be specified if the Protocol field is set to "ICMP"
+                        or "ICMPv6".
+                      properties:
+                        code:
+                          description: Match on a specific ICMP code.  If specified,
+                            the Type value must also be specified. This is a technical
+                            limitation imposed by the kernel's iptables firewall,
+                            which Calico uses to enforce the rule.
+                          type: integer
+                        type:
+                          description: Match on a specific ICMP type.  For example
+                            a value of 8 refers to ICMP Echo Request (i.e. pings).
+                          type: integer
+                      type: object
+                    ipVersion:
+                      description: IPVersion is an optional field that restricts the
+                        rule to only match a specific IP version.
+                      type: integer
+                    metadata:
+                      description: Metadata contains additional information for this
+                        rule
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Annotations is a set of key value pairs that
+                            give extra information about the rule
+                          type: object
+                      type: object
+                    notICMP:
+                      description: NotICMP is the negated version of the ICMP field.
+                      properties:
+                        code:
+                          description: Match on a specific ICMP code.  If specified,
+                            the Type value must also be specified. This is a technical
+                            limitation imposed by the kernel's iptables firewall,
+                            which Calico uses to enforce the rule.
+                          type: integer
+                        type:
+                          description: Match on a specific ICMP type.  For example
+                            a value of 8 refers to ICMP Echo Request (i.e. pings).
+                          type: integer
+                      type: object
+                    notProtocol:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: NotProtocol is the negated version of the Protocol
+                        field.
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    protocol:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: "Protocol is an optional field that restricts the
+                        rule to only apply to traffic of a specific IP protocol. Required
+                        if any of the EntityRules contain Ports (because ports only
+                        apply to certain protocols). \n Must be one of these string
+                        values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                        \"UDPLite\" or an integer in the range 1-255."
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    source:
+                      description: Source contains the match criteria that apply to
+                        source entity.
+                      properties:
+                        namespaceSelector:
+                          description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and another selector are defined on the same rule, then
+                            only workload endpoints that are matched by both selectors
+                            will be selected by the rule. \n For NetworkPolicy, an
+                            empty NamespaceSelector implies that the Selector is limited
+                            to selecting only workload endpoints in the same namespace
+                            as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                            NamespaceSelector implies that the Selector is limited
+                            to selecting only GlobalNetworkSet or HostEndpoint. \n
+                            For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                            the Selector applies to workload endpoints across all
+                            namespaces."
+                          type: string
+                        nets:
+                          description: Nets is an optional field that restricts the
+                            rule to only apply to traffic that originates from (or
+                            terminates at) IP addresses in any of the given subnets.
+                          items:
+                            type: string
+                          type: array
+                        notNets:
+                          description: NotNets is the negated version of the Nets
+                            field.
+                          items:
+                            type: string
+                          type: array
+                        notPorts:
+                          description: NotPorts is the negated version of the Ports
+                            field. Since only some protocols have ports, if any ports
+                            are specified it requires the Protocol match in the Rule
+                            to be set to "TCP" or "UDP".
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        notSelector:
+                          description: NotSelector is the negated version of the Selector
+                            field.  See Selector field for subtleties with negated
+                            selectors.
+                          type: string
+                        ports:
+                          description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        selector:
+                          description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label \"my_label\". \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label \"my_label\".
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                          type: string
+                        serviceAccounts:
+                          description: ServiceAccounts is an optional field that restricts
+                            the rule to only apply to traffic that originates from
+                            (or terminates at) a pod running as a matching service
+                            account.
+                          properties:
+                            names:
+                              description: Names is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account whose name is in the list.
+                              items:
+                                type: string
+                              type: array
+                            selector:
+                              description: Selector is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account that matches the given label selector. If
+                                both Names and Selector are specified then they are
+                                AND'ed.
+                              type: string
+                          type: object
+                        services:
+                          description: "Services is an optional field that contains
+                            options for matching Kubernetes Services. If specified,
+                            only traffic that originates from or terminates at endpoints
+                            within the selected service(s) will be matched, and only
+                            to/from each endpoint's port. \n Services cannot be specified
+                            on the same rule as Selector, NotSelector, NamespaceSelector,
+                            Nets, NotNets or ServiceAccounts. \n Ports and NotPorts
+                            can only be specified with Services on ingress rules."
+                          properties:
+                            name:
+                              description: Name specifies the name of a Kubernetes
+                                Service to match.
+                              type: string
+                            namespace:
+                              description: Namespace specifies the namespace of the
+                                given Service. If left empty, the rule will match
+                                within this policy's namespace.
+                              type: string
+                          type: object
+                      type: object
+                  required:
+                  - action
+                  type: object
+                type: array
+              order:
+                description: Order is an optional field that specifies the order in
+                  which the policy is applied. Policies with higher "order" are applied
+                  after those with lower order.  If the order is omitted, it may be
+                  considered to be "infinite" - i.e. the policy will be applied last.  Policies
+                  with identical order will be applied in alphanumerical order based
+                  on the Policy "Name".
+                type: number
+              selector:
+                description: "The selector is an expression used to pick pick out
+                  the endpoints that the policy should be applied to. \n Selector
+                  expressions follow this syntax: \n \tlabel == \"string_literal\"
+                  \ ->  comparison, e.g. my_label == \"foo bar\" \tlabel != \"string_literal\"
+                  \  ->  not equal; also matches if label is not present \tlabel in
+                  { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is
+                  one of \"a\", \"b\", \"c\" \tlabel not in { \"a\", \"b\", \"c\",
+                  ... }  ->  true if the value of label X is not one of \"a\", \"b\",
+                  \"c\" \thas(label_name)  -> True if that label is present \t! expr
+                  -> negation of expr \texpr && expr  -> Short-circuit and \texpr
+                  || expr  -> Short-circuit or \t( expr ) -> parens for grouping \tall()
+                  or the empty selector -> matches all endpoints. \n Label names are
+                  allowed to contain alphanumerics, -, _ and /. String literals are
+                  more permissive but they do not support escape characters. \n Examples
+                  (with made-up labels): \n \ttype == \"webserver\" && deployment
+                  == \"prod\" \ttype in {\"frontend\", \"backend\"} \tdeployment !=
+                  \"dev\" \t! has(label_name)"
+                type: string
+              serviceAccountSelector:
+                description: ServiceAccountSelector is an optional field for an expression
+                  used to select a pod based on service accounts.
+                type: string
+              types:
+                description: "Types indicates whether this policy applies to ingress,
+                  or to egress, or to both.  When not explicitly specified (and so
+                  the value on creation is empty or nil), Calico defaults Types according
+                  to what Ingress and Egress are present in the policy.  The default
+                  is: \n - [ PolicyTypeIngress ], if there are no Egress rules (including
+                  the case where there are   also no Ingress rules) \n - [ PolicyTypeEgress
+                  ], if there are Egress rules but no Ingress rules \n - [ PolicyTypeIngress,
+                  PolicyTypeEgress ], if there are both Ingress and Egress rules.
+                  \n When the policy is read back again, Types will always be one
+                  of these values, never empty or nil."
+                items:
+                  description: PolicyType enumerates the possible values of the PolicySpec
+                    Types field.
+                  type: string
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: terway-controlplane
+  namespace: kube-system
+  labels:
+    k8s-app: terway-controlplane
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: terway-controlplane
+  template:
+    metadata:
+      labels:
+        k8s-app: terway-controlplane
+    spec:
+      hostNetwork: true
+      serviceAccountName: terway
+      priorityClassName: system-node-critical
+      tolerations:
+      - operator: "Exists"
+      containers:
+      - name: terway-controlplane
+        image: registry-cn-hangzhou.ack.aliyuncs.com/acs/terway-controlplane:v1.17.6
+        imagePullPolicy: IfNotPresent
+        command:
+        - /usr/bin/terway-controlplane
+        - "-v"
+        - "2"
+        ports:
+        - name: healthz
+          containerPort: 8080
+          protocol: TCP
+        - name: metrics
+          containerPort: 8081
+          protocol: TCP
+        env:
+        - name: K8S_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: MY_POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          periodSeconds: 10
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 5
+        volumeMounts:
+        - name: config-vol
+          mountPath: /etc/config
+          readOnly: true
+        - name: secret-vol
+          mountPath: /etc/credential
+          readOnly: true
+        - name: addon-token
+          mountPath: /var/addon
+          readOnly: true
+      - name: cilium-operator
+        image: registry-cn-hangzhou.ack.aliyuncs.com/acs/terway-controlplane:v1.17.6
+        imagePullPolicy: IfNotPresent
+        command:
+        - /usr/bin/cilium-operator-generic
+        - --config
+        - /etc/config/cilium-config.yaml
+        - --gops-port
+        - "0"
+        env:
+        - name: K8S_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: MY_POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        livenessProbe:
+          httpGet:
+            host: 127.0.0.1
+            path: /healthz
+            port: 9234
+            scheme: HTTP
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          timeoutSeconds: 3
+        volumeMounts:
+        - name: config-vol
+          mountPath: /etc/config
+          readOnly: true
+      volumes:
+      - name: secret-vol
+        secret:
+          secretName: terway-controlplane-credential
+      - name: config-vol
+        configMap:
+          name: terway-controlplane
+          items:
+          - key: ctrl-config.yaml
+            path: ctrl-config.yaml
+          - key: cilium-config.yaml
+            path: cilium-config.yaml
+      - name: addon-token
+        secret:
+          secretName: addon.network.token
+          items:
+          - key: addon.token.config
+            path: token-config
+          optional: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: ciliumpodippools.cilium.io
+spec:
+  group: cilium.io
+  scope: Cluster
+  names:
+    kind: CiliumPodIPPool
+    plural: ciliumpodippools
+    singular: ciliumpodippool
+  versions:
+  - name: v2alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: ciliumloadbalancerippools.cilium.io
+spec:
+  group: cilium.io
+  scope: Cluster
+  names:
+    kind: CiliumLoadBalancerIPPool
+    plural: ciliumloadbalancerippools
+    singular: ciliumloadbalancerippool
+  versions:
+  - name: v2alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: ciliuml2announcementpolicies.cilium.io
+spec:
+  group: cilium.io
+  scope: Cluster
+  names:
+    kind: CiliumL2AnnouncementPolicy
+    plural: ciliuml2announcementpolicies
+    singular: ciliuml2announcementpolicy
+  versions:
+  - name: v2alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: ciliumcidrgroups.cilium.io
+spec:
+  group: cilium.io
+  scope: Cluster
+  names:
+    kind: CiliumCIDRGroup
+    plural: ciliumcidrgroups
+    singular: ciliumcidrgroup
+  versions:
+  - name: v2alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: terway-controlplane-credential
+  namespace: kube-system
+type: Opaque
+stringData:
+  ctrl-secret.yaml: |
+    credentialPath: "/var/addon/token-config"

--- a/tests/upgrade/templates/v1.7/configmap.yaml.tmpl
+++ b/tests/upgrade/templates/v1.7/configmap.yaml.tmpl
@@ -1,0 +1,65 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: eni-config
+  namespace: kube-system
+data:
+  eni_conf: |
+    {
+      "version": "1",
+      "max_pool_size": 5,
+      "min_pool_size": 0,
+      "credential_path": "/var/addon/token-config",
+      "vswitches": {{.PodVswitchId}},
+      "eni_tags": {"ack.aliyun.com":"{{.ClusterID}}"},
+      "service_cidr": "{{.ServiceCIDR}}",
+      "security_group": "{{.SecurityGroupId}}",
+      "ip_stack": "{{.IPStack}}",
+      "vswitch_selection_policy": "ordered"
+    }
+  10-terway.conf: |
+    {
+      "cniVersion": "0.4.0",
+      "name": "terway",
+      "capabilities": {"bandwidth": true},
+{{if .Datapath}}
+      "eniip_virtual_type": "IPVlan",
+      "host_stack_cidrs": ["169.254.20.10/32"],
+{{end}}
+      "type": "terway"
+    }
+  disable_network_policy: "{{.DisableNetworkPolicy}}"
+  in_cluster_loadbalance: "true"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: terway-controlplane
+  namespace: kube-system
+data:
+  ctrl-config.yaml: |
+    leaseLockName: "terway-controller-lock"
+    leaseLockNamespace: "kube-system"
+    controllerNamespace: "kube-system"
+    controllerName: "terway-controlplane"
+    healthzBindAddress: "0.0.0.0:8080"
+    clusterDomain: "cluster.local"
+    leaderElection: true
+    webhookPort: 0
+    disableWebhook: true
+    certDir: "/var/run/webhook-cert"
+    regionID: "{{ .RegionID }}"
+    clusterID: "{{ .ClusterID }}"
+    vpcID: "{{ .VPCID }}"
+    ipStack: "{{ .IPStack }}"
+    enableTrunk: false
+    enableTrace: false
+    metricsBindAddress: "0"
+    centralizedIPAM: true
+    controllers:
+    - pod-eni
+    - pod
+    - pod-networking
+    - node
+    - multi-ip-node
+    - multi-ip-pod

--- a/tests/upgrade/templates/v1.7/terway-eniip.yaml
+++ b/tests/upgrade/templates/v1.7/terway-eniip.yaml
@@ -1,0 +1,847 @@
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: terway
+  namespace: kube-system
+
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: terway-pod-reader
+  namespace: kube-system
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - pods
+      - nodes
+      - namespaces
+      - configmaps
+      - secrets
+      - serviceaccounts
+      - endpoints
+      - services
+    verbs:
+      - get
+      - watch
+      - list
+  - apiGroups:
+      - ''
+    resources:
+      - pods
+      - nodes
+      - nodes/status
+    verbs:
+      - patch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - watch
+      - update
+      - create
+  - apiGroups:
+      - ''
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - networkpolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ''
+    resources:
+      - pods/status
+    verbs:
+      - update
+  - apiGroups:
+      - crd.projectcalico.org
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+  - apiGroups:
+      - cilium.io
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  - apiGroups:
+      - network.alibabacloud.com
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  - apiGroups:
+      - alibabacloud.com
+    resources:
+      - '*'
+    verbs:
+      - '*'
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: terway-binding
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: terway-pod-reader
+subjects:
+- kind: ServiceAccount
+  name: terway
+  namespace: kube-system
+
+---
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: terway-preflight
+  namespace: kube-system
+spec:
+  ttlSecondsAfterFinished: 300
+  backoffLimit: 10
+  template:
+    spec:
+      hostNetwork: true
+      priorityClassName: system-node-critical
+      tolerations:
+      - operator: "Exists"
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: type
+                operator: NotIn
+                values:
+                - virtual-kubelet
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+                - arm64
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+      containers:
+      - name: preflight
+        image: registry-cn-hangzhou.ack.aliyuncs.com/acs/terway:v1.7.4
+        command:
+        - sh
+        - "-ce"
+        - "if grep -q IPVlan /etc/eni/10-terway.conf ; then cilium preflight register-crd ;fi;"
+        volumeMounts:
+        - name: configvolume
+          mountPath: /etc/eni
+      restartPolicy: OnFailure
+      serviceAccountName: terway
+      volumes:
+      - name: configvolume
+        configMap:
+          name: eni-config
+          items:
+          - key: eni_conf
+            path: eni.json
+          - key: 10-terway.conf
+            path: 10-terway.conf
+
+---
+
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: terway-eniip
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app: terway-eniip
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 3%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: terway-eniip
+    spec:
+      hostPID: true
+      priorityClassName: system-node-critical
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: type
+                operator: NotIn
+                values:
+                - virtual-kubelet
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+                - arm64
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+      tolerations:
+      - operator: "Exists"
+      terminationGracePeriodSeconds: 0
+      serviceAccountName: terway
+      hostNetwork: true
+      initContainers:
+      - name: terway-init
+        image: registry-cn-hangzhou.ack.aliyuncs.com/acs/terway:v1.7.4
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          privileged: true
+        command:
+        - /bin/init.sh
+        volumeMounts:
+        - name: config
+          mountPath: /etc/eni
+        - mountPath: /var-run-eni
+          name: var-run-eni
+        - name: configvolume
+          mountPath: /tmp/eni
+        - name: cni-bin
+          mountPath: /opt/cni/bin/
+        - name: cni
+          mountPath: /etc/cni/net.d/
+        - mountPath: /lib/modules
+          name: lib-modules
+        - mountPath: /host
+          name: host-root
+        - mountPath: /var/run/
+          name: eni-run
+      containers:
+      - name: terway
+        image: registry-cn-hangzhou.ack.aliyuncs.com/acs/terway:v1.7.4
+        imagePullPolicy: IfNotPresent
+        command: ["/usr/bin/terwayd", "-log-level", "info", "-daemon-mode", "ENIMultiIP"]
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+            - DAC_OVERRIDE
+            drop:
+            - ALL
+
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: POD_NAMESPACE
+          valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+
+        volumeMounts:
+        - name: config
+          mountPath: /etc/eni
+          readOnly: true
+        - mountPath: /var/run/
+          name: eni-run
+        - mountPath: /lib/modules
+          name: lib-modules
+        - mountPath: /var/lib/cni/networks
+          name: cni-networks
+        - mountPath: /var/lib/cni/terway
+          name: cni-terway
+        - mountPath: /var/lib/kubelet/device-plugins
+          name: device-plugin-path
+        - name: addon-token
+          mountPath: "/var/addon"
+          readOnly: true
+        - name: alibaba-addon-secret
+          mountPath: "/var/alibaba-addon-secret"
+          readOnly: true
+      - name: policy
+        image: registry-cn-hangzhou.ack.aliyuncs.com/acs/terway:v1.7.4
+        imagePullPolicy: IfNotPresent
+        command: ["/bin/policyinit.sh"]
+        env:
+        - name: NODENAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: DISABLE_POLICY
+          valueFrom:
+            configMapKeyRef:
+              name: eni-config
+              key: disable_network_policy
+              optional: true
+        - name: FELIX_TYPHAK8SSERVICENAME
+          valueFrom:
+            configMapKeyRef:
+              name: eni-config
+              key: felix_relay_service
+              optional: true
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: CILIUM_K8S_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: CILIUM_CNI_CHAINING_MODE
+          value: terway-chainer
+        - name: IN_CLUSTER_LOADBALANCE
+          valueFrom:
+            configMapKeyRef:
+              name: eni-config
+              key: in_cluster_loadbalance
+              optional: true
+        securityContext:
+          privileged: false
+          capabilities:
+            add:
+            - NET_ADMIN
+            - DAC_OVERRIDE
+            - SYS_ADMIN
+            - NET_RAW
+            - SYS_MODULE
+
+            - CHOWN
+            - KILL
+            - IPC_LOCK
+            - SYS_RESOURCE
+            - FOWNER
+            - SETGID
+            - SETUID
+
+            drop:
+            - ALL
+
+        livenessProbe:
+          httpGet: null
+          tcpSocket:
+            port: 9099
+            host: 127.0.0.1
+          periodSeconds: 10
+          initialDelaySeconds: 10
+          failureThreshold: 6
+        readinessProbe:
+          httpGet: null
+          tcpSocket:
+            port: 9099
+            host: 127.0.0.1
+          periodSeconds: 10
+        volumeMounts:
+        - mountPath: /var-run-eni
+          name: var-run-eni
+          readOnly: true
+        - mountPath: /lib/modules
+          name: lib-modules
+        - mountPath: /etc/cni/net.d
+          name: cni
+          readOnly: true
+        # volumes use by cilium
+        - mountPath: /sys/fs
+          name: sys-fs
+        - mountPath: /var/run/cilium
+          name: cilium-run
+          # Needed to be able to load kernel modules
+        - mountPath: /run/xtables.lock
+          name: xtables-lock
+      volumes:
+      - name: config
+        emptyDir: {}
+      - name: var-run-eni
+        emptyDir: { }
+      - name: configvolume
+        configMap:
+          name: eni-config
+          items: null
+      - name: cni-bin
+        hostPath:
+          path: /opt/cni/bin
+          type: "Directory"
+      - name: cni
+        hostPath:
+          path: /etc/cni/net.d
+      - name: eni-run
+        hostPath:
+          path: /var/run/
+          type: "Directory"
+      - name: lib-modules
+        hostPath:
+          path: /lib/modules
+      - name: cni-networks
+        hostPath:
+          path: /var/lib/cni/networks
+      - name: cni-terway
+        hostPath:
+          path: /var/lib/cni/terway
+      - name: device-plugin-path
+        hostPath:
+          path: /var/lib/kubelet/device-plugins
+          type: "Directory"
+      - name: host-root
+        hostPath:
+          path: /
+          type: "Directory"
+      - name: addon-token
+        secret:
+          secretName: addon.network.token
+          items:
+          - key: addon.token.config
+            path: token-config
+          optional: true
+      - name: alibaba-addon-secret
+        secret:
+          secretName: alibaba-addon-secret
+          optional: true
+      # used by cilium
+      # To keep state between restarts / upgrades
+      - hostPath:
+          path: /var/run/cilium
+          type: DirectoryOrCreate
+        name: cilium-run
+      # To keep state between restarts / upgrades for bpf maps
+      - hostPath:
+          path: /sys/fs/
+          type: DirectoryOrCreate
+        name: sys-fs
+        # To access iptables concurrently with other processes (e.g. kube-proxy)
+      - hostPath:
+          path: /run/xtables.lock
+          type: FileOrCreate
+        name: xtables-lock
+
+---
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: felixconfigurations.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            x-kubernetes-preserve-unknown-fields: true
+          apiVersion:
+            type: string
+  names:
+    kind: FelixConfiguration
+    plural: felixconfigurations
+    singular: felixconfiguration
+
+---
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: bgpconfigurations.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            x-kubernetes-preserve-unknown-fields: true
+          apiVersion:
+            type: string
+  names:
+    kind: BGPConfiguration
+    plural: bgpconfigurations
+    singular: bgpconfiguration
+
+---
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: ippools.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            x-kubernetes-preserve-unknown-fields: true
+          apiVersion:
+            type: string
+  names:
+    kind: IPPool
+    plural: ippools
+    singular: ippool
+
+---
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: hostendpoints.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            x-kubernetes-preserve-unknown-fields: true
+          apiVersion:
+            type: string
+  names:
+    kind: HostEndpoint
+    plural: hostendpoints
+    singular: hostendpoint
+
+---
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterinformations.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            x-kubernetes-preserve-unknown-fields: true
+          apiVersion:
+            type: string
+  names:
+    kind: ClusterInformation
+    plural: clusterinformations
+    singular: clusterinformation
+
+---
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: globalnetworkpolicies.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            x-kubernetes-preserve-unknown-fields: true
+          apiVersion:
+            type: string
+  names:
+    kind: GlobalNetworkPolicy
+    plural: globalnetworkpolicies
+    singular: globalnetworkpolicy
+
+---
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: globalnetworksets.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            x-kubernetes-preserve-unknown-fields: true
+          apiVersion:
+            type: string
+  names:
+    kind: GlobalNetworkSet
+    plural: globalnetworksets
+    singular: globalnetworkset
+
+---
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: networkpolicies.crd.projectcalico.org
+spec:
+  scope: Namespaced
+  group: crd.projectcalico.org
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            x-kubernetes-preserve-unknown-fields: true
+          apiVersion:
+            type: string
+  names:
+    kind: NetworkPolicy
+    plural: networkpolicies
+    singular: networkpolicy
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: terway-controlplane
+  namespace: kube-system
+  labels:
+    k8s-app: terway-controlplane
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: terway-controlplane
+  template:
+    metadata:
+      labels:
+        k8s-app: terway-controlplane
+    spec:
+      hostNetwork: true
+      serviceAccountName: terway
+      priorityClassName: system-node-critical
+      tolerations:
+      - operator: "Exists"
+      containers:
+      - name: terway-controlplane
+        image: registry-cn-hangzhou.ack.aliyuncs.com/acs/terway-controlplane:v1.7.4
+        imagePullPolicy: IfNotPresent
+        command:
+        - /usr/bin/terway-controlplane
+        - "-v"
+        - "2"
+        ports:
+        - name: healthz
+          containerPort: 8080
+          protocol: TCP
+        - name: metrics
+          containerPort: 8081
+          protocol: TCP
+        env:
+        - name: K8S_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: MY_POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          periodSeconds: 10
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 5
+        volumeMounts:
+        - name: config-vol
+          mountPath: /etc/config
+          readOnly: true
+        - name: secret-vol
+          mountPath: /etc/credential
+          readOnly: true
+        - name: addon-token
+          mountPath: /var/addon
+          readOnly: true
+      volumes:
+      - name: secret-vol
+        secret:
+          secretName: terway-controlplane-credential
+      - name: config-vol
+        configMap:
+          name: terway-controlplane
+          items:
+          - key: ctrl-config.yaml
+            path: ctrl-config.yaml
+      - name: addon-token
+        secret:
+          secretName: addon.network.token
+          items:
+          - key: addon.token.config
+            path: token-config
+          optional: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: ciliumpodippools.cilium.io
+spec:
+  group: cilium.io
+  scope: Cluster
+  names:
+    kind: CiliumPodIPPool
+    plural: ciliumpodippools
+    singular: ciliumpodippool
+  versions:
+  - name: v2alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: ciliumloadbalancerippools.cilium.io
+spec:
+  group: cilium.io
+  scope: Cluster
+  names:
+    kind: CiliumLoadBalancerIPPool
+    plural: ciliumloadbalancerippools
+    singular: ciliumloadbalancerippool
+  versions:
+  - name: v2alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: ciliuml2announcementpolicies.cilium.io
+spec:
+  group: cilium.io
+  scope: Cluster
+  names:
+    kind: CiliumL2AnnouncementPolicy
+    plural: ciliuml2announcementpolicies
+    singular: ciliuml2announcementpolicy
+  versions:
+  - name: v2alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: ciliumcidrgroups.cilium.io
+spec:
+  group: cilium.io
+  scope: Cluster
+  names:
+    kind: CiliumCIDRGroup
+    plural: ciliumcidrgroups
+    singular: ciliumcidrgroup
+  versions:
+  - name: v2alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: terway-controlplane-credential
+  namespace: kube-system
+type: Opaque
+stringData:
+  ctrl-secret.yaml: |
+    credentialPath: "/var/addon/token-config"

--- a/tests/upgrade/templates/v1.9/configmap.yaml.tmpl
+++ b/tests/upgrade/templates/v1.9/configmap.yaml.tmpl
@@ -1,0 +1,80 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: eni-config
+  namespace: kube-system
+data:
+  eni_conf: |
+    {
+      "version": "1",
+      "max_pool_size": 5,
+      "min_pool_size": 0,
+      "credential_path": "/var/addon/token-config",
+      "vswitches": {{.PodVswitchId}},
+      "eni_tags": {"ack.aliyun.com":"{{.ClusterID}}"},
+      "service_cidr": "{{.ServiceCIDR}}",
+      "security_group": "{{.SecurityGroupId}}",
+      "ip_stack": "{{.IPStack}}",
+      "vswitch_selection_policy": "ordered"
+    }
+  10-terway.conf: |
+    {
+      "cniVersion": "0.4.0",
+      "name": "terway",
+      "capabilities": {"bandwidth": true},
+      "network_policy_provider": "ebpf",
+{{if .Datapath}}
+      "eniip_virtual_type": "datapathv2",
+      "host_stack_cidrs": ["169.254.20.10/32"],
+{{end}}
+      "type": "terway"
+    }
+  disable_network_policy: "{{.DisableNetworkPolicy}}"
+  in_cluster_loadbalance: "true"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: terway-controlplane
+  namespace: kube-system
+data:
+  ctrl-config.yaml: |
+    leaseLockName: "terway-controller-lock"
+    leaseLockNamespace: "kube-system"
+    controllerNamespace: "kube-system"
+    controllerName: "terway-controlplane"
+    healthzBindAddress: "0.0.0.0:8080"
+    clusterDomain: "cluster.local"
+    leaderElection: true
+    webhookPort: 0
+    disableWebhook: true
+    certDir: "/var/run/webhook-cert"
+    regionID: "{{ .RegionID }}"
+    clusterID: "{{ .ClusterID }}"
+    vpcID: "{{ .VPCID }}"
+    ipStack: "{{ .IPStack }}"
+    enableTrunk: false
+    enableTrace: false
+    metricsBindAddress: "0"
+    centralizedIPAM: true
+    controllers:
+    - pod-eni
+    - pod
+    - pod-networking
+    - node
+    - multi-ip-node
+    - multi-ip-pod
+  cilium-config.yaml: |
+    k8s-namespace: kube-system
+    identity-gc-interval: 10m
+    identity-heartbeat-timeout: 20m
+    enable-gops: false
+    ipam: delegated-plugin
+    enable-cilium-endpoint-slice: true
+    set-cilium-node-taints: false
+    set-cilium-is-up-condition: false
+    remove-cilium-node-taints: false
+    k8s-client-qps: 20
+    k8s-client-burst: 30
+    operator-api-serve-addr: 127.0.0.1:9234
+    unmanaged-pod-watcher-interval: 0

--- a/tests/upgrade/templates/v1.9/terway-eniip.yaml
+++ b/tests/upgrade/templates/v1.9/terway-eniip.yaml
@@ -1,0 +1,2498 @@
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: terway
+  namespace: kube-system
+
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: terway-pod-reader
+  namespace: kube-system
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - pods
+      - nodes
+      - namespaces
+      - configmaps
+      - secrets
+      - serviceaccounts
+      - endpoints
+      - services
+    verbs:
+      - get
+      - watch
+      - list
+  - apiGroups:
+      - ''
+    resources:
+      - pods
+      - nodes
+      - nodes/status
+    verbs:
+      - patch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - watch
+      - update
+      - create
+  - apiGroups:
+      - ''
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - networkpolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ''
+    resources:
+      - pods/status
+    verbs:
+      - update
+  - apiGroups:
+      - crd.projectcalico.org
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+      - update
+  - apiGroups:
+      - cilium.io
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  - apiGroups:
+      - network.alibabacloud.com
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  - apiGroups:
+      - alibabacloud.com
+    resources:
+      - '*'
+    verbs:
+      - '*'
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: terway-binding
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: terway-pod-reader
+subjects:
+- kind: ServiceAccount
+  name: terway
+  namespace: kube-system
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: terway-preflight
+  namespace: kube-system
+spec:
+  ttlSecondsAfterFinished: 300
+  backoffLimit: 10
+  template:
+    spec:
+      hostNetwork: true
+      priorityClassName: system-node-critical
+      tolerations:
+      - operator: "Exists"
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: type
+                operator: NotIn
+                values:
+                - virtual-kubelet
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+                - arm64
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+      containers:
+      - name: preflight
+        image: registry-cn-hangzhou.ack.aliyuncs.com/acs/terway:v1.9.18
+        command:
+        - sh
+        - "-ce"
+        - "cilium preflight register-crd"
+        volumeMounts:
+        - name: configvolume
+          mountPath: /etc/eni
+      restartPolicy: OnFailure
+      serviceAccountName: terway
+      volumes:
+      - name: configvolume
+        configMap:
+          name: eni-config
+          items:
+          - key: eni_conf
+            path: eni.json
+          - key: 10-terway.conf
+            path: 10-terway.conf
+---
+
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: terway-eniip
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app: terway-eniip
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 3%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: terway-eniip
+    spec:
+      hostPID: true
+      priorityClassName: system-node-critical
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: type
+                operator: NotIn
+                values:
+                - virtual-kubelet
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+                - arm64
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+      tolerations:
+      - operator: "Exists"
+      terminationGracePeriodSeconds: 0
+      serviceAccountName: terway
+      hostNetwork: true
+      initContainers:
+      - name: terway-init
+        image: registry-cn-hangzhou.ack.aliyuncs.com/acs/terway:v1.9.18
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          privileged: true
+        command:
+        - /bin/init.sh
+        env:
+        - name: DISABLE_POLICY
+          valueFrom:
+            configMapKeyRef:
+              name: eni-config
+              key: disable_network_policy
+              optional: true
+        volumeMounts:
+        - name: config
+          mountPath: /etc/eni
+        - mountPath: /var-run-eni
+          name: var-run-eni
+        - name: configvolume
+          mountPath: /tmp/eni
+        - name: cni-bin
+          mountPath: /opt/cni/bin/
+        - name: cni
+          mountPath: /etc/cni/net.d/
+        - mountPath: /lib/modules
+          name: lib-modules
+        - mountPath: /host
+          name: host-root
+        - mountPath: /var/run/
+          name: eni-run
+      containers:
+      - name: terway
+        image: registry-cn-hangzhou.ack.aliyuncs.com/acs/terway:v1.9.18
+        imagePullPolicy: IfNotPresent
+        command: ["/usr/bin/terwayd", "-log-level", "info", "-daemon-mode", "ENIMultiIP"]
+        securityContext:
+          capabilities:
+            add:
+            - NET_ADMIN
+            - DAC_OVERRIDE
+            drop:
+            - ALL
+        env:
+        - name: TERWAY_GC_RULES
+          value: "true"
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: POD_NAMESPACE
+          valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+        volumeMounts:
+        - name: config
+          mountPath: /etc/eni
+          readOnly: true
+        - mountPath: /var/run/
+          name: eni-run
+        - mountPath: /lib/modules
+          name: lib-modules
+        - mountPath: /var/lib/cni/networks
+          name: cni-networks
+        - mountPath: /var/lib/cni/terway
+          name: cni-terway
+        - mountPath: /etc/cni/net.d
+          name: cni
+          readOnly: true
+        - mountPath: /host-etc-net.d
+          name: host-cni
+        - mountPath: /var/lib/kubelet/device-plugins
+          name: device-plugin-path
+        - name: addon-token
+          mountPath: "/var/addon"
+          readOnly: true
+
+      - name: policy
+        image: registry-cn-hangzhou.ack.aliyuncs.com/acs/terway:v1.9.18
+        imagePullPolicy: IfNotPresent
+        command: ["/bin/policyinit.sh"]
+        env:
+        - name: NODENAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: DISABLE_POLICY
+          valueFrom:
+            configMapKeyRef:
+              name: eni-config
+              key: disable_network_policy
+              optional: true
+        - name: FELIX_TYPHAK8SSERVICENAME
+          valueFrom:
+            configMapKeyRef:
+              name: eni-config
+              key: felix_relay_service
+              optional: true
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        - name: CILIUM_K8S_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: CILIUM_CNI_CHAINING_MODE
+          value: terway-chainer
+        - name: IN_CLUSTER_LOADBALANCE
+          valueFrom:
+            configMapKeyRef:
+              name: eni-config
+              key: in_cluster_loadbalance
+              optional: true
+        securityContext:
+          privileged: false
+          capabilities:
+            add:
+            - NET_ADMIN
+            - DAC_OVERRIDE
+            - SYS_ADMIN
+            - NET_RAW
+            - SYS_MODULE
+            - CHOWN
+            - KILL
+            - IPC_LOCK
+            - SYS_RESOURCE
+            - FOWNER
+            - SETGID
+            - SETUID
+            drop:
+            - ALL
+
+        livenessProbe:
+          httpGet: null
+          tcpSocket:
+            port: 9099
+            host: 127.0.0.1
+          periodSeconds: 10
+          initialDelaySeconds: 10
+          failureThreshold: 6
+        readinessProbe:
+          httpGet: null
+          tcpSocket:
+            port: 9099
+            host: 127.0.0.1
+          periodSeconds: 10
+        volumeMounts:
+        - mountPath: /var-run-eni
+          name: var-run-eni
+          readOnly: true
+        - mountPath: /lib/modules
+          name: lib-modules
+        - mountPath: /etc/cni/net.d
+          name: cni
+          readOnly: true
+        # volumes use by cilium
+        - mountPath: /sys/fs
+          name: sys-fs
+        - mountPath: /var/run/cilium
+          name: cilium-run
+          # Needed to be able to load kernel modules
+        - mountPath: /run/xtables.lock
+          name: xtables-lock
+      volumes:
+      - name: config
+        emptyDir: {}
+      - name: var-run-eni
+        emptyDir: { }
+      - name: configvolume
+        configMap:
+          name: eni-config
+          items: null
+      - name: cni-bin
+        hostPath:
+          path: /opt/cni/bin
+          type: "Directory"
+      - name: host-cni
+        hostPath:
+          path: /etc/cni/net.d
+      - name: cni
+        emptyDir: {}
+      - name: eni-run
+        hostPath:
+          path: /var/run/
+          type: "Directory"
+      - name: lib-modules
+        hostPath:
+          path: /lib/modules
+      - name: cni-networks
+        hostPath:
+          path: /var/lib/cni/networks
+      - name: cni-terway
+        hostPath:
+          path: /var/lib/cni/terway
+      - name: device-plugin-path
+        hostPath:
+          path: /var/lib/kubelet/device-plugins
+          type: "Directory"
+      - name: host-root
+        hostPath:
+          path: /
+          type: "Directory"
+      - name: addon-token
+        secret:
+          secretName: addon.network.token
+          items:
+          - key: addon.token.config
+            path: token-config
+          optional: true
+
+      # used by cilium
+      # To keep state between restarts / upgrades
+      - hostPath:
+          path: /var/run/cilium
+          type: DirectoryOrCreate
+        name: cilium-run
+      # To keep state between restarts / upgrades for bpf maps
+      - hostPath:
+          path: /sys/fs/
+          type: DirectoryOrCreate
+        name: sys-fs
+        # To access iptables concurrently with other processes (e.g. kube-proxy)
+      - hostPath:
+          path: /run/xtables.lock
+          type: FileOrCreate
+        name: xtables-lock
+
+---
+
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: felixconfigurations.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            x-kubernetes-preserve-unknown-fields: true
+          apiVersion:
+            type: string
+  names:
+    kind: FelixConfiguration
+    plural: felixconfigurations
+    singular: felixconfiguration
+
+---
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: bgpconfigurations.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            x-kubernetes-preserve-unknown-fields: true
+          apiVersion:
+            type: string
+  names:
+    kind: BGPConfiguration
+    plural: bgpconfigurations
+    singular: bgpconfiguration
+
+---
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: ippools.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            x-kubernetes-preserve-unknown-fields: true
+          apiVersion:
+            type: string
+  names:
+    kind: IPPool
+    plural: ippools
+    singular: ippool
+
+---
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: hostendpoints.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            x-kubernetes-preserve-unknown-fields: true
+          apiVersion:
+            type: string
+  names:
+    kind: HostEndpoint
+    plural: hostendpoints
+    singular: hostendpoint
+
+---
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterinformations.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            x-kubernetes-preserve-unknown-fields: true
+          apiVersion:
+            type: string
+  names:
+    kind: ClusterInformation
+    plural: clusterinformations
+    singular: clusterinformation
+
+---
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: globalnetworkpolicies.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: GlobalNetworkPolicy
+    listKind: GlobalNetworkPolicyList
+    plural: globalnetworkpolicies
+    singular: globalnetworkpolicy
+  scope: Cluster
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            x-kubernetes-preserve-unknown-fields: true
+            properties:
+              applyOnForward:
+                description: ApplyOnForward indicates to apply the rules in this policy
+                  on forward traffic.
+                type: boolean
+              doNotTrack:
+                description: DoNotTrack indicates whether packets matched by the rules
+                  in this policy should go through the data plane's connection tracking,
+                  such as Linux conntrack.  If True, the rules in this policy are
+                  applied before any data plane connection tracking, and packets allowed
+                  by this policy are marked as not to be tracked.
+                type: boolean
+              egress:
+                description: The ordered set of egress rules.  Each rule contains
+                  a set of packet match criteria and a corresponding action to apply.
+                items:
+                  description: "A Rule encapsulates a set of match criteria and an
+                    action.  Both selector-based security Policy and security Profiles
+                    reference rules - separated out as a list of rules for both ingress
+                    and egress packet matching. \n Each positive match criteria has
+                    a negated version, prefixed with \"Not\". All the match criteria
+                    within a rule must be satisfied for a packet to match. A single
+                    rule can contain the positive and negative version of a match
+                    and both must be satisfied for the rule to match."
+                  properties:
+                    action:
+                      type: string
+                    destination:
+                      description: Destination contains the match criteria that apply
+                        to destination entity.
+                      properties:
+                        namespaceSelector:
+                          description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and another selector are defined on the same rule, then
+                            only workload endpoints that are matched by both selectors
+                            will be selected by the rule. \n For NetworkPolicy, an
+                            empty NamespaceSelector implies that the Selector is limited
+                            to selecting only workload endpoints in the same namespace
+                            as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                            NamespaceSelector implies that the Selector is limited
+                            to selecting only GlobalNetworkSet or HostEndpoint. \n
+                            For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                            the Selector applies to workload endpoints across all
+                            namespaces."
+                          type: string
+                        nets:
+                          description: Nets is an optional field that restricts the
+                            rule to only apply to traffic that originates from (or
+                            terminates at) IP addresses in any of the given subnets.
+                          items:
+                            type: string
+                          type: array
+                        notNets:
+                          description: NotNets is the negated version of the Nets
+                            field.
+                          items:
+                            type: string
+                          type: array
+                        notPorts:
+                          description: NotPorts is the negated version of the Ports
+                            field. Since only some protocols have ports, if any ports
+                            are specified it requires the Protocol match in the Rule
+                            to be set to "TCP" or "UDP".
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        notSelector:
+                          description: NotSelector is the negated version of the Selector
+                            field.  See Selector field for subtleties with negated
+                            selectors.
+                          type: string
+                        ports:
+                          description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        selector:
+                          description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label \"my_label\". \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label \"my_label\".
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                          type: string
+                        serviceAccounts:
+                          description: ServiceAccounts is an optional field that restricts
+                            the rule to only apply to traffic that originates from
+                            (or terminates at) a pod running as a matching service
+                            account.
+                          properties:
+                            names:
+                              description: Names is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account whose name is in the list.
+                              items:
+                                type: string
+                              type: array
+                            selector:
+                              description: Selector is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account that matches the given label selector. If
+                                both Names and Selector are specified then they are
+                                AND'ed.
+                              type: string
+                          type: object
+                        services:
+                          description: "Services is an optional field that contains
+                            options for matching Kubernetes Services. If specified,
+                            only traffic that originates from or terminates at endpoints
+                            within the selected service(s) will be matched, and only
+                            to/from each endpoint's port. \n Services cannot be specified
+                            on the same rule as Selector, NotSelector, NamespaceSelector,
+                            Nets, NotNets or ServiceAccounts. \n Ports and NotPorts
+                            can only be specified with Services on ingress rules."
+                          properties:
+                            name:
+                              description: Name specifies the name of a Kubernetes
+                                Service to match.
+                              type: string
+                            namespace:
+                              description: Namespace specifies the namespace of the
+                                given Service. If left empty, the rule will match
+                                within this policy's namespace.
+                              type: string
+                          type: object
+                      type: object
+                    http:
+                      description: HTTP contains match criteria that apply to HTTP
+                        requests.
+                      properties:
+                        methods:
+                          description: Methods is an optional field that restricts
+                            the rule to apply only to HTTP requests that use one of
+                            the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                            methods are OR'd together.
+                          items:
+                            type: string
+                          type: array
+                        paths:
+                          description: 'Paths is an optional field that restricts
+                            the rule to apply to HTTP requests that use one of the
+                            listed HTTP Paths. Multiple paths are OR''d together.
+                            e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                            ONLY specify either a `exact` or a `prefix` match. The
+                            validator will check for it.'
+                          items:
+                            description: 'HTTPPath specifies an HTTP path to match.
+                              It may be either of the form: exact: <path>: which matches
+                              the path exactly or prefix: <path-prefix>: which matches
+                              the path prefix'
+                            properties:
+                              exact:
+                                type: string
+                              prefix:
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    icmp:
+                      description: ICMP is an optional field that restricts the rule
+                        to apply to a specific type and code of ICMP traffic.  This
+                        should only be specified if the Protocol field is set to "ICMP"
+                        or "ICMPv6".
+                      properties:
+                        code:
+                          description: Match on a specific ICMP code.  If specified,
+                            the Type value must also be specified. This is a technical
+                            limitation imposed by the kernel's iptables firewall,
+                            which Calico uses to enforce the rule.
+                          type: integer
+                        type:
+                          description: Match on a specific ICMP type.  For example
+                            a value of 8 refers to ICMP Echo Request (i.e. pings).
+                          type: integer
+                      type: object
+                    ipVersion:
+                      description: IPVersion is an optional field that restricts the
+                        rule to only match a specific IP version.
+                      type: integer
+                    metadata:
+                      description: Metadata contains additional information for this
+                        rule
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Annotations is a set of key value pairs that
+                            give extra information about the rule
+                          type: object
+                      type: object
+                    notICMP:
+                      description: NotICMP is the negated version of the ICMP field.
+                      properties:
+                        code:
+                          description: Match on a specific ICMP code.  If specified,
+                            the Type value must also be specified. This is a technical
+                            limitation imposed by the kernel's iptables firewall,
+                            which Calico uses to enforce the rule.
+                          type: integer
+                        type:
+                          description: Match on a specific ICMP type.  For example
+                            a value of 8 refers to ICMP Echo Request (i.e. pings).
+                          type: integer
+                      type: object
+                    notProtocol:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: NotProtocol is the negated version of the Protocol
+                        field.
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    protocol:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: "Protocol is an optional field that restricts the
+                        rule to only apply to traffic of a specific IP protocol. Required
+                        if any of the EntityRules contain Ports (because ports only
+                        apply to certain protocols). \n Must be one of these string
+                        values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                        \"UDPLite\" or an integer in the range 1-255."
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    source:
+                      description: Source contains the match criteria that apply to
+                        source entity.
+                      properties:
+                        namespaceSelector:
+                          description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and another selector are defined on the same rule, then
+                            only workload endpoints that are matched by both selectors
+                            will be selected by the rule. \n For NetworkPolicy, an
+                            empty NamespaceSelector implies that the Selector is limited
+                            to selecting only workload endpoints in the same namespace
+                            as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                            NamespaceSelector implies that the Selector is limited
+                            to selecting only GlobalNetworkSet or HostEndpoint. \n
+                            For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                            the Selector applies to workload endpoints across all
+                            namespaces."
+                          type: string
+                        nets:
+                          description: Nets is an optional field that restricts the
+                            rule to only apply to traffic that originates from (or
+                            terminates at) IP addresses in any of the given subnets.
+                          items:
+                            type: string
+                          type: array
+                        notNets:
+                          description: NotNets is the negated version of the Nets
+                            field.
+                          items:
+                            type: string
+                          type: array
+                        notPorts:
+                          description: NotPorts is the negated version of the Ports
+                            field. Since only some protocols have ports, if any ports
+                            are specified it requires the Protocol match in the Rule
+                            to be set to "TCP" or "UDP".
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        notSelector:
+                          description: NotSelector is the negated version of the Selector
+                            field.  See Selector field for subtleties with negated
+                            selectors.
+                          type: string
+                        ports:
+                          description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        selector:
+                          description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label \"my_label\". \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label \"my_label\".
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                          type: string
+                        serviceAccounts:
+                          description: ServiceAccounts is an optional field that restricts
+                            the rule to only apply to traffic that originates from
+                            (or terminates at) a pod running as a matching service
+                            account.
+                          properties:
+                            names:
+                              description: Names is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account whose name is in the list.
+                              items:
+                                type: string
+                              type: array
+                            selector:
+                              description: Selector is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account that matches the given label selector. If
+                                both Names and Selector are specified then they are
+                                AND'ed.
+                              type: string
+                          type: object
+                        services:
+                          description: "Services is an optional field that contains
+                            options for matching Kubernetes Services. If specified,
+                            only traffic that originates from or terminates at endpoints
+                            within the selected service(s) will be matched, and only
+                            to/from each endpoint's port. \n Services cannot be specified
+                            on the same rule as Selector, NotSelector, NamespaceSelector,
+                            Nets, NotNets or ServiceAccounts. \n Ports and NotPorts
+                            can only be specified with Services on ingress rules."
+                          properties:
+                            name:
+                              description: Name specifies the name of a Kubernetes
+                                Service to match.
+                              type: string
+                            namespace:
+                              description: Namespace specifies the namespace of the
+                                given Service. If left empty, the rule will match
+                                within this policy's namespace.
+                              type: string
+                          type: object
+                      type: object
+                  required:
+                  - action
+                  type: object
+                type: array
+              ingress:
+                description: The ordered set of ingress rules.  Each rule contains
+                  a set of packet match criteria and a corresponding action to apply.
+                items:
+                  description: "A Rule encapsulates a set of match criteria and an
+                    action.  Both selector-based security Policy and security Profiles
+                    reference rules - separated out as a list of rules for both ingress
+                    and egress packet matching. \n Each positive match criteria has
+                    a negated version, prefixed with \"Not\". All the match criteria
+                    within a rule must be satisfied for a packet to match. A single
+                    rule can contain the positive and negative version of a match
+                    and both must be satisfied for the rule to match."
+                  properties:
+                    action:
+                      type: string
+                    destination:
+                      description: Destination contains the match criteria that apply
+                        to destination entity.
+                      properties:
+                        namespaceSelector:
+                          description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and another selector are defined on the same rule, then
+                            only workload endpoints that are matched by both selectors
+                            will be selected by the rule. \n For NetworkPolicy, an
+                            empty NamespaceSelector implies that the Selector is limited
+                            to selecting only workload endpoints in the same namespace
+                            as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                            NamespaceSelector implies that the Selector is limited
+                            to selecting only GlobalNetworkSet or HostEndpoint. \n
+                            For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                            the Selector applies to workload endpoints across all
+                            namespaces."
+                          type: string
+                        nets:
+                          description: Nets is an optional field that restricts the
+                            rule to only apply to traffic that originates from (or
+                            terminates at) IP addresses in any of the given subnets.
+                          items:
+                            type: string
+                          type: array
+                        notNets:
+                          description: NotNets is the negated version of the Nets
+                            field.
+                          items:
+                            type: string
+                          type: array
+                        notPorts:
+                          description: NotPorts is the negated version of the Ports
+                            field. Since only some protocols have ports, if any ports
+                            are specified it requires the Protocol match in the Rule
+                            to be set to "TCP" or "UDP".
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        notSelector:
+                          description: NotSelector is the negated version of the Selector
+                            field.  See Selector field for subtleties with negated
+                            selectors.
+                          type: string
+                        ports:
+                          description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        selector:
+                          description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label \"my_label\". \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label \"my_label\".
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                          type: string
+                        serviceAccounts:
+                          description: ServiceAccounts is an optional field that restricts
+                            the rule to only apply to traffic that originates from
+                            (or terminates at) a pod running as a matching service
+                            account.
+                          properties:
+                            names:
+                              description: Names is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account whose name is in the list.
+                              items:
+                                type: string
+                              type: array
+                            selector:
+                              description: Selector is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account that matches the given label selector. If
+                                both Names and Selector are specified then they are
+                                AND'ed.
+                              type: string
+                          type: object
+                        services:
+                          description: "Services is an optional field that contains
+                            options for matching Kubernetes Services. If specified,
+                            only traffic that originates from or terminates at endpoints
+                            within the selected service(s) will be matched, and only
+                            to/from each endpoint's port. \n Services cannot be specified
+                            on the same rule as Selector, NotSelector, NamespaceSelector,
+                            Nets, NotNets or ServiceAccounts. \n Ports and NotPorts
+                            can only be specified with Services on ingress rules."
+                          properties:
+                            name:
+                              description: Name specifies the name of a Kubernetes
+                                Service to match.
+                              type: string
+                            namespace:
+                              description: Namespace specifies the namespace of the
+                                given Service. If left empty, the rule will match
+                                within this policy's namespace.
+                              type: string
+                          type: object
+                      type: object
+                    http:
+                      description: HTTP contains match criteria that apply to HTTP
+                        requests.
+                      properties:
+                        methods:
+                          description: Methods is an optional field that restricts
+                            the rule to apply only to HTTP requests that use one of
+                            the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                            methods are OR'd together.
+                          items:
+                            type: string
+                          type: array
+                        paths:
+                          description: 'Paths is an optional field that restricts
+                            the rule to apply to HTTP requests that use one of the
+                            listed HTTP Paths. Multiple paths are OR''d together.
+                            e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                            ONLY specify either a `exact` or a `prefix` match. The
+                            validator will check for it.'
+                          items:
+                            description: 'HTTPPath specifies an HTTP path to match.
+                              It may be either of the form: exact: <path>: which matches
+                              the path exactly or prefix: <path-prefix>: which matches
+                              the path prefix'
+                            properties:
+                              exact:
+                                type: string
+                              prefix:
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    icmp:
+                      description: ICMP is an optional field that restricts the rule
+                        to apply to a specific type and code of ICMP traffic.  This
+                        should only be specified if the Protocol field is set to "ICMP"
+                        or "ICMPv6".
+                      properties:
+                        code:
+                          description: Match on a specific ICMP code.  If specified,
+                            the Type value must also be specified. This is a technical
+                            limitation imposed by the kernel's iptables firewall,
+                            which Calico uses to enforce the rule.
+                          type: integer
+                        type:
+                          description: Match on a specific ICMP type.  For example
+                            a value of 8 refers to ICMP Echo Request (i.e. pings).
+                          type: integer
+                      type: object
+                    ipVersion:
+                      description: IPVersion is an optional field that restricts the
+                        rule to only match a specific IP version.
+                      type: integer
+                    metadata:
+                      description: Metadata contains additional information for this
+                        rule
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Annotations is a set of key value pairs that
+                            give extra information about the rule
+                          type: object
+                      type: object
+                    notICMP:
+                      description: NotICMP is the negated version of the ICMP field.
+                      properties:
+                        code:
+                          description: Match on a specific ICMP code.  If specified,
+                            the Type value must also be specified. This is a technical
+                            limitation imposed by the kernel's iptables firewall,
+                            which Calico uses to enforce the rule.
+                          type: integer
+                        type:
+                          description: Match on a specific ICMP type.  For example
+                            a value of 8 refers to ICMP Echo Request (i.e. pings).
+                          type: integer
+                      type: object
+                    notProtocol:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: NotProtocol is the negated version of the Protocol
+                        field.
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    protocol:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: "Protocol is an optional field that restricts the
+                        rule to only apply to traffic of a specific IP protocol. Required
+                        if any of the EntityRules contain Ports (because ports only
+                        apply to certain protocols). \n Must be one of these string
+                        values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                        \"UDPLite\" or an integer in the range 1-255."
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    source:
+                      description: Source contains the match criteria that apply to
+                        source entity.
+                      properties:
+                        namespaceSelector:
+                          description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and another selector are defined on the same rule, then
+                            only workload endpoints that are matched by both selectors
+                            will be selected by the rule. \n For NetworkPolicy, an
+                            empty NamespaceSelector implies that the Selector is limited
+                            to selecting only workload endpoints in the same namespace
+                            as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                            NamespaceSelector implies that the Selector is limited
+                            to selecting only GlobalNetworkSet or HostEndpoint. \n
+                            For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                            the Selector applies to workload endpoints across all
+                            namespaces."
+                          type: string
+                        nets:
+                          description: Nets is an optional field that restricts the
+                            rule to only apply to traffic that originates from (or
+                            terminates at) IP addresses in any of the given subnets.
+                          items:
+                            type: string
+                          type: array
+                        notNets:
+                          description: NotNets is the negated version of the Nets
+                            field.
+                          items:
+                            type: string
+                          type: array
+                        notPorts:
+                          description: NotPorts is the negated version of the Ports
+                            field. Since only some protocols have ports, if any ports
+                            are specified it requires the Protocol match in the Rule
+                            to be set to "TCP" or "UDP".
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        notSelector:
+                          description: NotSelector is the negated version of the Selector
+                            field.  See Selector field for subtleties with negated
+                            selectors.
+                          type: string
+                        ports:
+                          description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        selector:
+                          description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label \"my_label\". \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label \"my_label\".
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                          type: string
+                        serviceAccounts:
+                          description: ServiceAccounts is an optional field that restricts
+                            the rule to only apply to traffic that originates from
+                            (or terminates at) a pod running as a matching service
+                            account.
+                          properties:
+                            names:
+                              description: Names is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account whose name is in the list.
+                              items:
+                                type: string
+                              type: array
+                            selector:
+                              description: Selector is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account that matches the given label selector. If
+                                both Names and Selector are specified then they are
+                                AND'ed.
+                              type: string
+                          type: object
+                        services:
+                          description: "Services is an optional field that contains
+                            options for matching Kubernetes Services. If specified,
+                            only traffic that originates from or terminates at endpoints
+                            within the selected service(s) will be matched, and only
+                            to/from each endpoint's port. \n Services cannot be specified
+                            on the same rule as Selector, NotSelector, NamespaceSelector,
+                            Nets, NotNets or ServiceAccounts. \n Ports and NotPorts
+                            can only be specified with Services on ingress rules."
+                          properties:
+                            name:
+                              description: Name specifies the name of a Kubernetes
+                                Service to match.
+                              type: string
+                            namespace:
+                              description: Namespace specifies the namespace of the
+                                given Service. If left empty, the rule will match
+                                within this policy's namespace.
+                              type: string
+                          type: object
+                      type: object
+                  required:
+                  - action
+                  type: object
+                type: array
+              namespaceSelector:
+                description: NamespaceSelector is an optional field for an expression
+                  used to select a pod based on namespaces.
+                type: string
+              order:
+                description: Order is an optional field that specifies the order in
+                  which the policy is applied. Policies with higher "order" are applied
+                  after those with lower order.  If the order is omitted, it may be
+                  considered to be "infinite" - i.e. the policy will be applied last.  Policies
+                  with identical order will be applied in alphanumerical order based
+                  on the Policy "Name".
+                type: number
+              preDNAT:
+                description: PreDNAT indicates to apply the rules in this policy before
+                  any DNAT.
+                type: boolean
+              selector:
+                description: "The selector is an expression used to pick pick out
+                  the endpoints that the policy should be applied to. \n Selector
+                  expressions follow this syntax: \n \tlabel == \"string_literal\"
+                  \ ->  comparison, e.g. my_label == \"foo bar\" \tlabel != \"string_literal\"
+                  \  ->  not equal; also matches if label is not present \tlabel in
+                  { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is
+                  one of \"a\", \"b\", \"c\" \tlabel not in { \"a\", \"b\", \"c\",
+                  ... }  ->  true if the value of label X is not one of \"a\", \"b\",
+                  \"c\" \thas(label_name)  -> True if that label is present \t! expr
+                  -> negation of expr \texpr && expr  -> Short-circuit and \texpr
+                  || expr  -> Short-circuit or \t( expr ) -> parens for grouping \tall()
+                  or the empty selector -> matches all endpoints. \n Label names are
+                  allowed to contain alphanumerics, -, _ and /. String literals are
+                  more permissive but they do not support escape characters. \n Examples
+                  (with made-up labels): \n \ttype == \"webserver\" && deployment
+                  == \"prod\" \ttype in {\"frontend\", \"backend\"} \tdeployment !=
+                  \"dev\" \t! has(label_name)"
+                type: string
+              serviceAccountSelector:
+                description: ServiceAccountSelector is an optional field for an expression
+                  used to select a pod based on service accounts.
+                type: string
+              types:
+                description: "Types indicates whether this policy applies to ingress,
+                  or to egress, or to both.  When not explicitly specified (and so
+                  the value on creation is empty or nil), Calico defaults Types according
+                  to what Ingress and Egress rules are present in the policy.  The
+                  default is: \n - [ PolicyTypeIngress ], if there are no Egress rules
+                  (including the case where there are   also no Ingress rules) \n
+                  - [ PolicyTypeEgress ], if there are Egress rules but no Ingress
+                  rules \n - [ PolicyTypeIngress, PolicyTypeEgress ], if there are
+                  both Ingress and Egress rules. \n When the policy is read back again,
+                  Types will always be one of these values, never empty or nil."
+                items:
+                  description: PolicyType enumerates the possible values of the PolicySpec
+                    Types field.
+                  type: string
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+---
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: globalnetworksets.crd.projectcalico.org
+spec:
+  scope: Cluster
+  group: crd.projectcalico.org
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            x-kubernetes-preserve-unknown-fields: true
+          apiVersion:
+            type: string
+  names:
+    kind: GlobalNetworkSet
+    plural: globalnetworksets
+    singular: globalnetworkset
+
+---
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: networkpolicies.crd.projectcalico.org
+spec:
+  group: crd.projectcalico.org
+  names:
+    kind: NetworkPolicy
+    listKind: NetworkPolicyList
+    plural: networkpolicies
+    singular: networkpolicy
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            x-kubernetes-preserve-unknown-fields: true
+            properties:
+              egress:
+                description: The ordered set of egress rules.  Each rule contains
+                  a set of packet match criteria and a corresponding action to apply.
+                items:
+                  description: "A Rule encapsulates a set of match criteria and an
+                    action.  Both selector-based security Policy and security Profiles
+                    reference rules - separated out as a list of rules for both ingress
+                    and egress packet matching. \n Each positive match criteria has
+                    a negated version, prefixed with \"Not\". All the match criteria
+                    within a rule must be satisfied for a packet to match. A single
+                    rule can contain the positive and negative version of a match
+                    and both must be satisfied for the rule to match."
+                  properties:
+                    action:
+                      type: string
+                    destination:
+                      description: Destination contains the match criteria that apply
+                        to destination entity.
+                      properties:
+                        namespaceSelector:
+                          description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and another selector are defined on the same rule, then
+                            only workload endpoints that are matched by both selectors
+                            will be selected by the rule. \n For NetworkPolicy, an
+                            empty NamespaceSelector implies that the Selector is limited
+                            to selecting only workload endpoints in the same namespace
+                            as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                            NamespaceSelector implies that the Selector is limited
+                            to selecting only GlobalNetworkSet or HostEndpoint. \n
+                            For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                            the Selector applies to workload endpoints across all
+                            namespaces."
+                          type: string
+                        nets:
+                          description: Nets is an optional field that restricts the
+                            rule to only apply to traffic that originates from (or
+                            terminates at) IP addresses in any of the given subnets.
+                          items:
+                            type: string
+                          type: array
+                        notNets:
+                          description: NotNets is the negated version of the Nets
+                            field.
+                          items:
+                            type: string
+                          type: array
+                        notPorts:
+                          description: NotPorts is the negated version of the Ports
+                            field. Since only some protocols have ports, if any ports
+                            are specified it requires the Protocol match in the Rule
+                            to be set to "TCP" or "UDP".
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        notSelector:
+                          description: NotSelector is the negated version of the Selector
+                            field.  See Selector field for subtleties with negated
+                            selectors.
+                          type: string
+                        ports:
+                          description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        selector:
+                          description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label \"my_label\". \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label \"my_label\".
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                          type: string
+                        serviceAccounts:
+                          description: ServiceAccounts is an optional field that restricts
+                            the rule to only apply to traffic that originates from
+                            (or terminates at) a pod running as a matching service
+                            account.
+                          properties:
+                            names:
+                              description: Names is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account whose name is in the list.
+                              items:
+                                type: string
+                              type: array
+                            selector:
+                              description: Selector is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account that matches the given label selector. If
+                                both Names and Selector are specified then they are
+                                AND'ed.
+                              type: string
+                          type: object
+                        services:
+                          description: "Services is an optional field that contains
+                            options for matching Kubernetes Services. If specified,
+                            only traffic that originates from or terminates at endpoints
+                            within the selected service(s) will be matched, and only
+                            to/from each endpoint's port. \n Services cannot be specified
+                            on the same rule as Selector, NotSelector, NamespaceSelector,
+                            Nets, NotNets or ServiceAccounts. \n Ports and NotPorts
+                            can only be specified with Services on ingress rules."
+                          properties:
+                            name:
+                              description: Name specifies the name of a Kubernetes
+                                Service to match.
+                              type: string
+                            namespace:
+                              description: Namespace specifies the namespace of the
+                                given Service. If left empty, the rule will match
+                                within this policy's namespace.
+                              type: string
+                          type: object
+                      type: object
+                    http:
+                      description: HTTP contains match criteria that apply to HTTP
+                        requests.
+                      properties:
+                        methods:
+                          description: Methods is an optional field that restricts
+                            the rule to apply only to HTTP requests that use one of
+                            the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                            methods are OR'd together.
+                          items:
+                            type: string
+                          type: array
+                        paths:
+                          description: 'Paths is an optional field that restricts
+                            the rule to apply to HTTP requests that use one of the
+                            listed HTTP Paths. Multiple paths are OR''d together.
+                            e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                            ONLY specify either a `exact` or a `prefix` match. The
+                            validator will check for it.'
+                          items:
+                            description: 'HTTPPath specifies an HTTP path to match.
+                              It may be either of the form: exact: <path>: which matches
+                              the path exactly or prefix: <path-prefix>: which matches
+                              the path prefix'
+                            properties:
+                              exact:
+                                type: string
+                              prefix:
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    icmp:
+                      description: ICMP is an optional field that restricts the rule
+                        to apply to a specific type and code of ICMP traffic.  This
+                        should only be specified if the Protocol field is set to "ICMP"
+                        or "ICMPv6".
+                      properties:
+                        code:
+                          description: Match on a specific ICMP code.  If specified,
+                            the Type value must also be specified. This is a technical
+                            limitation imposed by the kernel's iptables firewall,
+                            which Calico uses to enforce the rule.
+                          type: integer
+                        type:
+                          description: Match on a specific ICMP type.  For example
+                            a value of 8 refers to ICMP Echo Request (i.e. pings).
+                          type: integer
+                      type: object
+                    ipVersion:
+                      description: IPVersion is an optional field that restricts the
+                        rule to only match a specific IP version.
+                      type: integer
+                    metadata:
+                      description: Metadata contains additional information for this
+                        rule
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Annotations is a set of key value pairs that
+                            give extra information about the rule
+                          type: object
+                      type: object
+                    notICMP:
+                      description: NotICMP is the negated version of the ICMP field.
+                      properties:
+                        code:
+                          description: Match on a specific ICMP code.  If specified,
+                            the Type value must also be specified. This is a technical
+                            limitation imposed by the kernel's iptables firewall,
+                            which Calico uses to enforce the rule.
+                          type: integer
+                        type:
+                          description: Match on a specific ICMP type.  For example
+                            a value of 8 refers to ICMP Echo Request (i.e. pings).
+                          type: integer
+                      type: object
+                    notProtocol:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: NotProtocol is the negated version of the Protocol
+                        field.
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    protocol:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: "Protocol is an optional field that restricts the
+                        rule to only apply to traffic of a specific IP protocol. Required
+                        if any of the EntityRules contain Ports (because ports only
+                        apply to certain protocols). \n Must be one of these string
+                        values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                        \"UDPLite\" or an integer in the range 1-255."
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    source:
+                      description: Source contains the match criteria that apply to
+                        source entity.
+                      properties:
+                        namespaceSelector:
+                          description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and another selector are defined on the same rule, then
+                            only workload endpoints that are matched by both selectors
+                            will be selected by the rule. \n For NetworkPolicy, an
+                            empty NamespaceSelector implies that the Selector is limited
+                            to selecting only workload endpoints in the same namespace
+                            as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                            NamespaceSelector implies that the Selector is limited
+                            to selecting only GlobalNetworkSet or HostEndpoint. \n
+                            For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                            the Selector applies to workload endpoints across all
+                            namespaces."
+                          type: string
+                        nets:
+                          description: Nets is an optional field that restricts the
+                            rule to only apply to traffic that originates from (or
+                            terminates at) IP addresses in any of the given subnets.
+                          items:
+                            type: string
+                          type: array
+                        notNets:
+                          description: NotNets is the negated version of the Nets
+                            field.
+                          items:
+                            type: string
+                          type: array
+                        notPorts:
+                          description: NotPorts is the negated version of the Ports
+                            field. Since only some protocols have ports, if any ports
+                            are specified it requires the Protocol match in the Rule
+                            to be set to "TCP" or "UDP".
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        notSelector:
+                          description: NotSelector is the negated version of the Selector
+                            field.  See Selector field for subtleties with negated
+                            selectors.
+                          type: string
+                        ports:
+                          description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        selector:
+                          description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label \"my_label\". \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label \"my_label\".
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                          type: string
+                        serviceAccounts:
+                          description: ServiceAccounts is an optional field that restricts
+                            the rule to only apply to traffic that originates from
+                            (or terminates at) a pod running as a matching service
+                            account.
+                          properties:
+                            names:
+                              description: Names is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account whose name is in the list.
+                              items:
+                                type: string
+                              type: array
+                            selector:
+                              description: Selector is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account that matches the given label selector. If
+                                both Names and Selector are specified then they are
+                                AND'ed.
+                              type: string
+                          type: object
+                        services:
+                          description: "Services is an optional field that contains
+                            options for matching Kubernetes Services. If specified,
+                            only traffic that originates from or terminates at endpoints
+                            within the selected service(s) will be matched, and only
+                            to/from each endpoint's port. \n Services cannot be specified
+                            on the same rule as Selector, NotSelector, NamespaceSelector,
+                            Nets, NotNets or ServiceAccounts. \n Ports and NotPorts
+                            can only be specified with Services on ingress rules."
+                          properties:
+                            name:
+                              description: Name specifies the name of a Kubernetes
+                                Service to match.
+                              type: string
+                            namespace:
+                              description: Namespace specifies the namespace of the
+                                given Service. If left empty, the rule will match
+                                within this policy's namespace.
+                              type: string
+                          type: object
+                      type: object
+                  required:
+                  - action
+                  type: object
+                type: array
+              ingress:
+                description: The ordered set of ingress rules.  Each rule contains
+                  a set of packet match criteria and a corresponding action to apply.
+                items:
+                  description: "A Rule encapsulates a set of match criteria and an
+                    action.  Both selector-based security Policy and security Profiles
+                    reference rules - separated out as a list of rules for both ingress
+                    and egress packet matching. \n Each positive match criteria has
+                    a negated version, prefixed with \"Not\". All the match criteria
+                    within a rule must be satisfied for a packet to match. A single
+                    rule can contain the positive and negative version of a match
+                    and both must be satisfied for the rule to match."
+                  properties:
+                    action:
+                      type: string
+                    destination:
+                      description: Destination contains the match criteria that apply
+                        to destination entity.
+                      properties:
+                        namespaceSelector:
+                          description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and another selector are defined on the same rule, then
+                            only workload endpoints that are matched by both selectors
+                            will be selected by the rule. \n For NetworkPolicy, an
+                            empty NamespaceSelector implies that the Selector is limited
+                            to selecting only workload endpoints in the same namespace
+                            as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                            NamespaceSelector implies that the Selector is limited
+                            to selecting only GlobalNetworkSet or HostEndpoint. \n
+                            For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                            the Selector applies to workload endpoints across all
+                            namespaces."
+                          type: string
+                        nets:
+                          description: Nets is an optional field that restricts the
+                            rule to only apply to traffic that originates from (or
+                            terminates at) IP addresses in any of the given subnets.
+                          items:
+                            type: string
+                          type: array
+                        notNets:
+                          description: NotNets is the negated version of the Nets
+                            field.
+                          items:
+                            type: string
+                          type: array
+                        notPorts:
+                          description: NotPorts is the negated version of the Ports
+                            field. Since only some protocols have ports, if any ports
+                            are specified it requires the Protocol match in the Rule
+                            to be set to "TCP" or "UDP".
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        notSelector:
+                          description: NotSelector is the negated version of the Selector
+                            field.  See Selector field for subtleties with negated
+                            selectors.
+                          type: string
+                        ports:
+                          description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        selector:
+                          description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label \"my_label\". \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label \"my_label\".
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                          type: string
+                        serviceAccounts:
+                          description: ServiceAccounts is an optional field that restricts
+                            the rule to only apply to traffic that originates from
+                            (or terminates at) a pod running as a matching service
+                            account.
+                          properties:
+                            names:
+                              description: Names is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account whose name is in the list.
+                              items:
+                                type: string
+                              type: array
+                            selector:
+                              description: Selector is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account that matches the given label selector. If
+                                both Names and Selector are specified then they are
+                                AND'ed.
+                              type: string
+                          type: object
+                        services:
+                          description: "Services is an optional field that contains
+                            options for matching Kubernetes Services. If specified,
+                            only traffic that originates from or terminates at endpoints
+                            within the selected service(s) will be matched, and only
+                            to/from each endpoint's port. \n Services cannot be specified
+                            on the same rule as Selector, NotSelector, NamespaceSelector,
+                            Nets, NotNets or ServiceAccounts. \n Ports and NotPorts
+                            can only be specified with Services on ingress rules."
+                          properties:
+                            name:
+                              description: Name specifies the name of a Kubernetes
+                                Service to match.
+                              type: string
+                            namespace:
+                              description: Namespace specifies the namespace of the
+                                given Service. If left empty, the rule will match
+                                within this policy's namespace.
+                              type: string
+                          type: object
+                      type: object
+                    http:
+                      description: HTTP contains match criteria that apply to HTTP
+                        requests.
+                      properties:
+                        methods:
+                          description: Methods is an optional field that restricts
+                            the rule to apply only to HTTP requests that use one of
+                            the listed HTTP Methods (e.g. GET, PUT, etc.) Multiple
+                            methods are OR'd together.
+                          items:
+                            type: string
+                          type: array
+                        paths:
+                          description: 'Paths is an optional field that restricts
+                            the rule to apply to HTTP requests that use one of the
+                            listed HTTP Paths. Multiple paths are OR''d together.
+                            e.g: - exact: /foo - prefix: /bar NOTE: Each entry may
+                            ONLY specify either a `exact` or a `prefix` match. The
+                            validator will check for it.'
+                          items:
+                            description: 'HTTPPath specifies an HTTP path to match.
+                              It may be either of the form: exact: <path>: which matches
+                              the path exactly or prefix: <path-prefix>: which matches
+                              the path prefix'
+                            properties:
+                              exact:
+                                type: string
+                              prefix:
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    icmp:
+                      description: ICMP is an optional field that restricts the rule
+                        to apply to a specific type and code of ICMP traffic.  This
+                        should only be specified if the Protocol field is set to "ICMP"
+                        or "ICMPv6".
+                      properties:
+                        code:
+                          description: Match on a specific ICMP code.  If specified,
+                            the Type value must also be specified. This is a technical
+                            limitation imposed by the kernel's iptables firewall,
+                            which Calico uses to enforce the rule.
+                          type: integer
+                        type:
+                          description: Match on a specific ICMP type.  For example
+                            a value of 8 refers to ICMP Echo Request (i.e. pings).
+                          type: integer
+                      type: object
+                    ipVersion:
+                      description: IPVersion is an optional field that restricts the
+                        rule to only match a specific IP version.
+                      type: integer
+                    metadata:
+                      description: Metadata contains additional information for this
+                        rule
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: Annotations is a set of key value pairs that
+                            give extra information about the rule
+                          type: object
+                      type: object
+                    notICMP:
+                      description: NotICMP is the negated version of the ICMP field.
+                      properties:
+                        code:
+                          description: Match on a specific ICMP code.  If specified,
+                            the Type value must also be specified. This is a technical
+                            limitation imposed by the kernel's iptables firewall,
+                            which Calico uses to enforce the rule.
+                          type: integer
+                        type:
+                          description: Match on a specific ICMP type.  For example
+                            a value of 8 refers to ICMP Echo Request (i.e. pings).
+                          type: integer
+                      type: object
+                    notProtocol:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: NotProtocol is the negated version of the Protocol
+                        field.
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    protocol:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: "Protocol is an optional field that restricts the
+                        rule to only apply to traffic of a specific IP protocol. Required
+                        if any of the EntityRules contain Ports (because ports only
+                        apply to certain protocols). \n Must be one of these string
+                        values: \"TCP\", \"UDP\", \"ICMP\", \"ICMPv6\", \"SCTP\",
+                        \"UDPLite\" or an integer in the range 1-255."
+                      pattern: ^.*
+                      x-kubernetes-int-or-string: true
+                    source:
+                      description: Source contains the match criteria that apply to
+                        source entity.
+                      properties:
+                        namespaceSelector:
+                          description: "NamespaceSelector is an optional field that
+                            contains a selector expression. Only traffic that originates
+                            from (or terminates at) endpoints within the selected
+                            namespaces will be matched. When both NamespaceSelector
+                            and another selector are defined on the same rule, then
+                            only workload endpoints that are matched by both selectors
+                            will be selected by the rule. \n For NetworkPolicy, an
+                            empty NamespaceSelector implies that the Selector is limited
+                            to selecting only workload endpoints in the same namespace
+                            as the NetworkPolicy. \n For NetworkPolicy, `global()`
+                            NamespaceSelector implies that the Selector is limited
+                            to selecting only GlobalNetworkSet or HostEndpoint. \n
+                            For GlobalNetworkPolicy, an empty NamespaceSelector implies
+                            the Selector applies to workload endpoints across all
+                            namespaces."
+                          type: string
+                        nets:
+                          description: Nets is an optional field that restricts the
+                            rule to only apply to traffic that originates from (or
+                            terminates at) IP addresses in any of the given subnets.
+                          items:
+                            type: string
+                          type: array
+                        notNets:
+                          description: NotNets is the negated version of the Nets
+                            field.
+                          items:
+                            type: string
+                          type: array
+                        notPorts:
+                          description: NotPorts is the negated version of the Ports
+                            field. Since only some protocols have ports, if any ports
+                            are specified it requires the Protocol match in the Rule
+                            to be set to "TCP" or "UDP".
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        notSelector:
+                          description: NotSelector is the negated version of the Selector
+                            field.  See Selector field for subtleties with negated
+                            selectors.
+                          type: string
+                        ports:
+                          description: "Ports is an optional field that restricts
+                            the rule to only apply to traffic that has a source (destination)
+                            port that matches one of these ranges/values. This value
+                            is a list of integers or strings that represent ranges
+                            of ports. \n Since only some protocols have ports, if
+                            any ports are specified it requires the Protocol match
+                            in the Rule to be set to \"TCP\" or \"UDP\"."
+                          items:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^.*
+                            x-kubernetes-int-or-string: true
+                          type: array
+                        selector:
+                          description: "Selector is an optional field that contains
+                            a selector expression (see Policy for sample syntax).
+                            \ Only traffic that originates from (terminates at) endpoints
+                            matching the selector will be matched. \n Note that: in
+                            addition to the negated version of the Selector (see NotSelector
+                            below), the selector expression syntax itself supports
+                            negation.  The two types of negation are subtly different.
+                            One negates the set of matched endpoints, the other negates
+                            the whole match: \n \tSelector = \"!has(my_label)\" matches
+                            packets that are from other Calico-controlled \tendpoints
+                            that do not have the label \"my_label\". \n \tNotSelector
+                            = \"has(my_label)\" matches packets that are not from
+                            Calico-controlled \tendpoints that do have the label \"my_label\".
+                            \n The effect is that the latter will accept packets from
+                            non-Calico sources whereas the former is limited to packets
+                            from Calico-controlled endpoints."
+                          type: string
+                        serviceAccounts:
+                          description: ServiceAccounts is an optional field that restricts
+                            the rule to only apply to traffic that originates from
+                            (or terminates at) a pod running as a matching service
+                            account.
+                          properties:
+                            names:
+                              description: Names is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account whose name is in the list.
+                              items:
+                                type: string
+                              type: array
+                            selector:
+                              description: Selector is an optional field that restricts
+                                the rule to only apply to traffic that originates
+                                from (or terminates at) a pod running as a service
+                                account that matches the given label selector. If
+                                both Names and Selector are specified then they are
+                                AND'ed.
+                              type: string
+                          type: object
+                        services:
+                          description: "Services is an optional field that contains
+                            options for matching Kubernetes Services. If specified,
+                            only traffic that originates from or terminates at endpoints
+                            within the selected service(s) will be matched, and only
+                            to/from each endpoint's port. \n Services cannot be specified
+                            on the same rule as Selector, NotSelector, NamespaceSelector,
+                            Nets, NotNets or ServiceAccounts. \n Ports and NotPorts
+                            can only be specified with Services on ingress rules."
+                          properties:
+                            name:
+                              description: Name specifies the name of a Kubernetes
+                                Service to match.
+                              type: string
+                            namespace:
+                              description: Namespace specifies the namespace of the
+                                given Service. If left empty, the rule will match
+                                within this policy's namespace.
+                              type: string
+                          type: object
+                      type: object
+                  required:
+                  - action
+                  type: object
+                type: array
+              order:
+                description: Order is an optional field that specifies the order in
+                  which the policy is applied. Policies with higher "order" are applied
+                  after those with lower order.  If the order is omitted, it may be
+                  considered to be "infinite" - i.e. the policy will be applied last.  Policies
+                  with identical order will be applied in alphanumerical order based
+                  on the Policy "Name".
+                type: number
+              selector:
+                description: "The selector is an expression used to pick pick out
+                  the endpoints that the policy should be applied to. \n Selector
+                  expressions follow this syntax: \n \tlabel == \"string_literal\"
+                  \ ->  comparison, e.g. my_label == \"foo bar\" \tlabel != \"string_literal\"
+                  \  ->  not equal; also matches if label is not present \tlabel in
+                  { \"a\", \"b\", \"c\", ... }  ->  true if the value of label X is
+                  one of \"a\", \"b\", \"c\" \tlabel not in { \"a\", \"b\", \"c\",
+                  ... }  ->  true if the value of label X is not one of \"a\", \"b\",
+                  \"c\" \thas(label_name)  -> True if that label is present \t! expr
+                  -> negation of expr \texpr && expr  -> Short-circuit and \texpr
+                  || expr  -> Short-circuit or \t( expr ) -> parens for grouping \tall()
+                  or the empty selector -> matches all endpoints. \n Label names are
+                  allowed to contain alphanumerics, -, _ and /. String literals are
+                  more permissive but they do not support escape characters. \n Examples
+                  (with made-up labels): \n \ttype == \"webserver\" && deployment
+                  == \"prod\" \ttype in {\"frontend\", \"backend\"} \tdeployment !=
+                  \"dev\" \t! has(label_name)"
+                type: string
+              serviceAccountSelector:
+                description: ServiceAccountSelector is an optional field for an expression
+                  used to select a pod based on service accounts.
+                type: string
+              types:
+                description: "Types indicates whether this policy applies to ingress,
+                  or to egress, or to both.  When not explicitly specified (and so
+                  the value on creation is empty or nil), Calico defaults Types according
+                  to what Ingress and Egress are present in the policy.  The default
+                  is: \n - [ PolicyTypeIngress ], if there are no Egress rules (including
+                  the case where there are   also no Ingress rules) \n - [ PolicyTypeEgress
+                  ], if there are Egress rules but no Ingress rules \n - [ PolicyTypeIngress,
+                  PolicyTypeEgress ], if there are both Ingress and Egress rules.
+                  \n When the policy is read back again, Types will always be one
+                  of these values, never empty or nil."
+                items:
+                  description: PolicyType enumerates the possible values of the PolicySpec
+                    Types field.
+                  type: string
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: terway-controlplane
+  namespace: kube-system
+  labels:
+    k8s-app: terway-controlplane
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: terway-controlplane
+  template:
+    metadata:
+      labels:
+        k8s-app: terway-controlplane
+    spec:
+      hostNetwork: true
+      serviceAccountName: terway
+      priorityClassName: system-node-critical
+      tolerations:
+      - operator: "Exists"
+      containers:
+      - name: terway-controlplane
+        image: registry-cn-hangzhou.ack.aliyuncs.com/acs/terway-controlplane:v1.9.18
+        imagePullPolicy: IfNotPresent
+        command:
+        - /usr/bin/terway-controlplane
+        - "-v"
+        - "2"
+        ports:
+        - name: healthz
+          containerPort: 8080
+          protocol: TCP
+        - name: metrics
+          containerPort: 8081
+          protocol: TCP
+        env:
+        - name: K8S_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: MY_POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          periodSeconds: 10
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 5
+        volumeMounts:
+        - name: config-vol
+          mountPath: /etc/config
+          readOnly: true
+        - name: secret-vol
+          mountPath: /etc/credential
+          readOnly: true
+        - name: addon-token
+          mountPath: /var/addon
+          readOnly: true
+      volumes:
+      - name: secret-vol
+        secret:
+          secretName: terway-controlplane-credential
+      - name: config-vol
+        configMap:
+          name: terway-controlplane
+          items:
+          - key: ctrl-config.yaml
+            path: ctrl-config.yaml
+          - key: cilium-config.yaml
+            path: cilium-config.yaml
+      - name: addon-token
+        secret:
+          secretName: addon.network.token
+          items:
+          - key: addon.token.config
+            path: token-config
+          optional: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: ciliumpodippools.cilium.io
+spec:
+  group: cilium.io
+  scope: Cluster
+  names:
+    kind: CiliumPodIPPool
+    plural: ciliumpodippools
+    singular: ciliumpodippool
+  versions:
+  - name: v2alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: ciliumloadbalancerippools.cilium.io
+spec:
+  group: cilium.io
+  scope: Cluster
+  names:
+    kind: CiliumLoadBalancerIPPool
+    plural: ciliumloadbalancerippools
+    singular: ciliumloadbalancerippool
+  versions:
+  - name: v2alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: ciliuml2announcementpolicies.cilium.io
+spec:
+  group: cilium.io
+  scope: Cluster
+  names:
+    kind: CiliumL2AnnouncementPolicy
+    plural: ciliuml2announcementpolicies
+    singular: ciliuml2announcementpolicy
+  versions:
+  - name: v2alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: ciliumcidrgroups.cilium.io
+spec:
+  group: cilium.io
+  scope: Cluster
+  names:
+    kind: CiliumCIDRGroup
+    plural: ciliumcidrgroups
+    singular: ciliumcidrgroup
+  versions:
+  - name: v2alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: terway-controlplane-credential
+  namespace: kube-system
+type: Opaque
+stringData:
+  ctrl-secret.yaml: |
+    credentialPath: "/var/addon/token-config"

--- a/tests/upgrade_compat_test.go
+++ b/tests/upgrade_compat_test.go
@@ -1,0 +1,396 @@
+//go:build e2e
+
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/e2e-framework/klient"
+)
+
+var (
+	upgradePhase            string
+	upgradeExpectedDatapath string
+)
+
+const upgradeTestNamespace = "terway-upgrade-test"
+
+const upgradeENIConfigSnapshotName = "upgrade-eni-config-snapshot"
+
+var upgradeHairpinNodeTypes = []NodeType{
+	NodeTypeECSSharedENI,
+	NodeTypeECSExclusiveENI,
+}
+
+func init() {
+	flag.StringVar(&upgradePhase, "upgrade-phase", "", "upgrade test phase: pre|post")
+	flag.StringVar(&upgradeExpectedDatapath, "upgrade-expected-datapath", "", "expected eniip_virtual_type: unset, IPVlan, or datapathv2")
+}
+
+// TestUpgrade_PreUpgrade creates long-lived server and client pods that must
+// survive the terway upgrade. Pods are NOT cleaned up — they persist for PostUpgrade.
+//
+// Run with: go test -tags e2e -run TestUpgrade_PreUpgrade -upgrade-phase pre
+func TestUpgrade_PreUpgrade(t *testing.T) {
+	if upgradePhase != "pre" {
+		t.Skip("not pre-upgrade phase")
+	}
+
+	ctx := context.Background()
+	client := testenv.EnvConf().Client()
+	ns := upgradeTestNamespace
+
+	t.Log("=== PreUpgrade: creating long-lived pods ===")
+	snapshotUpgradeENIConfig(ctx, t, client, ns)
+
+	// 1. Create server pod (nginx, listens on port 80)
+	server := NewPod("upgrade-server", ns).
+		WithLabels(map[string]string{"app": "upgrade-server"}).
+		WithContainer("server", nginxImage, nil)
+	if err := client.Resources().Create(ctx, server.Pod); err != nil {
+		t.Fatalf("failed to create server pod: %v", err)
+	}
+
+	// 2. Create ClusterIP service for server
+	svc := NewService("upgrade-server", ns, map[string]string{"app": "upgrade-server"}).
+		ExposePort(80, "http").
+		WithIPFamily("ipv4")
+	if err := client.Resources().Create(ctx, svc.Service); err != nil {
+		t.Fatalf("failed to create service: %v", err)
+	}
+
+	// 3. Create client pod — use preferred anti-affinity (best-effort cross-node, but works on single-node)
+	clientPod := NewPod("upgrade-client", ns).
+		WithLabels(map[string]string{"app": "upgrade-client"}).
+		WithContainer("client", nginxImage, nil)
+	// Soft anti-affinity: try different node, but allow same node if only 1 available
+	if clientPod.Spec.Affinity == nil {
+		clientPod.Spec.Affinity = &corev1.Affinity{}
+	}
+	clientPod.Spec.Affinity.PodAntiAffinity = &corev1.PodAntiAffinity{
+		PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+			{
+				Weight: 100,
+				PodAffinityTerm: corev1.PodAffinityTerm{
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "upgrade-server"},
+					},
+					TopologyKey: "kubernetes.io/hostname",
+				},
+			},
+		},
+	}
+	if err := client.Resources().Create(ctx, clientPod.Pod); err != nil {
+		t.Fatalf("failed to create client pod: %v", err)
+	}
+
+	// 4. Wait for both pods to be Ready
+	if err := waitPodsReady(client, server.Pod, clientPod.Pod); err != nil {
+		t.Fatalf("pods failed to become ready: %v", err)
+	}
+
+	// 5. Verify cross-node connectivity works
+	_, err := Pull(client, ns, "upgrade-client", "client", "upgrade-server", t)
+	if err != nil {
+		t.Errorf("pre-upgrade connectivity test failed: %v", err)
+	} else {
+		t.Log("PreUpgrade: cross-node connectivity verified")
+	}
+
+	nodeInfo, err := DiscoverNodeTypes(ctx, client)
+	if err != nil {
+		t.Fatalf("discover node types for pre-upgrade hairpin tests: %v", err)
+	}
+	for _, nodeType := range upgradeHairpinNodeTypes {
+		nodeType := nodeType
+		t.Run("ExistingHairpin/"+string(nodeType), func(t *testing.T) {
+			requireUpgradeNodeType(t, nodeInfo, nodeType)
+			podName := upgradeHairpinName("existing", nodeType)
+			createUpgradeHairpinWorkload(ctx, t, client, ns, podName, nodeType, true)
+			verifyUpgradeHairpin(ctx, t, client, ns, podName, nodeType)
+		})
+	}
+
+	// DON'T save resources to context — pods must persist for PostUpgrade.
+	// AfterEachFeature only cleans up resources saved via SaveResources.
+	t.Log("=== PreUpgrade complete: pods will persist through upgrade ===")
+}
+
+// TestUpgrade_PostUpgrade verifies existing long-lived pods survived the upgrade
+// and creates new pods to verify basic connectivity works after upgrade.
+//
+// For chain upgrades (e.g. 1.7.4→1.9.18→1.17.6), this test runs after EACH hop.
+// The long-lived pods from PreUpgrade must survive ALL hops.
+//
+// Run with: go test -tags e2e -run TestUpgrade_PostUpgrade -upgrade-phase post
+func TestUpgrade_PostUpgrade(t *testing.T) {
+	if upgradePhase != "post" {
+		t.Skip("not post-upgrade phase")
+	}
+
+	ctx := context.Background()
+	client := testenv.EnvConf().Client()
+	ns := upgradeTestNamespace
+	verifyUpgradeENIConfigUnchanged(ctx, t, client, ns)
+
+	// === Step 1: Verify existing long-lived pods survived the upgrade ===
+	t.Run("VerifyLongLivedPods", func(t *testing.T) {
+		// Check server pod
+		serverPod := &corev1.Pod{}
+		if err := client.Resources().Get(ctx, "upgrade-server", ns, serverPod); err != nil {
+			t.Fatalf("server pod not found (did PreUpgrade run?): %v", err)
+		}
+		if serverPod.Status.Phase != corev1.PodRunning {
+			t.Fatalf("server pod not Running: phase=%s", serverPod.Status.Phase)
+		}
+		for _, cs := range serverPod.Status.ContainerStatuses {
+			if cs.RestartCount > 0 {
+				t.Errorf("server pod restarted %d times during upgrade", cs.RestartCount)
+			}
+		}
+		t.Logf("Server pod OK: node=%s, restartCount=0", serverPod.Spec.NodeName)
+
+		// Check client pod
+		clientPod := &corev1.Pod{}
+		if err := client.Resources().Get(ctx, "upgrade-client", ns, clientPod); err != nil {
+			t.Fatalf("client pod not found (did PreUpgrade run?): %v", err)
+		}
+		if clientPod.Status.Phase != corev1.PodRunning {
+			t.Fatalf("client pod not Running: phase=%s", clientPod.Status.Phase)
+		}
+		for _, cs := range clientPod.Status.ContainerStatuses {
+			if cs.RestartCount > 0 {
+				t.Errorf("client pod restarted %d times during upgrade", cs.RestartCount)
+			}
+		}
+		t.Logf("Client pod OK: node=%s, restartCount=0", clientPod.Spec.NodeName)
+
+		// Verify server and client are on different nodes (cross-node)
+		if serverPod.Spec.NodeName == clientPod.Spec.NodeName {
+			t.Logf("Warning: server and client on same node %s (anti-affinity may not have worked)", serverPod.Spec.NodeName)
+		}
+
+		// Verify connectivity still works from surviving pods
+		_, err := Pull(client, ns, "upgrade-client", "client", "upgrade-server", t)
+		if err != nil {
+			t.Errorf("post-upgrade connectivity from surviving client failed: %v", err)
+		} else {
+			t.Log("Long-lived pods survived upgrade, connectivity still works")
+		}
+	})
+
+	// === Step 2: Verify hairpin before unrelated connectivity checks can block ===
+	// Cover both shared and exclusive ENI nodes. Node type alone does not imply
+	// that a Pod is represented by a Cilium generic-veth endpoint.
+	nodeInfo, err := DiscoverNodeTypes(ctx, client)
+	if err != nil {
+		t.Fatalf("discover node types for post-upgrade hairpin tests: %v", err)
+	}
+	for _, nodeType := range upgradeHairpinNodeTypes {
+		nodeType := nodeType
+		t.Run("ExistingHairpin/"+string(nodeType), func(t *testing.T) {
+			requireUpgradeNodeType(t, nodeInfo, nodeType)
+			verifyUpgradeHairpin(ctx, t, client, ns, upgradeHairpinName("existing", nodeType), nodeType)
+		})
+		t.Run("NewHairpin/"+string(nodeType), func(t *testing.T) {
+			requireUpgradeNodeType(t, nodeInfo, nodeType)
+			podName := upgradeHairpinName("new", nodeType)
+			createUpgradeHairpinWorkload(ctx, t, client, ns, podName, nodeType, false)
+			verifyUpgradeHairpin(ctx, t, client, ns, podName, nodeType)
+		})
+	}
+
+	// === Step 3: Create new pods and verify basic connectivity ===
+	t.Run("NewPodConnectivity", func(t *testing.T) {
+		newServer := NewPod("upgrade-server-new", ns).
+			WithLabels(map[string]string{"app": "upgrade-server-new"}).
+			WithContainer("server", nginxImage, nil)
+		if err := client.Resources().Create(ctx, newServer.Pod); err != nil {
+			t.Fatalf("create new server pod: %v", err)
+		}
+		defer func() { _ = client.Resources().Delete(ctx, newServer.Pod) }()
+
+		newSvc := NewService("upgrade-server-new", ns, map[string]string{"app": "upgrade-server-new"}).
+			ExposePort(80, "http").
+			WithIPFamily("ipv4")
+		if err := client.Resources().Create(ctx, newSvc.Service); err != nil {
+			t.Fatalf("create new service: %v", err)
+		}
+		defer func() { _ = client.Resources().Delete(ctx, newSvc.Service) }()
+
+		newClient := NewPod("upgrade-client-new", ns).
+			WithLabels(map[string]string{"app": "upgrade-client-new"}).
+			WithContainer("client", nginxImage, nil)
+		// Soft anti-affinity for new client too
+		if newClient.Spec.Affinity == nil {
+			newClient.Spec.Affinity = &corev1.Affinity{}
+		}
+		newClient.Spec.Affinity.PodAntiAffinity = &corev1.PodAntiAffinity{
+			PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+				{
+					Weight: 100,
+					PodAffinityTerm: corev1.PodAffinityTerm{
+						LabelSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "upgrade-server-new"},
+						},
+						TopologyKey: "kubernetes.io/hostname",
+					},
+				},
+			},
+		}
+		if err := client.Resources().Create(ctx, newClient.Pod); err != nil {
+			t.Fatalf("create new client pod: %v", err)
+		}
+		defer func() { _ = client.Resources().Delete(ctx, newClient.Pod) }()
+
+		if err := waitPodsReady(client, newServer.Pod, newClient.Pod); err != nil {
+			t.Fatalf("new pods failed to become ready: %v", err)
+		}
+
+		_, err := Pull(client, ns, "upgrade-client-new", "client", "upgrade-server-new", t)
+		if err != nil {
+			t.Errorf("new pod connectivity failed: %v", err)
+		} else {
+			t.Log("New pod connectivity verified after upgrade")
+		}
+	})
+
+	if t.Failed() {
+		isFailed.Store(true)
+	}
+}
+
+func snapshotUpgradeENIConfig(ctx context.Context, t *testing.T, client klient.Client, namespace string) {
+	t.Helper()
+	data := getAndValidateUpgradeENIConfig(ctx, t, client)
+	snapshot := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: upgradeENIConfigSnapshotName, Namespace: namespace},
+		Data:       data,
+	}
+	if err := client.Resources().Create(ctx, snapshot); err != nil {
+		t.Fatalf("create eni-config snapshot: %v", err)
+	}
+}
+
+func verifyUpgradeENIConfigUnchanged(ctx context.Context, t *testing.T, client klient.Client, namespace string) {
+	t.Helper()
+	want := &corev1.ConfigMap{}
+	if err := client.Resources().Get(ctx, upgradeENIConfigSnapshotName, namespace, want); err != nil {
+		t.Fatalf("get pre-upgrade eni-config snapshot: %v", err)
+	}
+	got := getAndValidateUpgradeENIConfig(ctx, t, client)
+	if !reflect.DeepEqual(got, want.Data) {
+		t.Fatalf("eni-config changed during upgrade: before=%q after=%q", want.Data, got)
+	}
+	t.Log("eni-config remained byte-for-byte unchanged during upgrade")
+}
+
+func getAndValidateUpgradeENIConfig(ctx context.Context, t *testing.T, client klient.Client) map[string]string {
+	t.Helper()
+	cm := &corev1.ConfigMap{}
+	if err := client.Resources().Get(ctx, "eni-config", "kube-system", cm); err != nil {
+		t.Fatalf("get kube-system/eni-config: %v", err)
+	}
+
+	eniConf := map[string]any{}
+	if err := json.Unmarshal([]byte(cm.Data["eni_conf"]), &eniConf); err != nil {
+		t.Fatalf("parse eni-config eni_conf: %v", err)
+	}
+	if value, exists := eniConf["ipam_type"]; exists {
+		t.Fatalf("BYO upgrade scenario must not set eni_conf.ipam_type, got %v", value)
+	}
+
+	cniConf := map[string]any{}
+	if err := json.Unmarshal([]byte(cm.Data["10-terway.conf"]), &cniConf); err != nil {
+		t.Fatalf("parse eni-config 10-terway.conf: %v", err)
+	}
+	virtualType, exists := cniConf["eniip_virtual_type"]
+	switch upgradeExpectedDatapath {
+	case "":
+	case "unset":
+		if exists {
+			t.Fatalf("upgrade scenario requires veth mode with eniip_virtual_type unset, got %v", virtualType)
+		}
+	case "IPVlan", "datapathv2":
+		if virtualType != upgradeExpectedDatapath {
+			t.Fatalf("upgrade scenario requires eniip_virtual_type=%s, got %v", upgradeExpectedDatapath, virtualType)
+		}
+	default:
+		t.Fatalf("unsupported -upgrade-expected-datapath value %q", upgradeExpectedDatapath)
+	}
+
+	return map[string]string{
+		"eni_conf":       cm.Data["eni_conf"],
+		"10-terway.conf": cm.Data["10-terway.conf"],
+	}
+}
+
+func upgradeHairpinName(lifecycle string, nodeType NodeType) string {
+	return "upgrade-hp-" + lifecycle + "-" + string(nodeType)
+}
+
+func requireUpgradeNodeType(t *testing.T, nodeInfo *NodeTypeInfo, nodeType NodeType) {
+	t.Helper()
+	if len(nodeInfo.GetNodesByType(nodeType)) == 0 {
+		t.Skipf("no nodes of type %s available", nodeType)
+	}
+}
+
+func createUpgradeHairpinWorkload(ctx context.Context, t *testing.T, client klient.Client, namespace, name string, nodeType NodeType, persist bool) {
+	t.Helper()
+	pod := NewPod(name, namespace).
+		WithLabels(map[string]string{"app": name, "upgrade-node-type": string(nodeType)}).
+		WithContainer("server", nginxImage, nil)
+	pod = applyNodeAffinityAndTolerations(pod, nodeType)
+	if err := client.Resources().Create(ctx, pod.Pod); err != nil {
+		t.Fatalf("create %s hairpin pod: %v", nodeType, err)
+	}
+
+	svc := NewService(name, namespace, map[string]string{"app": name, "upgrade-node-type": string(nodeType)}).
+		ExposePort(80, "http").
+		WithIPFamily("ipv4")
+	if err := client.Resources().Create(ctx, svc.Service); err != nil {
+		_ = client.Resources().Delete(ctx, pod.Pod)
+		t.Fatalf("create %s hairpin service: %v", nodeType, err)
+	}
+	if !persist {
+		t.Cleanup(func() {
+			_ = client.Resources().Delete(context.Background(), svc.Service)
+			_ = client.Resources().Delete(context.Background(), pod.Pod)
+		})
+	}
+	if err := waitPodsReady(client, pod.Pod); err != nil {
+		t.Fatalf("wait for %s hairpin pod: %v", nodeType, err)
+	}
+}
+
+func verifyUpgradeHairpin(ctx context.Context, t *testing.T, client klient.Client, namespace, name string, nodeType NodeType) {
+	t.Helper()
+	pod := &corev1.Pod{}
+	if err := client.Resources().Get(ctx, name, namespace, pod); err != nil {
+		t.Fatalf("get %s hairpin pod %s: %v", nodeType, name, err)
+	}
+	if pod.Status.Phase != corev1.PodRunning {
+		t.Fatalf("%s hairpin pod %s is not Running: %s", nodeType, name, pod.Status.Phase)
+	}
+	svc := &corev1.Service{}
+	if err := client.Resources().Get(ctx, name, namespace, svc); err != nil {
+		t.Fatalf("get %s hairpin service %s: %v", nodeType, name, err)
+	}
+	if svc.Spec.ClusterIP == "" || svc.Spec.ClusterIP == corev1.ClusterIPNone {
+		t.Fatalf("%s hairpin service %s has invalid ClusterIP %q", nodeType, name, svc.Spec.ClusterIP)
+	}
+	t.Logf("Hairpin target: lifecycle=%s nodeType=%s node=%s podIP=%s serviceIP=%s", name, nodeType, pod.Spec.NodeName, pod.Status.PodIP, svc.Spec.ClusterIP)
+	// Use the ClusterIP explicitly. The pod and service intentionally share a
+	// name, so resolving the bare name inside the pod can hit the pod's
+	// /etc/hosts entry and bypass service hairpin processing entirely.
+	if _, err := Pull(client, namespace, name, "server", "http://"+svc.Spec.ClusterIP, t); err != nil {
+		t.Errorf("hairpin connectivity failed for %s pod %s on node %s: %v", nodeType, name, pod.Spec.NodeName, err)
+	}
+}


### PR DESCRIPTION
Add a reusable upgrade compatibility test framework under tests/upgrade/. The framework validates that newer Terway versions can read older ConfigMap formats and that long-lived connections survive the upgrade.

Structure:
  tests/upgrade/
  ├── render-configmap.go         # Go template renderer (8 cluster params)
  ├── run-upgrade-test.sh         # Orchestrator (cluster reuse + reboot + 6 scenarios)
  ├── templates/
  │   ├── v1.7.4/                  # ConfigMap template + static YAML (terway-eniip + controlplane)
  │   ├── v1.9.18/
  │   └── v1.17.6/
  └── (templates include: RBAC, Cilium CRDs, credential secret, webhook disabled)

Test flow per scenario:
  1. Deploy initial version (render CM + apply YAML)
  2. PreUpgrade e2e: create long-lived pods + verify connectivity
  3. Upgrade: apply target version YAML only (ConfigMap unchanged)
  4. PostUpgrade e2e: verify pods survived + new pod connectivity

Test matrix (6 scenarios):
  - Single-hop: 1.9.18→1.17.6 (configs A/B/C)
  - Chain:      1.7.4→1.9.18→1.17.6 (configs A/B/C)

Config modes:
  A: datapath + NP    (eniip_virtual_type set, disable_network_policy=false)
  B: veth + NP         (no eniip_virtual_type, disable_network_policy=false)
  C: veth only         (no eniip_virtual_type, disable_network_policy=true)

Also modifies:
  - tests/main_test.go: add -upgrade-phase flag, conditional setup for upgrade tests
  - tests/upgrade_compat_test.go: PreUpgrade/PostUpgrade test functions
  - Makefile: e2e-upgrade-compat-test target

Validated on ACK BYO cluster: v1.9.18→v1.17.6 config C, all tests PASS.