### PR TITLE
[terway] Move host-local IPAM state to tmpfs

### DIFF
--- a/charts/terway/templates/daemonset.yaml
+++ b/charts/terway/templates/daemonset.yaml
@@ -124,6 +124,8 @@ spec:
               name: var-run-eni
             - mountPath: /etc-cni-net.d
               name: cni-config
+            - mountPath: /var/lib/cni/networks
+              name: cni-networks
       containers:
         - name: terway
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/init.sh
+++ b/init.sh
@@ -9,6 +9,15 @@ cp -f /usr/bin/cilium-cni /opt/cni/bin/
 chmod +x /opt/cni/bin/terway
 chmod +x /opt/cni/bin/cilium-cni
 
+# migrate host-local IPAM data from persistent path to tmpfs
+OLD_IPAM_DIR="/var/lib/cni/networks"
+NEW_IPAM_DIR="/var/run/cni/networks"
+if [ -d "$OLD_IPAM_DIR" ] && [ "$(ls -A "$OLD_IPAM_DIR" 2>/dev/null)" ]; then
+  mkdir -p "$NEW_IPAM_DIR"
+  mv "$OLD_IPAM_DIR"/* "$NEW_IPAM_DIR/" 2>/dev/null || true
+  echo "Migrated host-local IPAM data from $OLD_IPAM_DIR to $NEW_IPAM_DIR"
+fi
+
 # init cni config
 cp /tmp/eni/eni_conf /etc/eni/eni.json
 

--- a/plugin/terway/cni.go
+++ b/plugin/terway/cni.go
@@ -42,7 +42,7 @@ const (
 	"ipam": {
 		"type": "host-local",
 		"subnet": "%s",
-		"dataDir": "/var/lib/cni/",
+		"dataDir": "/var/run/cni/",
 		"routes": [
 			{ "dst": "0.0.0.0/0" }
 		]

--- a/terway.yml
+++ b/terway.yml
@@ -116,7 +116,7 @@ spec:
         imagePullPolicy: IfNotPresent
         securityContext:
           privileged: true
-        command: ['sh', '-c', 'cp /usr/bin/terway /opt/cni/bin/; chmod +x /opt/cni/bin/terway; cp /etc/eni/10-terway.conf /etc/cni/net.d/; modprobe sch_htb || true']
+        command: ['sh', '-c', 'cp /usr/bin/terway /opt/cni/bin/; chmod +x /opt/cni/bin/terway; cp /etc/eni/10-terway.conf /etc/cni/net.d/; modprobe sch_htb || true; if [ -d /var/lib/cni/networks ] && [ "$(ls -A /var/lib/cni/networks 2>/dev/null)" ]; then mkdir -p /var/run/cni/networks; mv /var/lib/cni/networks/* /var/run/cni/networks/ 2>/dev/null || true; fi']
         volumeMounts:
         - name: configvolume
           mountPath: /etc/eni
@@ -126,6 +126,10 @@ spec:
           mountPath: /etc/cni/net.d/
         - mountPath: /lib/modules
           name: lib-modules
+        - mountPath: /var/run/
+          name: eni-run
+        - mountPath: /var/lib/cni/networks
+          name: cni-networks
       containers:
       - name: terway
         image: registry.aliyuncs.com/acs/terway:v1.0.10.333-gfd2b7b8-aliyun

--- a/tests/templates/terway/terway-eni-only.yml
+++ b/tests/templates/terway/terway-eni-only.yml
@@ -117,7 +117,7 @@ spec:
         imagePullPolicy: Always
         securityContext:
           privileged: true
-        command: ['sh', '-c', 'cp /usr/bin/terway /opt/cni/bin/; chmod +x /opt/cni/bin/terway; cp /etc/eni/10-terway.conf /etc/cni/net.d/; modprobe sch_htb || true']
+        command: ['sh', '-c', 'cp /usr/bin/terway /opt/cni/bin/; chmod +x /opt/cni/bin/terway; cp /etc/eni/10-terway.conf /etc/cni/net.d/; modprobe sch_htb || true; if [ -d /var/lib/cni/networks ] && [ "$(ls -A /var/lib/cni/networks 2>/dev/null)" ]; then mkdir -p /var/run/cni/networks; mv /var/lib/cni/networks/* /var/run/cni/networks/ 2>/dev/null || true; fi']
         volumeMounts:
         - name: configvolume
           mountPath: /etc/eni
@@ -127,6 +127,10 @@ spec:
           mountPath: /etc/cni/net.d/
         - mountPath: /lib/modules
           name: lib-modules
+        - mountPath: /var/run/
+          name: eni-run
+        - mountPath: /var/lib/cni/networks
+          name: cni-networks
       containers:
       - name: terway
         image: TERWAY_IMAGE

--- a/tests/templates/terway/terway-multiip.yml
+++ b/tests/templates/terway/terway-multiip.yml
@@ -117,6 +117,7 @@ spec:
                   chmod +x /opt/cni/bin/terway;
                   cp /etc/eni/10-terway.conf /etc/cni/net.d/;
                   modprobe sch_htb || true;
+                  if [ -d /var/lib/cni/networks ] && [ "$(ls -A /var/lib/cni/networks 2>/dev/null)" ]; then mkdir -p /var/run/cni/networks; mv /var/lib/cni/networks/* /var/run/cni/networks/ 2>/dev/null || true; fi;
                   chroot /host sh -c "systemctl disable eni.service; rm -f /etc/udev/rules.d/75-persistent-net-generator.rules /lib/udev/rules.d/60-net.rules /lib/udev/rules.d/61-eni.rules /lib/udev/write_net_rules && udevadm control --reload-rules && udevadm trigger; true"'
         volumeMounts:
         - name: configvolume
@@ -129,6 +130,10 @@ spec:
           name: lib-modules
         - mountPath: /host
           name: host-root
+        - mountPath: /var/run/
+          name: eni-run
+        - mountPath: /var/lib/cni/networks
+          name: cni-networks
       containers:
       - name: terway
         image: TERWAY_IMAGE

--- a/tests/templates/terway/terway-vpc.yml
+++ b/tests/templates/terway/terway-vpc.yml
@@ -117,7 +117,7 @@ spec:
         imagePullPolicy: Always
         securityContext:
           privileged: true
-        command: ['sh', '-c', 'cp /usr/bin/terway /opt/cni/bin/; chmod +x /opt/cni/bin/terway; cp /etc/eni/10-terway.conf /etc/cni/net.d/; modprobe sch_htb || true']
+        command: ['sh', '-c', 'cp /usr/bin/terway /opt/cni/bin/; chmod +x /opt/cni/bin/terway; cp /etc/eni/10-terway.conf /etc/cni/net.d/; modprobe sch_htb || true; if [ -d /var/lib/cni/networks ] && [ "$(ls -A /var/lib/cni/networks 2>/dev/null)" ]; then mkdir -p /var/run/cni/networks; mv /var/lib/cni/networks/* /var/run/cni/networks/ 2>/dev/null || true; fi']
         volumeMounts:
         - name: configvolume
           mountPath: /etc/eni
@@ -127,6 +127,10 @@ spec:
           mountPath: /etc/cni/net.d/
         - mountPath: /lib/modules
           name: lib-modules
+        - mountPath: /var/run/
+          name: eni-run
+        - mountPath: /var/lib/cni/networks
+          name: cni-networks
       containers:
       - name: terway
         image: TERWAY_IMAGE


### PR DESCRIPTION
## Summary
- store delegated host-local IPAM state under `/var/run/cni`
- migrate existing state from `/var/lib/cni/networks` during init
- mount the legacy state directory for chart and test manifests

## Validation
- `make test` (Linux dev host)
- `helm lint charts/terway`
- `helm template terway charts/terway`
- YAML parsing and `sh -n init.sh`
- `git diff --check`