### PR TITLE
fix(datapath): stabilize host source selection for exclusive ENI pods

### DIFF
--- a/cmd/terway-cli/policy_test.go
+++ b/cmd/terway-cli/policy_test.go
@@ -552,6 +552,149 @@ func Test_runCalico_EnvironmentVariables(t *testing.T) {
 	assert.Equal(t, "false", envMap["FELIX_USAGEREPORTINGENABLED"])
 }
 
+func TestMasqENIOnlyRules(t *testing.T) {
+	script := "../../policy/uninstall_policy.sh"
+	managedRule := `-A terway-masq -o cali+ -m comment --comment "terway:masq-pod-bypass" -j RETURN`
+	masqueradeRule := `-A terway-masq -j MASQUERADE`
+
+	runModel := func(chainExists bool, initialRules []string, runs int, failDelete, failInsert bool) ([]string, []string, error) {
+		flag := func(value bool) string {
+			if value {
+				return "1"
+			}
+			return "0"
+		}
+		model := `
+script=$1
+runs=$2
+chain_exists=$3
+fail_delete=$4
+fail_insert=$5
+shift 5
+chain=("$@")
+writes=()
+postrouting=1
+managed_rule='-A terway-masq -o cali+ -m comment --comment "terway:masq-pod-bypass" -j RETURN'
+masquerade_rule='-A terway-masq -j MASQUERADE'
+
+has_rule() {
+  local want=$1 rule
+  for rule in "${chain[@]}"; do
+    [ "$rule" = "$want" ] && return 0
+  done
+  return 1
+}
+
+delete_rule() {
+  local want=$1 rule removed=0
+  local next=()
+  for rule in "${chain[@]}"; do
+    if [ "$removed" -eq 0 ] && [ "$rule" = "$want" ]; then
+      removed=1
+      continue
+    fi
+    next+=("$rule")
+  done
+  chain=("${next[@]}")
+}
+
+iptables() {
+  case "$*" in
+    "-t nat -L terway-masq")
+      [ "$chain_exists" -eq 1 ] || return 1
+      printf '%s\n' "${chain[@]}"
+      ;;
+    "-t nat -N terway-masq")
+      chain_exists=1
+      writes+=("$*")
+      ;;
+    "-t nat -L POSTROUTING")
+      [ "$postrouting" -eq 1 ] && printf '%s\n' terway-masq
+      ;;
+    "-t nat -A POSTROUTING "*)
+      postrouting=1
+      writes+=("$*")
+      ;;
+    "-t nat -S terway-masq")
+      [ "$chain_exists" -eq 1 ] || return 1
+      printf '%s\n' '-N terway-masq'
+      printf '%s\n' "${chain[@]}"
+      ;;
+    "-t nat -C terway-masq -o cali+ -m comment --comment terway:masq-pod-bypass -j RETURN") has_rule "$managed_rule" ;;
+    "-t nat -D terway-masq -o cali+ -m comment --comment terway:masq-pod-bypass -j RETURN")
+      [ "$fail_delete" -eq 0 ] || return 4
+      delete_rule "$managed_rule"
+      writes+=("$*")
+      ;;
+    "-t nat -I terway-masq 1 -o cali+ -m comment --comment terway:masq-pod-bypass -j RETURN")
+      [ "$fail_insert" -eq 0 ] || return 4
+      chain=("$managed_rule" "${chain[@]}")
+      writes+=("$*")
+      ;;
+    "-t nat -A terway-masq -j MASQUERADE")
+      chain+=("$masquerade_rule")
+      writes+=("$*")
+      ;;
+    *) return 2 ;;
+  esac
+}
+
+source "$script"
+status=0
+for ((i = 0; i < runs; i++)); do
+  masq_eni_only iptables || { status=$?; break; }
+done
+for rule in "${chain[@]}"; do printf '__RULE__%s\n' "$rule"; done
+for write in "${writes[@]}"; do printf '__WRITE__%s\n' "$write"; done
+exit "$status"
+`
+		args := []string{"-c", model, "bash", script, fmt.Sprint(runs), flag(chainExists), flag(failDelete), flag(failInsert)}
+		args = append(args, initialRules...)
+		out, err := exec.Command("bash", args...).CombinedOutput()
+		var rules, writes []string
+		for _, line := range strings.Split(string(out), "\n") {
+			switch {
+			case strings.HasPrefix(line, "__RULE__"):
+				rules = append(rules, strings.TrimPrefix(line, "__RULE__"))
+			case strings.HasPrefix(line, "__WRITE__"):
+				writes = append(writes, strings.TrimPrefix(line, "__WRITE__"))
+			}
+		}
+		return rules, writes, err
+	}
+
+	t.Run("fresh install", func(t *testing.T) {
+		rules, _, err := runModel(false, nil, 1, false, false)
+		assert.NoError(t, err)
+		assert.Equal(t, []string{managedRule, masqueradeRule}, rules)
+	})
+
+	t.Run("correct chain is unchanged across runs", func(t *testing.T) {
+		rules, writes, err := runModel(true, []string{managedRule, masqueradeRule}, 3, false, false)
+		assert.NoError(t, err)
+		assert.Equal(t, []string{managedRule, masqueradeRule}, rules)
+		assert.Empty(t, writes)
+	})
+
+	t.Run("misordered and duplicate rules converge", func(t *testing.T) {
+		rules, _, err := runModel(true, []string{masqueradeRule, managedRule, managedRule}, 2, false, false)
+		assert.NoError(t, err)
+		assert.Equal(t, []string{managedRule, masqueradeRule}, rules)
+	})
+
+	t.Run("delete failure is returned", func(t *testing.T) {
+		rules, _, err := runModel(true, []string{masqueradeRule, managedRule}, 1, true, false)
+		assert.Error(t, err)
+		assert.Equal(t, []string{masqueradeRule, managedRule}, rules)
+	})
+
+	t.Run("insert failure is returned", func(t *testing.T) {
+		rules, _, err := runModel(true, []string{masqueradeRule}, 1, false, true)
+		assert.Error(t, err)
+		assert.Equal(t, []string{masqueradeRule}, rules)
+	})
+}
+
 func Test_runCilium(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/daemon/rule_linux.go
+++ b/daemon/rule_linux.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"github.com/samber/lo"
 	"github.com/vishvananda/netlink"
@@ -20,6 +21,10 @@ import (
 func ruleSync(ctx context.Context, res daemon.PodResources) error {
 	if res.PodInfo == nil {
 		return nil
+	}
+
+	if res.PodInfo.PodNetworkType == daemon.PodNetworkTypeVPCENI {
+		return syncExclusiveENIRoutes(ctx, res)
 	}
 
 	if res.PodInfo.PodNetworkType != daemon.PodNetworkTypeENIMultiIP {
@@ -121,6 +126,85 @@ func ruleSync(ctx context.Context, res daemon.PodResources) error {
 
 		for _, rule := range hostVethConf.Rules {
 			_, err = utils.EnsureIPRule(ctx, rule)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func syncExclusiveENIRoutes(ctx context.Context, res daemon.PodResources) error {
+	if res.NetConf == "" {
+		return nil
+	}
+
+	netConf := make([]*rpc.NetConf, 0)
+	err := json.Unmarshal([]byte(res.NetConf), &netConf)
+	if err != nil {
+		return fmt.Errorf("parse network config for pod %s/%s: %w", res.PodInfo.Namespace, res.PodInfo.Name, err)
+	}
+
+	links, err := netlink.LinkList()
+	if err != nil {
+		return err
+	}
+
+	for _, conf := range netConf {
+		if conf.BasicInfo == nil || conf.BasicInfo.PodIP == nil {
+			continue
+		}
+
+		ifName := "eth0"
+		if conf.IfName != "" {
+			ifName = conf.IfName
+		}
+		hostVethName, _ := link.VethNameForPod(res.PodInfo.Name, res.PodInfo.Namespace, ifName, "cali")
+		hostVeth, ok := lo.Find(links, func(item netlink.Link) bool {
+			return hostVethName == item.Attrs().Name
+		})
+		if !ok {
+			continue
+		}
+
+		setup := &types.SetupConfig{
+			HostVETHName:   hostVethName,
+			ContainerIPNet: &terwayTypes.IPNetSet{},
+		}
+		if conf.BasicInfo.PodIP.IPv4 != "" {
+			setup.ContainerIPNet.SetIPNet(conf.BasicInfo.PodIP.IPv4 + "/32")
+		}
+		if conf.BasicInfo.PodIP.IPv6 != "" {
+			setup.ContainerIPNet.SetIPNet(conf.BasicInfo.PodIP.IPv6 + "/128")
+		}
+
+		setup.HostIPSet, err = utils.GetHostIP(
+			setup.ContainerIPNet.IPv4 != nil,
+			setup.ContainerIPNet.IPv6 != nil,
+		)
+		if err != nil {
+			return err
+		}
+
+		var routes []*netlink.Route
+		if setup.ContainerIPNet.IPv4 != nil {
+			routes = append(routes, &netlink.Route{
+				LinkIndex: hostVeth.Attrs().Index,
+				Scope:     netlink.SCOPE_LINK,
+				Dst:       utils.NewIPNetWithMaxMask(setup.ContainerIPNet.IPv4),
+				Src:       setup.HostIPSet.IPv4.IP,
+			})
+		}
+		if setup.ContainerIPNet.IPv6 != nil {
+			routes = append(routes, &netlink.Route{
+				LinkIndex: hostVeth.Attrs().Index,
+				Dst:       utils.NewIPNetWithMaxMask(setup.ContainerIPNet.IPv6),
+				Src:       setup.HostIPSet.IPv6.IP,
+			})
+		}
+		for _, route := range routes {
+			_, err = utils.EnsureRoute(ctx, route)
 			if err != nil {
 				return err
 			}

--- a/daemon/rule_linux_test.go
+++ b/daemon/rule_linux_test.go
@@ -96,6 +96,16 @@ func TestGenerateHostPeerCfgForPolicy(t *testing.T) {
 			IPv4: net.ParseIP("169.254.169.254"),
 			IPv6: net.ParseIP("fd0::1"),
 		},
+		HostIPSet: &terwayTypes.IPNetSet{
+			IPv4: &net.IPNet{
+				IP:   net.ParseIP("10.0.0.1"),
+				Mask: net.CIDRMask(32, 32),
+			},
+			IPv6: &net.IPNet{
+				IP:   net.ParseIP("fd0::10"),
+				Mask: net.CIDRMask(128, 128),
+			},
+		},
 		ENIIndex: 1,
 	}
 	veth := &netlink.GenericLink{
@@ -107,6 +117,77 @@ func TestGenerateHostPeerCfgForPolicy(t *testing.T) {
 	vethConf := datapath.GenerateHostPeerCfgForPolicy(setUp, veth, 1)
 	assert.Equal(t, 2, len(vethConf.Routes))
 	assert.Equal(t, 4, len(vethConf.Rules))
+	assert.Equal(t, setUp.HostIPSet.IPv4.IP, vethConf.Routes[0].Src)
+	assert.Equal(t, setUp.HostIPSet.IPv6.IP, vethConf.Routes[1].Src)
+}
+
+func TestRuleSyncExclusiveENIPreferredSource(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	patches.ApplyFunc(link.VethNameForPod, func(name, namespace, ifName, prefix string) (string, error) {
+		return "cali12345678901", nil
+	})
+	patches.ApplyFunc(netlink.LinkList, func() ([]netlink.Link, error) {
+		return []netlink.Link{&netlink.Veth{LinkAttrs: netlink.LinkAttrs{
+			Index: 10,
+			Name:  "cali12345678901",
+		}}}, nil
+	})
+	patches.ApplyFunc(utils.GetHostIP, func(ipv4, ipv6 bool) (*terwayTypes.IPNetSet, error) {
+		assert.True(t, ipv4)
+		assert.True(t, ipv6)
+		return &terwayTypes.IPNetSet{
+			IPv4: &net.IPNet{IP: net.ParseIP("10.0.0.1"), Mask: net.CIDRMask(32, 32)},
+			IPv6: &net.IPNet{IP: net.ParseIP("fd00::1"), Mask: net.CIDRMask(128, 128)},
+		}, nil
+	})
+
+	var ensuredRoutes []*netlink.Route
+	patches.ApplyFunc(utils.EnsureRoute, func(ctx context.Context, route *netlink.Route) (bool, error) {
+		ensuredRoutes = append(ensuredRoutes, route)
+		return true, nil
+	})
+
+	err := ruleSync(context.Background(), daemon.PodResources{
+		PodInfo: &daemon.PodInfo{
+			Name:           "test-pod",
+			Namespace:      "default",
+			PodNetworkType: daemon.PodNetworkTypeVPCENI,
+		},
+		NetConf: `[{"BasicInfo":{"PodIP":{"IPv4":"10.0.0.2","IPv6":"fd00::2"}}}]`,
+	})
+	require.NoError(t, err)
+	require.Len(t, ensuredRoutes, 2)
+	assert.Equal(t, net.ParseIP("10.0.0.1"), ensuredRoutes[0].Src)
+	assert.Equal(t, "10.0.0.2/32", ensuredRoutes[0].Dst.String())
+	assert.Equal(t, netlink.SCOPE_LINK, ensuredRoutes[0].Scope)
+	assert.Equal(t, net.ParseIP("fd00::1"), ensuredRoutes[1].Src)
+	assert.Equal(t, "fd00::2/128", ensuredRoutes[1].Dst.String())
+	assert.Equal(t, netlink.SCOPE_UNIVERSE, ensuredRoutes[1].Scope)
+}
+
+func TestSyncExclusiveENIRoutesRejectsInvalidNetConf(t *testing.T) {
+	err := syncExclusiveENIRoutes(context.Background(), daemon.PodResources{
+		PodInfo: &daemon.PodInfo{Name: "test-pod", Namespace: "default"},
+		NetConf: `{`,
+	})
+	require.ErrorContains(t, err, "parse network config for pod default/test-pod")
+}
+
+func TestSyncExclusiveENIRoutesSkipsEmptyNetConf(t *testing.T) {
+	err := syncExclusiveENIRoutes(context.Background(), daemon.PodResources{
+		PodInfo: &daemon.PodInfo{Name: "test-pod", Namespace: "default"},
+	})
+	require.NoError(t, err)
+}
+
+func TestSyncExclusiveENIRoutesSkipsIncompleteNetConf(t *testing.T) {
+	err := syncExclusiveENIRoutes(context.Background(), daemon.PodResources{
+		PodInfo: &daemon.PodInfo{Name: "test-pod", Namespace: "default"},
+		NetConf: `[{}, {"BasicInfo":{}}]`,
+	})
+	require.NoError(t, err)
 }
 
 // setupTestNetNS creates a test network namespace for testing
@@ -315,7 +396,7 @@ func TestRuleSync_WrongNetworkType(t *testing.T) {
 		PodInfo: &daemon.PodInfo{
 			Name:           "test-pod",
 			Namespace:      "default",
-			PodNetworkType: daemon.PodNetworkTypeVPCENI, // Wrong type
+			PodNetworkType: "unsupported",
 		},
 	}
 

--- a/plugin/datapath/exclusive_eni_linux.go
+++ b/plugin/datapath/exclusive_eni_linux.go
@@ -278,18 +278,27 @@ func generateHostSlaveCfg(cfg *types.SetupConfig, link netlink.Link) *nic.Conf {
 	var sysctl map[string][]string
 
 	if cfg.ContainerIPNet.IPv4 != nil {
+		var src net.IP
+		if cfg.HostIPSet != nil && cfg.HostIPSet.IPv4 != nil {
+			src = cfg.HostIPSet.IPv4.IP
+		}
 		// add route to container
 		routes = append(routes, &netlink.Route{
 			LinkIndex: link.Attrs().Index,
 			Scope:     netlink.SCOPE_LINK,
 			Dst:       utils.NewIPNetWithMaxMask(cfg.ContainerIPNet.IPv4),
+			Src:       src,
 		})
 	}
 	if cfg.ContainerIPNet.IPv6 != nil {
+		var src net.IP
+		if cfg.HostIPSet != nil && cfg.HostIPSet.IPv6 != nil {
+			src = cfg.HostIPSet.IPv6.IP
+		}
 		routes = append(routes, &netlink.Route{
 			LinkIndex: link.Attrs().Index,
-			Scope:     netlink.SCOPE_LINK,
 			Dst:       utils.NewIPNetWithMaxMask(cfg.ContainerIPNet.IPv6),
+			Src:       src,
 		})
 
 		sysctl = utils.GenerateIPv6Sysctl(cfg.HostVETHName, true, false)

--- a/plugin/datapath/exclusive_eni_linux_test.go
+++ b/plugin/datapath/exclusive_eni_linux_test.go
@@ -19,9 +19,23 @@ import (
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/containernetworking/plugins/pkg/testutils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
 )
+
+func setupExclusiveENITestHostIPs(t *testing.T) {
+	t.Helper()
+
+	hostLink := &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: "host"}}
+	require.NoError(t, netlink.LinkAdd(hostLink))
+	require.NoError(t, netlink.LinkSetUp(hostLink))
+	require.NoError(t, netlink.AddrAdd(hostLink, &netlink.Addr{IPNet: eth0IPNet}))
+	require.NoError(t, netlink.AddrAdd(hostLink, &netlink.Addr{
+		IPNet: eth0IPNetIPv6,
+		Flags: unix.IFA_F_NODAD,
+	}))
+}
 
 func TestDataPathExclusiveENI(t *testing.T) {
 	runtime.LockOSThread()
@@ -50,6 +64,7 @@ func TestDataPathExclusiveENI(t *testing.T) {
 		err = testutils.UnmountNS(hostNS)
 		assert.NoError(t, err)
 	}()
+	setupExclusiveENITestHostIPs(t)
 
 	err = netlink.LinkAdd(&netlink.Dummy{
 		LinkAttrs: netlink.LinkAttrs{Name: "eni"},
@@ -145,7 +160,7 @@ func TestDataPathExclusiveENI(t *testing.T) {
 	assert.Equal(t, cfg.MTU, hostVETHLink.Attrs().MTU)
 	assert.True(t, hostVETHLink.Attrs().Flags&net.FlagUp != 0)
 
-	// no explicit IP assignment - should auto borrow IP
+	// The host veth must remain unnumbered; HostIPSet is used only as route prefsrc.
 	addrs, err := netlink.AddrList(hostVETHLink, netlink.FAMILY_ALL)
 	assert.NoError(t, err)
 	// Only link-local or auto-assigned addresses, no explicit IPv4/IPv6 from cfg.HostIPSet
@@ -172,6 +187,7 @@ func TestDataPathExclusiveENI(t *testing.T) {
 	}, netlink.RT_FILTER_DST|netlink.RT_FILTER_OIF)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(routes))
+	assert.True(t, cfg.HostIPSet.IPv4.IP.Equal(routes[0].Src))
 
 	// add some ip rule make sure we don't delete it
 	dummyRule := netlink.NewRule()
@@ -213,6 +229,7 @@ func TestDataPathExclusiveENI_PreSetUP(t *testing.T) {
 		err = testutils.UnmountNS(hostNS)
 		assert.NoError(t, err)
 	}()
+	setupExclusiveENITestHostIPs(t)
 	err = netlink.LinkAdd(&netlink.Dummy{
 		LinkAttrs: netlink.LinkAttrs{Name: "eni"},
 	})
@@ -306,7 +323,7 @@ func TestDataPathExclusiveENI_PreSetUP(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, cfg.MTU, hostVETHLink.Attrs().MTU)
 	assert.True(t, hostVETHLink.Attrs().Flags&net.FlagUp != 0)
-	// no explicit IP assignment - should auto borrow IP
+	// The host veth must remain unnumbered; HostIPSet is used only as route prefsrc.
 	addrs, err := netlink.AddrList(hostVETHLink, netlink.FAMILY_ALL)
 	assert.NoError(t, err)
 	// Only link-local or auto-assigned addresses, no explicit IPv4/IPv6 from cfg.HostIPSet
@@ -332,6 +349,7 @@ func TestDataPathExclusiveENI_PreSetUP(t *testing.T) {
 	}, netlink.RT_FILTER_DST|netlink.RT_FILTER_OIF)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(routes))
+	assert.True(t, cfg.HostIPSet.IPv4.IP.Equal(routes[0].Src))
 	// add some ip rule make sure we don't delete it
 	dummyRule := netlink.NewRule()
 	dummyRule.Priority = toContainerPriority
@@ -378,6 +396,7 @@ func TestDataPathExclusiveENIMultiNetwork(t *testing.T) {
 		err = testutils.UnmountNS(hostNS)
 		assert.NoError(t, err)
 	}()
+	setupExclusiveENITestHostIPs(t)
 
 	err = netlink.LinkAdd(&netlink.Dummy{
 		LinkAttrs: netlink.LinkAttrs{Name: "eni"},
@@ -526,7 +545,7 @@ func TestDataPathExclusiveENIMultiNetwork(t *testing.T) {
 	assert.Equal(t, cfg.MTU, hostVETHLink.Attrs().MTU)
 	assert.True(t, hostVETHLink.Attrs().Flags&net.FlagUp != 0)
 
-	// no explicit IP assignment - should auto borrow IP
+	// The host veth must remain unnumbered; HostIPSet is used only as route prefsrc.
 	addrs, err := netlink.AddrList(hostVETHLink, netlink.FAMILY_ALL)
 	assert.NoError(t, err)
 	// Only link-local or auto-assigned addresses, no explicit IPv4/IPv6 from cfg.HostIPSet
@@ -553,6 +572,7 @@ func TestDataPathExclusiveENIMultiNetwork(t *testing.T) {
 	}, netlink.RT_FILTER_DST|netlink.RT_FILTER_OIF)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(routes))
+	assert.True(t, cfg.HostIPSet.IPv4.IP.Equal(routes[0].Src))
 
 	// add some ip rule make sure we don't delete it
 	dummyRule := netlink.NewRule()

--- a/plugin/datapath/exclusive_eni_linux_unit_test.go
+++ b/plugin/datapath/exclusive_eni_linux_unit_test.go
@@ -1,0 +1,50 @@
+//go:build linux
+
+package datapath
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vishvananda/netlink"
+
+	"github.com/AliyunContainerService/terway/plugin/driver/types"
+	terwayTypes "github.com/AliyunContainerService/terway/types"
+)
+
+func TestGenerateHostSlaveCfgPreferredSource(t *testing.T) {
+	link := &netlink.Veth{LinkAttrs: netlink.LinkAttrs{Index: 10, Name: "calixxx"}}
+	containerIPv4 := net.ParseIP("10.0.0.2")
+	containerIPv6 := net.ParseIP("fd00::2")
+	hostIPv4 := net.ParseIP("10.0.0.1")
+	hostIPv6 := net.ParseIP("fd00::1")
+
+	cfg := &types.SetupConfig{
+		HostVETHName: "calixxx",
+		ContainerIPNet: &terwayTypes.IPNetSet{
+			IPv4: &net.IPNet{IP: containerIPv4, Mask: net.CIDRMask(32, 32)},
+			IPv6: &net.IPNet{IP: containerIPv6, Mask: net.CIDRMask(128, 128)},
+		},
+		HostIPSet: &terwayTypes.IPNetSet{
+			IPv4: &net.IPNet{IP: hostIPv4, Mask: net.CIDRMask(32, 32)},
+			IPv6: &net.IPNet{IP: hostIPv6, Mask: net.CIDRMask(128, 128)},
+		},
+	}
+
+	conf := generateHostSlaveCfg(cfg, link)
+	require.Len(t, conf.Routes, 2)
+	assert.Equal(t, hostIPv4, conf.Routes[0].Src)
+	assert.Equal(t, hostIPv6, conf.Routes[1].Src)
+	assert.Equal(t, netlink.SCOPE_LINK, conf.Routes[0].Scope)
+	assert.Equal(t, netlink.SCOPE_UNIVERSE, conf.Routes[1].Scope)
+	assert.Equal(t, "10.0.0.2/32", conf.Routes[0].Dst.String())
+	assert.Equal(t, "fd00::2/128", conf.Routes[1].Dst.String())
+
+	cfg.HostIPSet = nil
+	conf = generateHostSlaveCfg(cfg, link)
+	require.Len(t, conf.Routes, 2)
+	assert.Nil(t, conf.Routes[0].Src)
+	assert.Nil(t, conf.Routes[1].Src)
+}

--- a/plugin/datapath/policy_router_linux.go
+++ b/plugin/datapath/policy_router_linux.go
@@ -178,6 +178,10 @@ func GenerateHostPeerCfgForPolicy(cfg *types.SetupConfig, link netlink.Link, tab
 	var sysctl map[string][]string
 
 	if cfg.ContainerIPNet.IPv4 != nil {
+		var src net.IP
+		if cfg.HostIPSet != nil && cfg.HostIPSet.IPv4 != nil {
+			src = cfg.HostIPSet.IPv4.IP
+		}
 		if len(cfg.ExtraRoutes) > 0 {
 			addrs = append(addrs, &netlink.Addr{
 				IPNet: LinkIPNet,
@@ -189,6 +193,7 @@ func GenerateHostPeerCfgForPolicy(cfg *types.SetupConfig, link netlink.Link, tab
 			LinkIndex: link.Attrs().Index,
 			Scope:     netlink.SCOPE_LINK,
 			Dst:       utils.NewIPNetWithMaxMask(cfg.ContainerIPNet.IPv4),
+			Src:       src,
 		})
 
 		v4 := utils.NewIPNetWithMaxMask(cfg.ContainerIPNet.IPv4)
@@ -207,6 +212,10 @@ func GenerateHostPeerCfgForPolicy(cfg *types.SetupConfig, link netlink.Link, tab
 	}
 
 	if cfg.ContainerIPNet.IPv6 != nil {
+		var src net.IP
+		if cfg.HostIPSet != nil && cfg.HostIPSet.IPv6 != nil {
+			src = cfg.HostIPSet.IPv6.IP
+		}
 		if len(cfg.ExtraRoutes) > 0 {
 			addrs = append(addrs, &netlink.Addr{
 				IPNet: LinkIPNetv6,
@@ -216,6 +225,7 @@ func GenerateHostPeerCfgForPolicy(cfg *types.SetupConfig, link netlink.Link, tab
 		routes = append(routes, &netlink.Route{
 			LinkIndex: link.Attrs().Index,
 			Dst:       utils.NewIPNetWithMaxMask(cfg.ContainerIPNet.IPv6),
+			Src:       src,
 		})
 
 		v6 := utils.NewIPNetWithMaxMask(cfg.ContainerIPNet.IPv6)

--- a/plugin/driver/utils/utils_linux.go
+++ b/plugin/driver/utils/utils_linux.go
@@ -144,6 +144,11 @@ func FoundRoutes(expected *netlink.Route) ([]netlink.Route, error) {
 	if find.Gw != nil {
 		routeFilter = routeFilter | netlink.RT_FILTER_GW
 	}
+	// A nil expected source intentionally does not filter routes that already
+	// have a preferred source, preserving compatibility across upgrades.
+	if find.Src != nil {
+		routeFilter = routeFilter | netlink.RT_FILTER_SRC
+	}
 	if find.Table > 0 {
 		routeFilter = routeFilter | netlink.RT_FILTER_TABLE
 	}

--- a/plugin/driver/utils/utils_linux_test.go
+++ b/plugin/driver/utils/utils_linux_test.go
@@ -14,6 +14,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 
 	"github.com/AliyunContainerService/terway/pkg/tc"
 	terwayTypes "github.com/AliyunContainerService/terway/types"
@@ -1474,6 +1475,76 @@ var _ = Describe("Utils", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(changed).To(BeFalse())
 
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should replace a route when preferred source differs", func() {
+			var err error
+
+			err = hostNS.Do(func(netNS ns.NetNS) error {
+				defer GinkgoRecover()
+
+				link, err := netlink.LinkByName(nicName)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(netlink.LinkSetUp(link)).To(Succeed())
+
+				src := net.ParseIP("192.168.30.2")
+				Expect(netlink.AddrAdd(link, &netlink.Addr{IPNet: &net.IPNet{
+					IP: src, Mask: net.CIDRMask(24, 32),
+				}})).To(Succeed())
+
+				dst := &net.IPNet{IP: net.ParseIP("10.0.3.0"), Mask: net.CIDRMask(24, 32)}
+				withoutSource := &netlink.Route{
+					Dst: dst, LinkIndex: link.Attrs().Index, Scope: netlink.SCOPE_LINK,
+				}
+				Expect(netlink.RouteAdd(withoutSource)).To(Succeed())
+
+				withSource := &netlink.Route{
+					Dst: dst, LinkIndex: link.Attrs().Index, Scope: netlink.SCOPE_LINK, Src: src,
+				}
+				changed, err := EnsureRoute(context.Background(), withSource)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(changed).To(BeTrue())
+
+				routes, err := FoundRoutes(withSource)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(routes).To(HaveLen(1))
+				Expect(routes[0].Src.Equal(src)).To(BeTrue())
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should converge an IPv6 route with preferred source", func() {
+			var err error
+
+			err = hostNS.Do(func(netNS ns.NetNS) error {
+				defer GinkgoRecover()
+
+				link, err := netlink.LinkByName(nicName)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(netlink.LinkSetUp(link)).To(Succeed())
+
+				src := net.ParseIP("fd00:30::2")
+				Expect(netlink.AddrAdd(link, &netlink.Addr{
+					IPNet: &net.IPNet{IP: src, Mask: net.CIDRMask(64, 128)},
+					Flags: unix.IFA_F_NODAD,
+				})).To(Succeed())
+
+				route := &netlink.Route{
+					Dst:       &net.IPNet{IP: net.ParseIP("fd00:40::"), Mask: net.CIDRMask(64, 128)},
+					LinkIndex: link.Attrs().Index,
+					Src:       src,
+				}
+				changed, err := EnsureRoute(context.Background(), route)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(changed).To(BeTrue())
+
+				changed, err = EnsureRoute(context.Background(), route)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(changed).To(BeFalse())
 				return nil
 			})
 			Expect(err).NotTo(HaveOccurred())

--- a/policy/uninstall_policy.sh
+++ b/policy/uninstall_policy.sh
@@ -3,16 +3,32 @@
 masq_eni_only() {
   if ! "$1" -t nat -L terway-masq; then
     # Create a new chain in nat table.
-    "$1" -t nat -N terway-masq
+    "$1" -t nat -N terway-masq || return 1
   fi
 
   if ! "$1" -t nat -L POSTROUTING | grep -q terway-masq; then
     # Append that chain to POSTROUTING table.
-    "$1" -t nat -A POSTROUTING -m comment --comment "terway:masq-outgoing" ! -o lo -j terway-masq
+    "$1" -t nat -A POSTROUTING -m comment --comment "terway:masq-outgoing" ! -o lo -j terway-masq || return 1
+  fi
+
+  # The host-side peer for an exclusive ENI Pod is a cali* veth with no IP
+  # address.  Do not let node-to-Pod traffic reach MASQUERADE: its address
+  # selection may otherwise fall back to an unrelated host interface.
+  # Normalize duplicate or misplaced bypass rules. Leave a correct
+  # steady-state chain untouched so there is no transient MASQUERADE window.
+  managed_rule='-A terway-masq -o cali+ -m comment --comment "terway:masq-pod-bypass" -j RETURN'
+  rules=$("$1" -t nat -S terway-masq 2>/dev/null) || return 1
+  first_rule=$(printf '%s\n' "$rules" | sed -n '2p')
+  managed_count=$(printf '%s\n' "$rules" | grep -Fxc -- "$managed_rule")
+  if [ "$first_rule" != "$managed_rule" ] || [ "$managed_count" -ne 1 ]; then
+    while "$1" -t nat -C terway-masq -o 'cali+' -m comment --comment "terway:masq-pod-bypass" -j RETURN >/dev/null 2>&1; do
+      "$1" -t nat -D terway-masq -o 'cali+' -m comment --comment "terway:masq-pod-bypass" -j RETURN || return 1
+    done
+    "$1" -t nat -I terway-masq 1 -o 'cali+' -m comment --comment "terway:masq-pod-bypass" -j RETURN || return 1
   fi
 
   if ! "$1" -t nat -L terway-masq | grep -q MASQUERADE; then
-    "$1" -t nat -A terway-masq -j MASQUERADE
+    "$1" -t nat -A terway-masq -j MASQUERADE || return 1
   fi
 }
 


### PR DESCRIPTION
Fix host-to-Pod source address selection on multi-NIC nodes.

After #939 stopped assigning an address to the `cali*` host veth, host routes no longer had a deterministic source address. In exclusive ENI mode, the catch-all `terway-masq` rule could additionally MASQUERADE node-to-Pod traffic using an unrelated interface address when the output veth was unnumbered.

This change:

- sets the node IP as the preferred source for host-to-Pod routes in exclusive ENI and shared-IP policy-routing datapaths;
- reconciles existing exclusive ENI Pod routes after upgrade;
- makes route lookup source-aware when an expected preferred source is present;
- inserts a tagged `cali+` RETURN rule ahead of `terway-masq` MASQUERADE on exclusive ENI nodes;
- normalizes duplicate or misplaced managed bypass rules while leaving a correct chain untouched;
- propagates iptables mutation failures and keeps empty legacy `NetConf` records compatible;
- leaves IPv6 route scope unspecified so reconciliation converges with the kernel representation.

Mode-specific behavior:

- Exclusive ENI: new and existing host-to-Pod routes use the current node IP as `src`; node-to-Pod traffic exits `terway-masq` before MASQUERADE.
- Shared IP: newly created or reconfigured host routes gain `src`; policy rules are unchanged and existing Pods are not retroactively reconciled.

Upgrade and rollback:

- upgrade reconciliation repairs missing or stale preferred sources and normalizes the managed bypass rule;
- rollback does not actively remove an existing route `src` or the tagged RETURN rule; older code tolerates both;
- processes that explicitly bind a different host source address still require a matching `host_stack_cidrs` return route in the Pod.

Tests cover iptables ordering, duplicate normalization, repeated-run idempotency, mutation failures, IPv4 and IPv6 preferred-source generation, daemon reconciliation, malformed and legacy-empty network configuration, privileged installed-route assertions, and real-kernel IPv6 route convergence.

Validation:

- affected Linux privileged tests;
- real iptables 1.8.8 rule serialization and convergence checks;
- `go vet -tags privileged` for affected packages;
- `git diff --check`.

/kind bug