### PR TITLE
fix(controller): improve ENI phase error messages

### DIFF
--- a/pkg/controller/common/eni.go
+++ b/pkg/controller/common/eni.go
@@ -96,7 +96,7 @@ func Attach(ctx context.Context, c client.Client, option *AttachOption) error {
 	case v1beta1.ENIPhaseBind, v1beta1.ENIPhaseBinding:
 		return nil
 	case v1beta1.ENIPhaseDetaching, v1beta1.ENIPhaseDeleting:
-		return fmt.Errorf("eni cr phase %s ", networkInterface.Status.Phase)
+		return fmt.Errorf("networkinterface %s phase %s can not be attached; inspect with: kubectl describe networkinterface %s", option.NetworkInterfaceID, networkInterface.Status.Phase, option.NetworkInterfaceID)
 	}
 
 	// update to binding
@@ -145,7 +145,13 @@ func WaitStatus(ctx context.Context, c client.Client, option *DescribeOption) (*
 
 		if option.ExpectPhase != nil &&
 			*option.ExpectPhase != networkInterface.Status.Phase {
-			innerErr = fmt.Errorf("eni cr phase %s not match %s", networkInterface.Status.Phase, *option.ExpectPhase)
+			innerErr = fmt.Errorf(
+				"networkinterface %s phase %s did not reach expected phase %s; inspect with: kubectl describe networkinterface %s",
+				option.NetworkInterfaceID,
+				networkInterface.Status.Phase,
+				*option.ExpectPhase,
+				option.NetworkInterfaceID,
+			)
 			return false, nil
 		}
 		return true, nil
@@ -194,7 +200,7 @@ func Detach(ctx context.Context, c client.Client, option *DetachOption) error {
 		return nil
 	case v1beta1.ENIPhaseInitial, v1beta1.ENIPhaseBind:
 	case v1beta1.ENIPhaseBinding, v1beta1.ENIPhaseDeleting:
-		return fmt.Errorf("eni cr phase %s ", networkInterface.Status.Phase)
+		return fmt.Errorf("networkinterface %s phase %s can not be detached; inspect with: kubectl describe networkinterface %s", option.NetworkInterfaceID, networkInterface.Status.Phase, option.NetworkInterfaceID)
 	}
 
 	networkInterface.Status.Phase = v1beta1.ENIPhaseDetaching

--- a/pkg/controller/common/eni_test.go
+++ b/pkg/controller/common/eni_test.go
@@ -111,7 +111,7 @@ var _ = Describe("Common ENI Operations", func() {
 				NodeName:           "node-1",
 			})
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("eni cr phase"))
+			Expect(err.Error()).To(ContainSubstring("networkinterface eni-detaching phase Detaching can not be attached"))
 		})
 
 		It("should return nil if ENI is already in Bind phase", func() {
@@ -203,7 +203,7 @@ var _ = Describe("Common ENI Operations", func() {
 				NetworkInterfaceID: "eni-binding",
 			})
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("eni cr phase"))
+			Expect(err.Error()).To(ContainSubstring("networkinterface eni-binding phase Binding can not be detached"))
 		})
 
 		It("should do nothing if ENI is UnManaged", func() {
@@ -430,7 +430,7 @@ var _ = Describe("Common ENI Operations", func() {
 				},
 			})
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("eni cr phase"))
+			Expect(err.Error()).To(Equal("networkinterface eni-mismatch phase Unbind did not reach expected phase Bind; inspect with: kubectl describe networkinterface eni-mismatch"))
 		})
 
 		It("should default BackOff.Steps to 1 when zero", func() {


### PR DESCRIPTION
Improve all ENI phase mismatch error messages in WaitStatus, Attach, and Detach to include the ENI ID, current phase, action context, and a kubectl describe hint for quick debugging.