### PR TITLE
fix: support per-endpoint scheme override

### DIFF
--- a/pkg/aliyun/credential/aliyun_client_mgr.go
+++ b/pkg/aliyun/credential/aliyun_client_mgr.go
@@ -158,6 +158,27 @@ func (c *ClientMgr) EFLOController() *eflocontroller20221215.Client {
 type ClientScheme string
 type NetworkType string
 
+// schemeFromEnv returns the scheme from the given environment variable when
+// it is set to a valid value, otherwise it keeps the fallback (the shared
+// ALICLOUD_CLIENT_SCHEME carried in ClientConfig).
+func schemeFromEnv(key, fallback string) string {
+	if scheme := normalizeScheme(os.Getenv(key)); scheme != "" {
+		return scheme
+	}
+	return fallback
+}
+
+func normalizeScheme(scheme string) string {
+	switch strings.ToUpper(strings.TrimSpace(scheme)) {
+	case "HTTP":
+		return "HTTP"
+	case "HTTPS":
+		return "HTTPS"
+	default:
+		return ""
+	}
+}
+
 func parseURL(str string) (string, error) {
 	if str == "" {
 		return "", nil

--- a/pkg/aliyun/credential/clients.go
+++ b/pkg/aliyun/credential/clients.go
@@ -84,6 +84,7 @@ func NewECSClient(config ClientConfig, credential auth.Credential) (ECSClient, e
 	if domain != "" {
 		config.Domain = domain
 	}
+	config.Scheme = schemeFromEnv("ECS_SCHEME", config.Scheme)
 
 	sdkConfig := provideSDKConfig(config)
 
@@ -110,6 +111,7 @@ func NewECSV2Client(config ClientConfig, credential credential.Credential) (ECSV
 	if domain != "" {
 		config.Domain = domain
 	}
+	config.Scheme = schemeFromEnv("ECS_SCHEME", config.Scheme)
 
 	regionID := os.Getenv("ECS_ENDPOINT")
 	if regionID != "" {
@@ -147,6 +149,7 @@ func NewVPCClient(config ClientConfig, credential auth.Credential) (VPCClient, e
 	if domain != "" {
 		config.Domain = domain
 	}
+	config.Scheme = schemeFromEnv("VPC_SCHEME", config.Scheme)
 
 	sdkConfig := provideSDKConfig(config)
 
@@ -173,6 +176,7 @@ func NewEFLOClient(config ClientConfig, credential auth.Credential) (EFLOClient,
 	if domain != "" {
 		config.Domain = domain
 	}
+	config.Scheme = schemeFromEnv("EFLO_SCHEME", config.Scheme)
 
 	regionID := os.Getenv("EFLO_REGION_ID")
 	if regionID != "" {
@@ -199,10 +203,10 @@ func NewEFLOV2Client(config ClientConfig, credential credential.Credential) (EFL
 	if err != nil {
 		return nil, err
 	}
-
 	if domain != "" {
 		config.Domain = domain
 	}
+	config.Scheme = schemeFromEnv("EFLO_SCHEME", config.Scheme)
 
 	regionID := os.Getenv("EFLO_REGION_ID")
 	if regionID != "" {
@@ -237,10 +241,10 @@ func NewEFLOControllerClient(config ClientConfig, credential credential.Credenti
 	if err != nil {
 		return nil, err
 	}
-
 	if domain != "" {
 		config.Domain = domain
 	}
+	config.Scheme = schemeFromEnv("EFLO_CONTROLLER_SCHEME", config.Scheme)
 
 	regionID := os.Getenv("EFLO_CONTROLLER_REGION_ID")
 	if regionID != "" {

--- a/pkg/aliyun/credential/clients_test.go
+++ b/pkg/aliyun/credential/clients_test.go
@@ -71,6 +71,90 @@ func TestNewVPCClient(t *testing.T) {
 	}
 }
 
+func TestSchemeFromEnv(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		fallback string
+		expected string
+	}{
+		{
+			name:     "unset keeps fallback",
+			fallback: "HTTPS",
+			expected: "HTTPS",
+		},
+		{
+			name:     "valid override wins",
+			value:    "HTTP",
+			fallback: "HTTPS",
+			expected: "HTTP",
+		},
+		{
+			name:     "value is normalized",
+			value:    "https",
+			fallback: "HTTP",
+			expected: "HTTPS",
+		},
+		{
+			name:     "invalid value keeps fallback",
+			value:    "grpc",
+			fallback: "HTTPS",
+			expected: "HTTPS",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("TEST_SCHEME", tt.value)
+			require.Equal(t, tt.expected, schemeFromEnv("TEST_SCHEME", tt.fallback))
+		})
+	}
+}
+
+func TestParseURL(t *testing.T) {
+	domain, err := parseURL("endpoint.example.com")
+	require.NoError(t, err)
+	require.Equal(t, "endpoint.example.com", domain)
+
+	domain, err = parseURL("http://endpoint.example.com")
+	require.NoError(t, err)
+	require.Equal(t, "endpoint.example.com", domain)
+
+	domain, err = parseURL("")
+	require.NoError(t, err)
+	require.Equal(t, "", domain)
+}
+
+// TestEndpointClientsUseIndependentSchemes covers the mixed-protocol scenario
+// from production: EFLO Controller endpoints only support HTTP while VPC
+// endpoints only support HTTPS, so the shared scheme carried in ClientConfig
+// cannot serve both. Each client must honor its own <SERVICE>_SCHEME override
+// instead of the shared scheme.
+func TestEndpointClientsUseIndependentSchemes(t *testing.T) {
+	t.Setenv("VPC_ENDPOINT", "vpc.example.com")
+	t.Setenv("VPC_SCHEME", "HTTPS")
+	t.Setenv("EFLO_CONTROLLER_ENDPOINT", "eflo-controller.example.com")
+	t.Setenv("EFLO_CONTROLLER_SCHEME", "HTTP")
+	t.Setenv("EFLO_CONTROLLER_REGION_ID", "")
+
+	// v1 SDK client: override must win over the opposite shared scheme.
+	vpcClient, err := NewVPCClient(
+		ClientConfig{RegionID: "cn-test", Scheme: "HTTP"},
+		ProviderV1(&fakeProvider{}),
+	)
+	require.NoError(t, err)
+	require.Equal(t, "HTTPS", vpcClient.GetClient().GetConfig().Scheme)
+
+	// v2 SDK client: override must win over the opposite shared scheme.
+	efloControllerClient, err := NewEFLOControllerClient(
+		ClientConfig{RegionID: "cn-test", Scheme: "HTTPS"},
+		ProviderV2(&fakeProvider{}),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, efloControllerClient.GetClient().Protocol)
+	require.Equal(t, "HTTP", *efloControllerClient.GetClient().Protocol)
+}
+
 func TestNewEFLOClient(t *testing.T) {
 	os.Setenv("EFLO_ENDPOINT", "test")
 	os.Setenv("EFLO_REGION_ID", "test")


### PR DESCRIPTION
ALICLOUD_CLIENT_SCHEME is global and cannot express mixed protocols (e.g. EFLO Controller endpoints only support HTTP while VPC endpoints only support HTTPS). Every endpoint client (ECS/ECSV2/VPC/EFLO/EFLOV2/ EFLOController) now resolves its scheme independently via <SERVICE>_SCHEME, falling back to ALICLOUD_CLIENT_SCHEME. The *_ENDPOINT variables keep their original domain-only semantics.