### PR TITLE
fix(init): drop the ECS multiqueue udev rule to keep GPU device cgroups intact

### DIFF
--- a/hack/init.sh
+++ b/hack/init.sh
@@ -63,4 +63,4 @@ fi
 set +o errexit
 
 chroot /host systemctl disable eni.service
-chroot /host rm -f /etc/udev/rules.d/75-persistent-net-generator.rules /lib/udev/rules.d/60-net.rules /lib/udev/rules.d/61-eni.rules /lib/udev/write_net_rules
+chroot /host rm -f /etc/udev/rules.d/75-persistent-net-generator.rules /lib/udev/rules.d/60-net.rules /lib/udev/rules.d/61-eni.rules /lib/udev/rules.d/62-ecs-mq.rules /lib/udev/write_net_rules


### PR DESCRIPTION
## What

Add `62-ecs-mq.rules` to the list of net udev rules `hack/init.sh` already clears:

```diff
-chroot /host rm -f .../60-net.rules /lib/udev/rules.d/61-eni.rules /lib/udev/write_net_rules
+chroot /host rm -f .../60-net.rules /lib/udev/rules.d/61-eni.rules /lib/udev/rules.d/62-ecs-mq.rules /lib/udev/write_net_rules
```

## Why

`/usr/lib/udev/rules.d/62-ecs-mq.rules` runs the ECS network optimization script on every `eth*` add event — which on a terway cluster means **on every ENI attach terway performs** (`pkg/eni/ops/executor.go` `AttachNetworkInterfaceV2`, `pkg/aliyun/client/hdeni.go` `AttachHDENI`). The very first thing that script does, before it even looks at a device, is:

```sh
systemctl stop irqbalance
systemctl disable irqbalance
```

`systemctl disable` implies a daemon-reload unless `--no-reload` is passed. The reload makes PID 1 re-apply cgroup properties for every unit, including the transient scopes of *running* containers. systemd only knows the static `DeviceAllow` list handed to it when the scope was created, so it recompiles the device BPF program from that list and drops anything injected afterwards — notably NVIDIA majors 195/234 added by `nvidia-container-cli`. Containers that were happily using the GPU then get:

```
open("/dev/nvidiactl") = -EPERM
```

Downstream that surfaces as `cgpu_procfs` init failures, `modprobe: Bad address`, and installers failing to read `/proc/cgpu_km/version`. The failure looks completely unrelated to networking, which is what makes it expensive to debug.

One detail worth noting: the script only takes the destructive branch **if irqbalance is currently running** (`ps -ef | grep irqbalance`), otherwise it just logs `OK. irqbalance stoped.` and issues no systemctl call at all. So this reproduces specifically on nodes where something enables irqbalance — which several node-provisioning flows do, for NIC NUMA affinity.

## Why the rule has nothing left to protect

- Multiqueue has been a virtio_net default since **v4.10**, commit [`449000102901`](https://github.com/torvalds/linux/commit/4490001029012539937ff02778fe6180613fa949) *"virtio-net: enable multiqueue by default"*: `curr_queue_pairs = min(num_online_cpus(), max_queue_pairs)`. That commit's own rationale was that requiring an in-guest admin tool to turn on multiqueue "brings extra troubles for the management". So the script's `ethtool -L <eth> combined <pre-set max>` is a no-op on every kernel in support (v3.10 and v4.9 still defaulted to a single pair; v4.19 / v5.10 / v6.6 / mainline do not).
- `virtnet_set_affinity()` already assigns per-queue CPU masks and calls `__netif_set_xps_queue()`, on probe and on every CPU hotplug. It goes through `irq_set_affinity_and_hint()`, which *applies* the affinity rather than only recording a hint. When `max_queue_pairs == vCPU` — the common ECS case — `stride == 1` and the kernel's result is identical to the script's.
- The script is in fact a userspace reimplementation of that function: it cites [`2ca653d607ce`](https://github.com/torvalds/linux/commit/2ca653d607ce59f2729173a7ea56dbfa6330ec88) *"virtio_net: Stripe queue affinities across cores"* in a comment for its straggler handling.
- The one genuine delta is NUMA-local placement — the driver walks CPUs with `for_each_online_cpu_wrap()` and never consults the device's `numa_node`, while the script puts the local node's CPUs first. But irqbalance does build a NUMA-aware topology, and the script kills irqbalance in order to get there.
- The script also skips every non-virtio device (`eth*` glob plus a `grep -q virtio` on the driver), so it never touches `reth*` / erdma NICs. On Lingjun nodes irqbalance is the only thing that can place those IRQs, and this rule is what disables it.

No `udevadm` call is added: udevd checks the rules directories' timestamps before processing an event. This deliberately keeps `a430a3c1` *"init: do not reload udev"* intact — no `udevadm trigger`, no replayed device events.

## Testing

- `bash -n hack/init.sh` passes; no Go code is touched, so `make test` has nothing relevant to exercise here.
- Not yet validated on a live node by me. On a node the chain can be confirmed with:

```sh
grep "ECS network setting" /var/log/ecs_network_optimization.log   # when the script ran
journalctl -b _PID=1 | grep -i Reloading                          # matching daemon-reloads
systemctl show cri-containerd-<id>.scope -p DevicePolicy -p DeviceAllow | tr ' ' '\n' | grep -E '19[45]|234'
```

An empty result from the last command on a working GPU container is what makes the rebuild destructive.

Happy to put this behind a config flag or restrict it to GPU nodes if you would rather not change behaviour unconditionally — though given the two points above (no-op on supported kernels, and it disables the only thing that can place RDMA IRQs) I think unconditional is the right default.